### PR TITLE
fix: correct xterm CSS import to use scoped package name

### DIFF
--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
 import './styles/index.css'
-import 'xterm/css/xterm.css'
+import '@xterm/xterm/css/xterm.css'
 import { isIOSPWA } from './utils/device'
 
 // Add class for iOS PWA safe area handling


### PR DESCRIPTION
## Summary
- Fixed xterm CSS import path from `xterm/css/xterm.css` to `@xterm/xterm/css/xterm.css`
- The package is installed as `@xterm/xterm` (scoped name) but the import was using the old unscoped name, causing the build to fail

## Test plan
- [x] Verify `bun run build` completes successfully
- [x] Verify xterm styling renders correctly in the terminal component