### PR TITLE
feat: improve external session handling

### DIFF
--- a/src/server/SessionManager.ts
+++ b/src/server/SessionManager.ts
@@ -242,9 +242,11 @@ export class SessionManager {
           this.capturePaneContent,
           this.now
         )
+        // For external sessions, use session name as display name (more meaningful than window name)
+        const displayName = source === 'external' ? sessionName : window.name
         return {
           id: `${sessionName}:${window.id}`,
-          name: window.name,
+          name: displayName,
           tmuxWindow,
           projectPath: window.path,
           status,

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -443,9 +443,10 @@ describe('server message handlers', () => {
     )
 
     expect(sent[0]).toEqual({ type: 'error', message: 'Session not found' })
-    // External sessions can now be killed
-    expect(killed).toEqual([externalSession.tmuxWindow])
-    expect(sent[1]).toEqual({ type: 'error', message: 'Session not found' })
+    // External sessions cannot be killed by default (requires ALLOW_KILL_EXTERNAL=true)
+    expect(sent[1]).toEqual({ type: 'error', message: 'Cannot kill external sessions' })
+    expect(killed).toEqual([])
+    expect(sent[2]).toEqual({ type: 'error', message: 'Session not found' })
   })
 
   test('handles kill and rename success paths', async () => {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -18,6 +18,8 @@ export const config = {
   pruneWsSessions: process.env.PRUNE_WS_SESSIONS !== 'false',
   terminalMode,
   terminalMonitorTargets: process.env.TERMINAL_MONITOR_TARGETS !== 'false',
+  // Allow killing external (discovered) sessions from UI
+  allowKillExternal: process.env.ALLOW_KILL_EXTERNAL === 'true',
   // TLS config - set both to enable HTTPS
   tlsCert: process.env.TLS_CERT || '',
   tlsKey: process.env.TLS_KEY || '',

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -545,6 +545,10 @@ function handleKill(sessionId: string, ws: ServerWebSocket<WSData>) {
     send(ws, { type: 'error', message: 'Session not found' })
     return
   }
+  if (session.source !== 'managed' && !config.allowKillExternal) {
+    send(ws, { type: 'error', message: 'Cannot kill external sessions' })
+    return
+  }
 
   try {
     sessionManager.killWindow(session.tmuxWindow)


### PR DESCRIPTION
- Add ALLOW_KILL_EXTERNAL config option to permit killing discovered sessions
- Use tmux session name as display name for external sessions (more meaningful than the window name, which is often just "docker" or similar)
- External sessions are read-only by default for safety; set ALLOW_KILL_EXTERNAL=true to enable killing them from the UI