### PR TITLE
fix: improve selected session visibility in sidebar

### DIFF
--- a/src/client/styles/index.css
+++ b/src/client/styles/index.css
@@ -313,7 +313,9 @@ body {
 }
 
 .session-row.selected {
-  background: var(--bg-surface);
+  background: var(--bg-hover);
+  border: 1px solid var(--border);
+  border-left: none;
 }
 
 .session-row.selected:hover {


### PR DESCRIPTION
## Summary
- Improved the visual distinction of the selected session row in the sidebar
- Changed to use hover background color for better contrast
- Added subtle border (top, right, bottom) to frame the selection

The selected session was too faint and hard to distinguish from other sessions. This makes it more obvious at a glance.

<img width="233" height="170" alt="image" src="https://github.com/user-attachments/assets/a1c6bc43-e90f-465d-9c9f-fc0f63f02501" />


## Test plan
- [ ] Open the app and select different sessions in the sidebar
- [ ] Verify the selected session is clearly distinguishable from unselected ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)