### PR TITLE
fix: require start of line for permission prompt pattern

### DIFF
--- a/src/server/__tests__/permissionPrompt.test.ts
+++ b/src/server/__tests__/permissionPrompt.test.ts
@@ -25,6 +25,15 @@ describe('detectsPermissionPrompt', () => {
     expect(detectsPermissionPrompt(content)).toBe(false)
   })
 
+  test('does not match "1. Allow" appearing mid-sentence', () => {
+    const content = [
+      '3. **fix: prevent false positive permission detection**',
+      '   - Regex was matching "1. Allow" in regular numbered lists',
+      '   - Added fix to require start of line',
+    ].join('\n')
+    expect(detectsPermissionPrompt(content)).toBe(false)
+  })
+
   test('matches AskUserQuestion selection menu', () => {
     const content = [
       'Which issue would you like me to investigate?',

--- a/src/server/statusInference.ts
+++ b/src/server/statusInference.ts
@@ -14,8 +14,8 @@ export const PERMISSION_PATTERNS: RegExp[] = [
   // Claude Code: numbered selection menu with navigation hint (AskUserQuestion)
   /❯\s*\d+\.\s+\S+[\s\S]*?Esc to cancel/,
   // Claude Code: numbered options like "❯ 1. Yes" or "1. Yes"
-  // Negative lookahead rejects long sentences like "1. Allow users to enter..."
-  /[❯>]?\s*1\.\s*(Yes|Allow)(?!\s+\w+\s+\w+\s+\w+\s+\w+)/i,
+  // Requires start of line to avoid matching "1. Allow" in mid-sentence text
+  /(?:^|\n)\s*[❯>]?\s*1\.\s*(Yes|Allow)(?!\s+\w+\s+\w+\s+\w+\s+\w+)/im,
   // Claude Code: "Do you want to proceed?" or similar
   /do you want to (proceed|continue|allow|run)\?/i,
   // Claude Code: "Yes, and don't ask again" style options


### PR DESCRIPTION
## Summary
- Fixes false positive permission detection when `"1. Allow"` appears mid-sentence in Claude's output

## Problem
The permission pattern `/[❯>]?\s*1\.\s*(Yes|Allow).../i` was matching text like:
```
Regex was matching "1. Allow" in regular numbered lists
```

This caused sessions to incorrectly show "needs input" status when Claude's output happened to contain `"1. Allow"` or `"1. Yes"` in quoted text or explanations.

## Solution
Added `(?:^|\n)` anchor to require the pattern starts at beginning of string or after a newline. This prevents matches in quoted or inline text while still catching real permission prompts that appear at the start of a line.

## Test plan
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test` passes (306 tests)
- [x] Added test case for mid-sentence false positive
- [x] Manual test: Reproduced the issue by outputting text containing `"1. Allow"`, confirmed fix prevents false positive

🤖 Generated with [Claude Code](https://claude.com/claude-code)