### PR TITLE
fix: add post-merge hook to auto-reinstall dependencies

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Automatically run bun install when dependencies change after git pull/merge
+
+changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
+
+check_run() {
+  echo "$changed_files" | grep --quiet "$1" && eval "$2"
+}
+
+# Run bun install if package.json or bun.lock changed
+check_run "package.json\|bun.lock" "echo '📦 Dependencies changed, running bun install...' && bun install"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-bun.lockb
 .DS_Store
 .env
 .env.*


### PR DESCRIPTION
After git pull/merge, native binaries in node_modules (like esbuild) can become corrupted or mismatched with the current platform. This causes "installed for another platform" errors.

The post-merge hook automatically runs `bun install` when package.json or bun.lock changes, ensuring dependencies stay in sync.

Also removes obsolete bun.lockb from .gitignore (Bun now uses bun.lock).