### PR TITLE
fix: prevent blank session entries on external session discovery

### DIFF
--- a/src/client/components/SessionList.tsx
+++ b/src/client/components/SessionList.tsx
@@ -785,13 +785,13 @@ const SortableSessionItem = forwardRef<HTMLDivElement, SortableSessionItemProps>
       ref={setRefs}
       style={{ ...style, overflow: 'hidden' }}
       className="relative"
-      layout={!prefersReducedMotion && !isDragging && !layoutAnimationsDisabled && !isExiting}
+      layout={!prefersReducedMotion && !isDragging && !layoutAnimationsDisabled && !isExiting && !isNew}
       transformTemplate={(_, generatedTransform) => {
         if (!dndTransform) return generatedTransform
         if (!generatedTransform || generatedTransform === 'none') return dndTransform
         return `${dndTransform} ${generatedTransform}`
       }}
-      initial={prefersReducedMotion ? false : { opacity: 0, scale: 0.97 }}
+      initial={prefersReducedMotion || !isNew ? false : { opacity: 0, scale: 0.97 }}
       animate={
         prefersReducedMotion
           ? { opacity: 1 }


### PR DESCRIPTION
## Summary
- Fixed bug where new external sessions appeared blank/black until clicked or page reloaded
- Root cause: race condition between render cycle and useEffect that marks sessions as "new"
- Only apply entry animation (opacity: 0 → 1) for items confirmed as new
- Disable layout animations for new items to prevent animation conflicts

## Test plan
- [x] Create new external tmux session with matching prefix
- [x] Verify session entry appears immediately with content visible
- [x] All lint, typecheck, and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)