### PR TITLE
feat: add context menu for sidebar session items

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -367,6 +367,8 @@ export default function App() {
           onSelect={setSelectedSessionId}
           onRename={handleRenameSession}
           onResume={handleResumeSession}
+          onKill={handleKillSession}
+          onOpenSettings={handleOpenSettings}
           loading={!hasLoaded}
           error={connectionError || serverError}
         />


### PR DESCRIPTION
## Summary
- Adds right-click context menu to session items in the sidebar
- Menu options include: Rename, Settings, and Kill Session
- Proper click-outside and Escape key dismissal handling

## Test plan
- [ ] Right-click on a session item in the sidebar to open context menu
- [ ] Verify "Rename" triggers inline editing
- [ ] Verify "Settings" opens the settings modal
- [ ] Verify "Kill Session" terminates the session
- [ ] Verify clicking outside or pressing Escape closes the menu


🤖 Generated with [Claude Code](https://claude.com/claude-code)