### PR TITLE
feat: add sound notifications for session status changes

### DIFF
--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -13,6 +13,7 @@ import {
 import { useThemeStore, type Theme } from '../stores/themeStore'
 import { getEffectiveModifier, getModifierDisplay } from '../utils/device'
 import { Switch } from './Switch'
+import { playPermissionSound, playIdleSound, primeAudio } from '../utils/sound'
 
 interface SettingsChangeFlags {
   webglChanged: boolean
@@ -79,6 +80,10 @@ export default function SettingsModal({
   )
   const theme = useThemeStore((state) => state.theme)
   const setTheme = useThemeStore((state) => state.setTheme)
+  const soundOnPermission = useSettingsStore((state) => state.soundOnPermission)
+  const setSoundOnPermission = useSettingsStore((state) => state.setSoundOnPermission)
+  const soundOnIdle = useSettingsStore((state) => state.soundOnIdle)
+  const setSoundOnIdle = useSettingsStore((state) => state.setSoundOnIdle)
 
   const [draftDir, setDraftDir] = useState(defaultProjectDir)
   const [draftPresets, setDraftPresets] = useState<CommandPreset[]>(commandPresets)
@@ -105,6 +110,8 @@ export default function SettingsModal({
     showSessionIdPrefix
   )
   const [draftTheme, setDraftTheme] = useState<Theme>(theme)
+  const [draftSoundOnPermission, setDraftSoundOnPermission] = useState(soundOnPermission)
+  const [draftSoundOnIdle, setDraftSoundOnIdle] = useState(soundOnIdle)
 
   // New preset form state
   const [showAddForm, setShowAddForm] = useState(false)
@@ -137,6 +144,8 @@ export default function SettingsModal({
       setDraftShowLastUserMessage(showLastUserMessage)
       setDraftShowSessionIdSuffix(showSessionIdPrefix)
       setDraftTheme(theme)
+      setDraftSoundOnPermission(soundOnPermission)
+      setDraftSoundOnIdle(soundOnIdle)
       setShowAddForm(false)
       setNewLabel('')
       setNewBaseCommand('')
@@ -188,6 +197,8 @@ export default function SettingsModal({
     showLastUserMessage,
     showSessionIdPrefix,
     theme,
+    soundOnPermission,
+    soundOnIdle,
     isOpen,
   ])
 
@@ -230,6 +241,8 @@ export default function SettingsModal({
     setShowLastUserMessage(draftShowLastUserMessage)
     setShowSessionIdPrefix(draftShowSessionIdPrefix)
     setTheme(draftTheme)
+    setSoundOnPermission(draftSoundOnPermission)
+    setSoundOnIdle(draftSoundOnIdle)
     onClose({ webglChanged })
   }
 
@@ -561,6 +574,60 @@ export default function SettingsModal({
                 checked={draftShowSessionIdPrefix}
                 onCheckedChange={setDraftShowSessionIdSuffix}
               />
+            </div>
+          </div>
+
+          <div className="border-t border-border pt-4 space-y-3">
+            <label className="mb-1 block text-xs text-secondary">
+              Notifications
+            </label>
+            <div className="flex items-center justify-between">
+              <div className="flex-1">
+                <div className="text-sm text-primary">Permission Sound</div>
+                <div className="text-[10px] text-muted">
+                  Play a ping when any session needs permission.
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => void playPermissionSound()}
+                  className="btn text-xs px-2 py-1"
+                >
+                  Test
+                </button>
+                <Switch
+                  checked={draftSoundOnPermission}
+                  onCheckedChange={(checked) => {
+                    setDraftSoundOnPermission(checked)
+                    if (checked) void primeAudio() // Unlock audio on user gesture
+                  }}
+                />
+              </div>
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="flex-1">
+                <div className="text-sm text-primary">Idle Sound</div>
+                <div className="text-[10px] text-muted">
+                  Play a chime when a session finishes working.
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => void playIdleSound()}
+                  className="btn text-xs px-2 py-1"
+                >
+                  Test
+                </button>
+                <Switch
+                  checked={draftSoundOnIdle}
+                  onCheckedChange={(checked) => {
+                    setDraftSoundOnIdle(checked)
+                    if (checked) void primeAudio() // Unlock audio on user gesture
+                  }}
+                />
+              </div>
             </div>
           </div>
 

--- a/src/client/stores/settingsStore.ts
+++ b/src/client/stores/settingsStore.ts
@@ -146,6 +146,11 @@ interface SettingsState {
   setSidebarWidth: (width: number) => void
   projectFilters: string[]
   setProjectFilters: (filters: string[]) => void
+  // Sound notifications
+  soundOnPermission: boolean
+  setSoundOnPermission: (enabled: boolean) => void
+  soundOnIdle: boolean
+  setSoundOnIdle: (enabled: boolean) => void
   // Command presets
   commandPresets: CommandPreset[]
   setCommandPresets: (presets: CommandPreset[]) => void
@@ -205,6 +210,11 @@ export const useSettingsStore = create<SettingsState>()(
         }),
       projectFilters: [],
       setProjectFilters: (filters) => set({ projectFilters: filters }),
+      // Sound notifications
+      soundOnPermission: false,
+      setSoundOnPermission: (enabled) => set({ soundOnPermission: enabled }),
+      soundOnIdle: false,
+      setSoundOnIdle: (enabled) => set({ soundOnIdle: enabled }),
       // Command presets
       commandPresets: DEFAULT_PRESETS,
       setCommandPresets: (presets) => set({ commandPresets: presets }),

--- a/src/client/utils/sound.ts
+++ b/src/client/utils/sound.ts
@@ -1,0 +1,151 @@
+/**
+ * Web Audio API sound notifications for session status changes.
+ * Generates tones programmatically - no external audio files needed.
+ */
+
+// Lazy AudioContext singleton
+let audioContext: AudioContext | null = null
+
+// Rate limiting: track last play time per sound type
+const lastPlayTime: Record<string, number> = {}
+const RATE_LIMIT_MS = 500 // Minimum ms between same sound type
+
+function getAudioContext(): AudioContext | null {
+  if (typeof window === 'undefined') return null
+
+  // Handle closed context (can happen after iOS background/lifecycle events)
+  if (audioContext?.state === 'closed') {
+    audioContext = null
+  }
+
+  if (!audioContext) {
+    const AudioContextCtor =
+      window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+    if (!AudioContextCtor) return null
+    audioContext = new AudioContextCtor()
+  }
+  return audioContext
+}
+
+/**
+ * Prime the AudioContext for later playback.
+ * Call this from a user gesture (click/tap) to unlock audio on iOS/Safari.
+ */
+export async function primeAudio(): Promise<void> {
+  const ctx = getAudioContext()
+  if (ctx && ctx.state === 'suspended') {
+    await ctx.resume().catch(() => {})
+  }
+}
+
+async function ensureRunning(ctx: AudioContext): Promise<void> {
+  if (ctx.state === 'suspended') {
+    await ctx.resume().catch(() => {
+      // Ignore resume failures (autoplay policy)
+    })
+  }
+}
+
+interface ToneOptions {
+  frequencies: number[]
+  durationMs: number
+  attackMs: number
+  peakGain: number
+  type?: OscillatorType
+}
+
+async function playTone(options: ToneOptions): Promise<void> {
+  const ctx = getAudioContext()
+  if (!ctx) return
+
+  await ensureRunning(ctx)
+
+  // Guard: don't create nodes if context is still suspended (autoplay blocked)
+  if (ctx.state !== 'running') return
+
+  const { frequencies, durationMs, attackMs, peakGain, type = 'sine' } = options
+  const now = ctx.currentTime
+  const duration = durationMs / 1000
+  const attack = attackMs / 1000
+
+  // Create gain node for envelope
+  const gainNode = ctx.createGain()
+  gainNode.connect(ctx.destination)
+
+  // Envelope: 0 -> peak (attack) -> hold -> 0 (release at end)
+  const releaseStart = now + duration * 0.7 // Start release at 70% of duration
+  gainNode.gain.setValueAtTime(0, now)
+  gainNode.gain.linearRampToValueAtTime(peakGain, now + attack)
+  gainNode.gain.setValueAtTime(peakGain, releaseStart)
+  gainNode.gain.linearRampToValueAtTime(0, now + duration)
+
+  // Create oscillators for each frequency
+  const oscillators = frequencies.map((freq) => {
+    const osc = ctx.createOscillator()
+    osc.type = type
+    osc.frequency.setValueAtTime(freq, now)
+    osc.connect(gainNode)
+    return osc
+  })
+
+  // Start and stop all oscillators
+  for (const osc of oscillators) {
+    osc.start(now)
+    osc.stop(now + duration)
+  }
+
+  // Cleanup using onended (more reliable than setTimeout when backgrounded)
+  const lastOsc = oscillators[oscillators.length - 1]
+  lastOsc.onended = () => {
+    for (const osc of oscillators) {
+      osc.disconnect()
+    }
+    gainNode.disconnect()
+  }
+}
+
+/**
+ * Play a short attention-grabbing ping for permission requests.
+ * Higher pitched (880Hz), quick attack.
+ */
+export async function playPermissionSound(): Promise<void> {
+  // Rate limit to prevent burst notifications
+  const now = Date.now()
+  if (now - (lastPlayTime.permission || 0) < RATE_LIMIT_MS) return
+  lastPlayTime.permission = now
+
+  try {
+    await playTone({
+      frequencies: [880],
+      durationMs: 150,
+      attackMs: 5,
+      peakGain: 0.15,
+      type: 'sine',
+    })
+  } catch {
+    // Ignore all playback errors
+  }
+}
+
+/**
+ * Play a pleasant two-tone chime when a session becomes idle.
+ * Lower frequencies (440Hz + 550Hz), gentler envelope.
+ */
+export async function playIdleSound(): Promise<void> {
+  // Rate limit to prevent burst notifications
+  const now = Date.now()
+  if (now - (lastPlayTime.idle || 0) < RATE_LIMIT_MS) return
+  lastPlayTime.idle = now
+
+  try {
+    await playTone({
+      frequencies: [440, 550],
+      durationMs: 300,
+      attackMs: 10,
+      peakGain: 0.08, // Lower to avoid clipping with two oscillators
+      type: 'sine',
+    })
+  } catch {
+    // Ignore all playback errors
+  }
+}


### PR DESCRIPTION
## Summary

- Add audio notifications when sessions need permission (ping) or become idle (chime)
- Use Web Audio API to generate tones (no external audio files)
- Per-event toggles in Settings → Notifications with test buttons
- Sounds play regardless of tab focus

## Implementation

- **`src/client/utils/sound.ts`** - Web Audio API utility with lazy AudioContext, rate limiting, and proper cleanup
- **`src/client/stores/settingsStore.ts`** - `soundOnPermission` and `soundOnIdle` settings (default: off)
- **`src/client/components/SettingsModal.tsx`** - Notifications section with toggles and test buttons
- **`src/client/App.tsx`** - Status transition detection in WebSocket handler

## Test plan

- [ ] Enable both toggles in Settings → Notifications
- [ ] Click test buttons to verify sounds play
- [ ] Create session that triggers permission → hear ping
- [ ] Have session finish working → hear idle chime
- [ ] Toggle off and verify no sounds
- [ ] Verify sounds work when tab is in background

🤖 Generated with [Claude Code](https://claude.com/claude-code)