### PR TITLE
fix: improve headless session skipping and skip-match performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ All persistent data is stored in `~/.agentboard/`: session database (`agentboard
 
 `AGENTBOARD_EXCLUDE_PROJECTS` filters out sessions from specific project directories (comma-separated). Use `<empty>` to exclude sessions with no project path. Useful for hiding automated/spam sessions.
 
+`AGENTBOARD_SKIP_MATCHING_PATTERNS` controls which orphan sessions skip expensive window matching (comma-separated). Defaults: `<codex-exec>` (headless Codex exec sessions), `/private/tmp/*`, `/private/var/folders/*`, `/var/folders/*`, `/tmp/*`. Patterns support trailing `*` for prefix matching. Set to empty string to disable skip matching entirely.
+
 ## Logging
 
 ```

--- a/src/server/__tests__/logMatchGate.test.ts
+++ b/src/server/__tests__/logMatchGate.test.ts
@@ -14,6 +14,7 @@ function makeEntry(
     projectPath: '/proj',
     agentType: 'claude',
     isCodexSubagent: false,
+    isCodexExec: false,
     logTokenCount: 10,
     ...overrides,
   }
@@ -77,5 +78,170 @@ describe('logMatchGate', () => {
     const entries = [makeEntry({ sessionId: 'session-match' })]
     const sessions: SessionSnapshot[] = []
     expect(shouldRunMatching(entries, sessions, { minTokens: 1 })).toBe(true)
+  })
+
+  test('codex exec sessions are always skipped (headless), but path patterns only skip orphans', () => {
+    const entries: LogEntrySnapshot[] = [
+      makeEntry({ sessionId: 'session-codex-exec', logPath: 'log-exec', isCodexExec: true, agentType: 'codex' }),
+      makeEntry({ sessionId: 'session-tmp', logPath: 'log-tmp', projectPath: '/tmp/test-project' }),
+      makeEntry({ sessionId: 'session-normal', logPath: 'log-normal' }),
+    ]
+    const sessions: SessionSnapshot[] = []
+
+    // Codex exec sessions are always skipped (they're headless by definition)
+    // Path-based patterns (like /tmp/*) only skip orphan sessions, not new sessions
+    const needs = getEntriesNeedingMatch(entries, sessions, {
+      minTokens: 0,
+      skipMatchingPatterns: ['<codex-exec>', '/tmp/*'],
+    })
+    expect(needs.map((e) => e.sessionId)).toEqual(['session-tmp', 'session-normal'])
+  })
+
+  test('codex exec sessions are skipped even without skip patterns configured', () => {
+    const entries: LogEntrySnapshot[] = [
+      makeEntry({ sessionId: 'session-codex-exec', logPath: 'log-exec', isCodexExec: true, agentType: 'codex' }),
+      makeEntry({ sessionId: 'session-normal', logPath: 'log-normal' }),
+    ]
+    const sessions: SessionSnapshot[] = []
+
+    // Codex exec sessions are always skipped regardless of skipMatchingPatterns
+    const needs = getEntriesNeedingMatch(entries, sessions, {
+      minTokens: 0,
+      skipMatchingPatterns: [],
+    })
+    expect(needs.map((e) => e.sessionId)).toEqual(['session-normal'])
+  })
+
+  test('skips orphan sessions matching codex-exec pattern', () => {
+    const entries: LogEntrySnapshot[] = [
+      makeEntry({
+        sessionId: 'session-orphan-exec',
+        logPath: 'log-orphan-exec',
+        isCodexExec: true,
+        agentType: 'codex',
+        mtime: 1_800_000_000_001,
+      }),
+      makeEntry({
+        sessionId: 'session-orphan-normal',
+        logPath: 'log-orphan-normal',
+        mtime: 1_800_000_000_001,
+      }),
+    ]
+    const sessions: SessionSnapshot[] = [
+      {
+        sessionId: 'session-orphan-exec',
+        logFilePath: 'log-orphan-exec',
+        currentWindow: null,
+        lastActivityAt: '2025-01-01T00:00:00Z',
+      },
+      {
+        sessionId: 'session-orphan-normal',
+        logFilePath: 'log-orphan-normal',
+        currentWindow: null,
+        lastActivityAt: '2025-01-01T00:00:00Z',
+      },
+    ]
+
+    const needs = getEntriesNeedingMatch(entries, sessions, {
+      minTokens: 0,
+      skipMatchingPatterns: ['<codex-exec>'],
+    })
+    // Only the normal orphan should need matching
+    expect(needs.map((e) => e.sessionId)).toEqual(['session-orphan-normal'])
+  })
+
+  test('skips orphan sessions in temp directories when pattern is set', () => {
+    const entries: LogEntrySnapshot[] = [
+      makeEntry({
+        sessionId: 'session-orphan-tmp',
+        logPath: 'log-orphan-tmp',
+        projectPath: '/tmp/test-project',
+        mtime: 1_800_000_000_001,
+      }),
+      makeEntry({
+        sessionId: 'session-orphan-normal',
+        logPath: 'log-orphan-normal',
+        projectPath: '/Users/test/project',
+        mtime: 1_800_000_000_001,
+      }),
+    ]
+    const sessions: SessionSnapshot[] = [
+      {
+        sessionId: 'session-orphan-tmp',
+        logFilePath: 'log-orphan-tmp',
+        currentWindow: null,
+        lastActivityAt: '2025-01-01T00:00:00Z',
+      },
+      {
+        sessionId: 'session-orphan-normal',
+        logFilePath: 'log-orphan-normal',
+        currentWindow: null,
+        lastActivityAt: '2025-01-01T00:00:00Z',
+      },
+    ]
+
+    const needs = getEntriesNeedingMatch(entries, sessions, {
+      minTokens: 0,
+      skipMatchingPatterns: ['/tmp/*'],
+    })
+    // Only the normal orphan should need matching
+    expect(needs.map((e) => e.sessionId)).toEqual(['session-orphan-normal'])
+  })
+
+  test('codex-exec pattern is case-insensitive', () => {
+    const entries: LogEntrySnapshot[] = [
+      makeEntry({
+        sessionId: 'session-orphan-exec',
+        logPath: 'log-orphan-exec',
+        isCodexExec: true,
+        agentType: 'codex',
+        mtime: 1_800_000_000_001,
+      }),
+    ]
+    const sessions: SessionSnapshot[] = [
+      {
+        sessionId: 'session-orphan-exec',
+        logFilePath: 'log-orphan-exec',
+        currentWindow: null,
+        lastActivityAt: '2025-01-01T00:00:00Z',
+      },
+    ]
+
+    // Should work with different case variations
+    for (const pattern of ['<codex-exec>', '<CODEX-EXEC>', '<Codex-Exec>']) {
+      const needs = getEntriesNeedingMatch(entries, sessions, {
+        minTokens: 0,
+        skipMatchingPatterns: [pattern],
+      })
+      expect(needs).toEqual([])
+    }
+  })
+
+  test('pattern matching is case-insensitive for paths (orphans only)', () => {
+    const entries: LogEntrySnapshot[] = [
+      makeEntry({ sessionId: 'session-tmp', logPath: 'log-tmp', projectPath: '/TMP/Test', mtime: 1_800_000_000_001 }),
+      makeEntry({ sessionId: 'session-normal', logPath: 'log-normal', projectPath: '/Users/test', mtime: 1_800_000_000_001 }),
+    ]
+    // Must be orphan sessions (with session records but no currentWindow) for skip patterns to apply
+    const sessions: SessionSnapshot[] = [
+      {
+        sessionId: 'session-tmp',
+        logFilePath: 'log-tmp',
+        currentWindow: null,
+        lastActivityAt: '2025-01-01T00:00:00Z',
+      },
+      {
+        sessionId: 'session-normal',
+        logFilePath: 'log-normal',
+        currentWindow: null,
+        lastActivityAt: '2025-01-01T00:00:00Z',
+      },
+    ]
+
+    const needs = getEntriesNeedingMatch(entries, sessions, {
+      minTokens: 0,
+      skipMatchingPatterns: ['/tmp/*'],
+    })
+    expect(needs.map((e) => e.sessionId)).toEqual(['session-normal'])
   })
 })

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -52,6 +52,27 @@ const excludeProjects = (process.env.AGENTBOARD_EXCLUDE_PROJECTS || '')
   .map((p) => p.trim())
   .filter(Boolean)
 
+// Default patterns for sessions that should skip window matching when orphaned.
+// These sessions are still tracked in the DB but won't trigger expensive
+// ripgrep scans trying to match them to tmux windows.
+// Special markers:
+//   <codex-exec> - Codex sessions started via `codex exec` (headless)
+// Path patterns support trailing * for prefix matching.
+const defaultSkipMatchingPatterns = [
+  '<codex-exec>',
+  '/private/tmp/*',
+  '/private/var/folders/*',
+  '/var/folders/*',
+  '/tmp/*',
+]
+
+// Allow override via env var (comma-separated). If set (even empty), replaces defaults.
+// Set to empty string to disable skip matching entirely.
+const skipMatchingPatternsRaw = process.env.AGENTBOARD_SKIP_MATCHING_PATTERNS
+const skipMatchingPatterns = skipMatchingPatternsRaw !== undefined
+  ? skipMatchingPatternsRaw.split(',').map((p) => p.trim()).filter(Boolean)
+  : defaultSkipMatchingPatterns
+
 // Logging config
 const logLevelRaw = process.env.LOG_LEVEL?.toLowerCase()
 const logLevel = ['debug', 'info', 'warn', 'error'].includes(logLevelRaw || '')
@@ -95,6 +116,7 @@ export const config = {
   workingGracePeriodMs,
   inactiveSessionMaxAgeHours,
   excludeProjects,
+  skipMatchingPatterns,
   logLevel,
   logFile,
 }

--- a/src/server/logDiscovery.ts
+++ b/src/server/logDiscovery.ts
@@ -354,3 +354,28 @@ export function isCodexSubagent(logPath: string): boolean {
   // Subagents have source: { subagent: "review" } (object)
   return typeof payload.source === 'object' && payload.source !== null
 }
+
+/**
+ * Check if a Codex log file is from a headless exec session.
+ * Exec sessions have payload.source === "exec", indicating they were
+ * started via `codex exec` rather than the interactive CLI.
+ */
+export function isCodexExec(logPath: string): boolean {
+  const head = readLogHead(logPath)
+  if (!head) return false
+
+  // Check only the first line (session_meta)
+  const firstLine = head.split('\n')[0]?.trim()
+  if (!firstLine) return false
+
+  const entry = safeParseJson(firstLine)
+  if (!entry) return false
+
+  // Only check session_meta entries
+  if (entry.type !== 'session_meta') return false
+
+  const payload = entry.payload as Record<string, unknown> | undefined
+  if (!payload) return false
+
+  return payload.source === 'exec'
+}

--- a/src/server/logMatchGate.ts
+++ b/src/server/logMatchGate.ts
@@ -8,10 +8,59 @@ export interface SessionSnapshot {
   lastUserMessage?: string | null
 }
 
+/**
+ * Check if a path matches a pattern from skipMatchingPatterns.
+ * Supports trailing * for prefix matching.
+ * Normalizes backslashes to forward slashes for cross-platform compatibility.
+ */
+function matchesPathPattern(path: string | null, pattern: string): boolean {
+  if (!path) return false
+  const normalizedPath = path.toLowerCase().replace(/\\/g, '/')
+  const normalizedPattern = pattern.toLowerCase().replace(/\\/g, '/')
+
+  if (normalizedPattern.endsWith('*')) {
+    const prefix = normalizedPattern.slice(0, -1)
+    return normalizedPath.startsWith(prefix)
+  }
+
+  return normalizedPath === normalizedPattern
+}
+
+/**
+ * Check if an entry should skip matching based on configured patterns.
+ * This is used to avoid expensive window matching for orphaned sessions
+ * (e.g., headless Codex exec, temp directories) that are unlikely to
+ * have a tmux window to match against.
+ */
+export function shouldSkipMatching(
+  entry: LogEntrySnapshot,
+  patterns: string[]
+): boolean {
+  for (const pattern of patterns) {
+    // Special marker for Codex exec sessions (case-insensitive)
+    if (pattern.toLowerCase() === '<codex-exec>' && entry.isCodexExec) {
+      return true
+    }
+
+    // Path pattern - check projectPath
+    if (matchesPathPattern(entry.projectPath, pattern)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+export interface GetEntriesNeedingMatchOptions {
+  minTokens?: number
+  /** Patterns for sessions that should skip matching when orphaned */
+  skipMatchingPatterns?: string[]
+}
+
 export function getEntriesNeedingMatch(
   entries: LogEntrySnapshot[],
   sessions: SessionSnapshot[],
-  { minTokens = 0 }: { minTokens?: number } = {}
+  { minTokens = 0, skipMatchingPatterns = [] }: GetEntriesNeedingMatchOptions = {}
 ): LogEntrySnapshot[] {
   if (entries.length === 0) return []
   const sessionsByLogPath = new Map(
@@ -24,16 +73,23 @@ export function getEntriesNeedingMatch(
 
   for (const entry of entries) {
     if (!entry.sessionId) continue
+    // Codex exec sessions are headless by definition - never attempt window matching
+    if (entry.isCodexExec) continue
     // logTokenCount = -1 means enrichment was skipped (known session, already validated)
     if (minTokens > 0 && entry.logTokenCount >= 0 && entry.logTokenCount < minTokens) continue
     const session =
       sessionsByLogPath.get(entry.logPath) ??
       sessionsById.get(entry.sessionId)
     if (!session) {
+      // New session - always attempt matching (give it one chance)
       needs.push(entry)
       continue
     }
     if (!session.currentWindow) {
+      // Orphan session - check if it should skip matching
+      if (shouldSkipMatching(entry, skipMatchingPatterns)) {
+        continue
+      }
       const lastActivity = Date.parse(session.lastActivityAt)
       if (!Number.isFinite(lastActivity) || entry.mtime > lastActivity) {
         needs.push(entry)
@@ -47,7 +103,7 @@ export function getEntriesNeedingMatch(
 export function shouldRunMatching(
   entries: LogEntrySnapshot[],
   sessions: SessionSnapshot[],
-  { minTokens = 0 }: { minTokens?: number } = {}
+  options: GetEntriesNeedingMatchOptions = {}
 ): boolean {
-  return getEntriesNeedingMatch(entries, sessions, { minTokens }).length > 0
+  return getEntriesNeedingMatch(entries, sessions, options).length > 0
 }

--- a/src/server/logMatchWorkerTypes.ts
+++ b/src/server/logMatchWorkerTypes.ts
@@ -38,6 +38,8 @@ export interface MatchWorkerRequest {
   orphanCandidates?: OrphanCandidate[]
   lastMessageCandidates?: LastMessageCandidate[]
   search?: MatchWorkerSearchOptions
+  /** Patterns for sessions that should skip window matching when orphaned */
+  skipMatchingPatterns?: string[]
 }
 
 export interface MatchWorkerResponse {

--- a/src/server/logPoller.ts
+++ b/src/server/logPoller.ts
@@ -253,6 +253,7 @@ export class LogPoller {
           forceOrphanRematch: true,
           orphanCandidates,
           lastMessageCandidates: [],
+          skipMatchingPatterns: config.skipMatchingPatterns,
           search: {
             rgThreads: this.rgThreads,
           },
@@ -483,6 +484,7 @@ export class LogPoller {
             forceOrphanRematch: false, // Orphan rematch runs in background separately
             orphanCandidates: [],
             lastMessageCandidates,
+            skipMatchingPatterns: config.skipMatchingPatterns,
             search: {
               rgThreads: this.rgThreads,
               profile: this.matchProfile,
@@ -511,6 +513,7 @@ export class LogPoller {
           }
           entriesToMatch = getEntriesNeedingMatch(entries, sessions, {
             minTokens: MIN_LOG_TOKENS_FOR_INSERT,
+            skipMatchingPatterns: config.skipMatchingPatterns,
           })
         } catch (error) {
           errors += 1


### PR DESCRIPTION
## Summary
- Add `/private/var/folders/*` to default skip patterns (macOS temp variant)
- Move skip filtering before token counting in orphan-rematch for performance
- Always skip `isCodexExec` sessions from window matching (headless by definition)
- Normalize backslashes in pattern matching for cross-platform support
- Fix env override semantics: empty string now disables skip matching
- Document `AGENTBOARD_SKIP_MATCHING_PATTERNS` in README

## Test plan
- [x] All existing tests pass
- [x] New tests added for codex exec always-skip behavior
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)