### PR TITLE
fix: enable tmux mouse mode for scroll wheel support

### DIFF
--- a/src/server/__tests__/db.test.ts
+++ b/src/server/__tests__/db.test.ts
@@ -185,4 +185,26 @@ describe('db', () => {
     migrated.close()
     fs.rmSync(tempDir, { recursive: true, force: true })
   })
+
+  test('app settings get/set', () => {
+    // Initially null
+    expect(db.getAppSetting('test_key')).toBeNull()
+
+    // Set a value
+    db.setAppSetting('test_key', 'test_value')
+    expect(db.getAppSetting('test_key')).toBe('test_value')
+
+    // Update the value
+    db.setAppSetting('test_key', 'updated_value')
+    expect(db.getAppSetting('test_key')).toBe('updated_value')
+
+    // Different key
+    db.setAppSetting('another_key', 'another_value')
+    expect(db.getAppSetting('another_key')).toBe('another_value')
+    expect(db.getAppSetting('test_key')).toBe('updated_value')
+
+    // Cleanup
+    db.db.exec("DELETE FROM app_settings WHERE key = 'test_key'")
+    db.db.exec("DELETE FROM app_settings WHERE key = 'another_key'")
+  })
 })

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -318,6 +318,8 @@ mock.module('../../db', () => ({
       Array.from(dbState.records.values()).filter(
         (record) => record.isPinned && record.currentWindow === null
       ),
+    getAppSetting: () => null,
+    setAppSetting: () => {},
     close: () => {},
   }),
 }))

--- a/src/server/__tests__/sessionManager.test.ts
+++ b/src/server/__tests__/sessionManager.test.ts
@@ -1039,4 +1039,57 @@ describe('SessionManager', () => {
       config.discoverPrefixes = originalPrefixes
     }
   })
+
+  test('mouse mode can be disabled via constructor option', () => {
+    const sessionName = 'agentboard-mouse-test'
+    const runner = createTmuxRunner(
+      [{ name: sessionName, windows: [] }],
+      1
+    )
+
+    const manager = new SessionManager(sessionName, {
+      runTmux: runner.runTmux,
+      capturePaneContent: () => null,
+      mouseMode: false,
+    })
+
+    manager.listWindows() // Triggers ensureSession
+
+    // Should set mouse off when disabled
+    const setOptionCall = runner.calls.find(
+      (call) => call[0] === 'set-option' && call.includes('mouse')
+    )
+    expect(setOptionCall).toBeTruthy()
+    expect(setOptionCall).toContain('off')
+    expect(setOptionCall).toContain('-t')
+    expect(setOptionCall).toContain(sessionName)
+  })
+
+  test('setMouseMode applies change immediately', () => {
+    const sessionName = 'agentboard-setmouse-test'
+    const runner = createTmuxRunner(
+      [{ name: sessionName, windows: [] }],
+      1
+    )
+
+    const manager = new SessionManager(sessionName, {
+      runTmux: runner.runTmux,
+      capturePaneContent: () => null,
+      mouseMode: true,
+    })
+
+    manager.listWindows() // Triggers ensureSession with mouse on
+
+    // Clear calls to track new calls
+    runner.calls.length = 0
+
+    // Toggle mouse mode off
+    manager.setMouseMode(false)
+
+    const setOptionCall = runner.calls.find(
+      (call) => call[0] === 'set-option' && call.includes('mouse')
+    )
+    expect(setOptionCall).toBeTruthy()
+    expect(setOptionCall).toContain('off')
+  })
 })


### PR DESCRIPTION
## Summary
- Enables tmux mouse mode (`set-option -g mouse on`) when agentboard ensures a session exists
- This allows SGR mouse wheel sequences to work correctly for trackpad/mouse scrolling

## Problem
Trackpad scrolling was cycling through command history instead of scrolling the terminal content. This happens because agentboard sends SGR mouse sequences for scroll events, but these require tmux mouse mode to be enabled.

## Test plan
- [x] All existing tests pass
- [x] Verified fix locally - trackpad scrolling now scrolls terminal content correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)