### PR TITLE
feat: remote host aggregation (POL-422)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ VITE_ALLOWED_HOSTS=nuc,myserver
 AGENTBOARD_DB_PATH=~/.agentboard/agentboard.db
 AGENTBOARD_INACTIVE_MAX_AGE_HOURS=24
 AGENTBOARD_EXCLUDE_PROJECTS=<empty>,/workspace
+AGENTBOARD_HOST=blade
+AGENTBOARD_REMOTE_HOSTS=mba,carbon,worm
+AGENTBOARD_REMOTE_POLL_MS=15000
+AGENTBOARD_REMOTE_TIMEOUT_MS=4000
+AGENTBOARD_REMOTE_STALE_MS=45000
+AGENTBOARD_REMOTE_SSH_OPTS=-o BatchMode=yes -o ConnectTimeout=3
+AGENTBOARD_REMOTE_ALLOW_CONTROL=false
 ```
 
 `HOSTNAME` controls which interfaces the server binds to (default `0.0.0.0` for network access; use `127.0.0.1` for local-only).
@@ -93,6 +100,16 @@ All persistent data is stored in `~/.agentboard/`: session database (`agentboard
 `AGENTBOARD_EXCLUDE_PROJECTS` filters out sessions from specific project directories (comma-separated). Use `<empty>` to exclude sessions with no project path. Useful for hiding automated/spam sessions.
 
 `AGENTBOARD_SKIP_MATCHING_PATTERNS` controls which orphan sessions skip expensive window matching (comma-separated). Defaults: `<codex-exec>` (headless Codex exec sessions), `/private/tmp/*`, `/private/var/folders/*`, `/var/folders/*`, `/tmp/*`. Patterns support trailing `*` for prefix matching. Set to empty string to disable skip matching entirely.
+
+`AGENTBOARD_HOST` sets the host label for local sessions (default: `hostname`).
+
+`AGENTBOARD_REMOTE_HOSTS` enables remote tmux polling over SSH. Provide a comma-separated list of hosts (e.g., `mba,carbon,worm`).
+
+`AGENTBOARD_REMOTE_POLL_MS`, `AGENTBOARD_REMOTE_TIMEOUT_MS`, and `AGENTBOARD_REMOTE_STALE_MS` control remote poll cadence, SSH timeout, and stale host cutoff.
+
+`AGENTBOARD_REMOTE_SSH_OPTS` appends extra SSH options (space-separated).
+
+`AGENTBOARD_REMOTE_ALLOW_CONTROL` is reserved for future remote control support (read-only in MVP).
 
 ## Logging
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -38,6 +38,7 @@ export default function App() {
   )
   const setSessions = useSessionStore((state) => state.setSessions)
   const setAgentSessions = useSessionStore((state) => state.setAgentSessions)
+  const setHostStatuses = useSessionStore((state) => state.setHostStatuses)
   const updateSession = useSessionStore((state) => state.updateSession)
   const setSelectedSessionId = useSessionStore(
     (state) => state.setSelectedSessionId
@@ -65,6 +66,7 @@ export default function App() {
   const sidebarWidth = useSettingsStore((state) => state.sidebarWidth)
   const setSidebarWidth = useSettingsStore((state) => state.setSidebarWidth)
   const projectFilters = useSettingsStore((state) => state.projectFilters)
+  const hostFilters = useSettingsStore((state) => state.hostFilters)
   const soundOnPermission = useSettingsStore((state) => state.soundOnPermission)
   const soundOnIdle = useSettingsStore((state) => state.soundOnIdle)
 
@@ -158,6 +160,9 @@ export default function App() {
         }
 
         setSessions(message.sessions)
+      }
+      if (message.type === 'host-status') {
+        setHostStatuses(message.hosts)
       }
       if (message.type === 'session-update') {
         // Detect status transitions for sound notifications
@@ -277,6 +282,7 @@ export default function App() {
     setSelectedSessionId,
     setSessions,
     setAgentSessions,
+    setHostStatuses,
     subscribe,
     updateSession,
   ])
@@ -312,13 +318,17 @@ export default function App() {
     [sessions, sessionSortMode, sessionSortDirection, manualSessionOrder]
   )
 
-  // Apply project filters to sorted sessions for keyboard navigation
+  // Apply filters to sorted sessions for keyboard navigation
   const filteredSortedSessions = useMemo(() => {
-    if (projectFilters.length === 0) return sortedSessions
-    return sortedSessions.filter((session) =>
-      projectFilters.includes(session.projectPath)
-    )
-  }, [sortedSessions, projectFilters])
+    let next = sortedSessions
+    if (projectFilters.length > 0) {
+      next = next.filter((session) => projectFilters.includes(session.projectPath))
+    }
+    if (hostFilters.length > 0) {
+      next = next.filter((session) => hostFilters.includes(session.host ?? ''))
+    }
+    return next
+  }, [sortedSessions, projectFilters, hostFilters])
 
   // Auto-select first visible session when current selection is filtered out
   useEffect(() => {

--- a/src/client/__tests__/app.test.tsx
+++ b/src/client/__tests__/app.test.tsx
@@ -168,6 +168,7 @@ beforeEach(() => {
     showProjectName: true,
     showLastUserMessage: true,
     showSessionIdPrefix: false,
+    hostFilters: [],
   })
 
   useThemeStore.setState({ theme: 'dark' })
@@ -190,6 +191,7 @@ afterEach(() => {
     showProjectName: true,
     showLastUserMessage: true,
     showSessionIdPrefix: false,
+    hostFilters: [],
   })
 })
 

--- a/src/client/__tests__/sessionDrawer.test.tsx
+++ b/src/client/__tests__/sessionDrawer.test.tsx
@@ -112,6 +112,7 @@ beforeEach(() => {
     showProjectName: true,
     showLastUserMessage: true,
     showSessionIdPrefix: false,
+    hostFilters: [],
   })
 })
 
@@ -127,6 +128,7 @@ afterEach(() => {
     showProjectName: true,
     showLastUserMessage: true,
     showSessionIdPrefix: false,
+    hostFilters: [],
   })
 })
 

--- a/src/client/__tests__/sessionListComponent.test.tsx
+++ b/src/client/__tests__/sessionListComponent.test.tsx
@@ -59,6 +59,7 @@ beforeEach(() => {
     showLastUserMessage: true,
     showSessionIdPrefix: false,
     projectFilters: [],
+    hostFilters: [],
   })
 
   useSessionStore.setState({
@@ -80,6 +81,7 @@ afterEach(() => {
     showLastUserMessage: true,
     showSessionIdPrefix: false,
     projectFilters: [],
+    hostFilters: [],
   })
   useSessionStore.setState({
     exitingSessions: new Map(),

--- a/src/client/__tests__/sessionListFilters.test.tsx
+++ b/src/client/__tests__/sessionListFilters.test.tsx
@@ -32,6 +32,7 @@ beforeEach(() => {
     showLastUserMessage: true,
     showSessionIdPrefix: false,
     projectFilters: [],
+    hostFilters: [],
   })
 
   useSessionStore.setState({
@@ -50,6 +51,7 @@ afterEach(() => {
     showLastUserMessage: true,
     showSessionIdPrefix: false,
     projectFilters: [],
+    hostFilters: [],
   })
   useSessionStore.setState({
     exitingSessions: new Map(),
@@ -69,7 +71,7 @@ const baseSession: Session = {
 
 describe('SessionList project filters', () => {
   test('marks hidden permission sessions when filters exclude them', () => {
-    useSettingsStore.setState({ projectFilters: ['/tmp/visible'] })
+    useSettingsStore.setState({ projectFilters: ['/tmp/visible'], hostFilters: [] })
 
     const sessions: Session[] = [
       { ...baseSession, id: 'visible', projectPath: '/tmp/visible', status: 'working' },

--- a/src/client/__tests__/sessionState.test.ts
+++ b/src/client/__tests__/sessionState.test.ts
@@ -34,6 +34,7 @@ beforeEach(() => {
     showProjectName: true,
     showLastUserMessage: true,
     showSessionIdPrefix: false,
+    hostFilters: [],
   })
 })
 

--- a/src/client/__tests__/settingsModal.test.tsx
+++ b/src/client/__tests__/settingsModal.test.tsx
@@ -47,6 +47,7 @@ beforeEach(() => {
     showProjectName: true,
     showLastUserMessage: true,
     showSessionIdPrefix: false,
+    hostFilters: [],
   })
   useThemeStore.setState({ theme: 'dark' })
 })
@@ -64,6 +65,7 @@ afterEach(() => {
     showProjectName: true,
     showLastUserMessage: true,
     showSessionIdPrefix: false,
+    hostFilters: [],
   })
   useThemeStore.setState({ theme: 'dark' })
 })

--- a/src/client/__tests__/settingsStore.test.ts
+++ b/src/client/__tests__/settingsStore.test.ts
@@ -63,6 +63,7 @@ beforeEach(() => {
     showLastUserMessage: true,
     showSessionIdPrefix: false,
     projectFilters: [],
+    hostFilters: [],
   })
 })
 
@@ -74,6 +75,7 @@ describe('useSettingsStore', () => {
     expect(state.lastProjectPath).toBeNull()
     expect(state.recentPaths).toEqual([])
     expect(state.projectFilters).toEqual([])
+    expect(state.hostFilters).toEqual([])
   })
 
   test('updates default project dir', () => {

--- a/src/client/components/HostBadge.tsx
+++ b/src/client/components/HostBadge.tsx
@@ -1,0 +1,20 @@
+import { getProjectColorStyle } from '../utils/projectColor'
+
+interface HostBadgeProps {
+  name: string
+  className?: string
+}
+
+export default function HostBadge({ name, className = '' }: HostBadgeProps) {
+  const colorStyle = getProjectColorStyle(`host:${name}`)
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase leading-none tracking-wide ${className}`}
+      style={colorStyle}
+      title={name}
+    >
+      {name}
+    </span>
+  )
+}

--- a/src/client/components/HostFilterDropdown.tsx
+++ b/src/client/components/HostFilterDropdown.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import ChevronDownIcon from '@untitledui-icons/react/line/esm/ChevronDownIcon'
+import type { HostStatus } from '@shared/types'
+
+interface HostFilterDropdownProps {
+  hosts: string[]
+  selectedHosts: string[]
+  onSelect: (hosts: string[]) => void
+  statuses?: HostStatus[]
+}
+
+export default function HostFilterDropdown({
+  hosts,
+  selectedHosts,
+  onSelect,
+  statuses = [],
+}: HostFilterDropdownProps) {
+  const [open, setOpen] = useState(false)
+  const menuId = useId()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const selectedSet = useMemo(() => new Set(selectedHosts), [selectedHosts])
+  const statusMap = useMemo(
+    () => new Map(statuses.map((status) => [status.host, status])),
+    [statuses]
+  )
+
+  const selectedTitle = useMemo(() => {
+    if (selectedHosts.length === 0) return 'All Hosts'
+    return selectedHosts.join(', ')
+  }, [selectedHosts])
+
+  const selectedLabel = useMemo(() => {
+    if (selectedHosts.length === 0) return 'All Hosts'
+    if (selectedHosts.length === 1) return selectedHosts[0]
+    return `${selectedHosts.length} hosts`
+  }, [selectedHosts])
+
+  useEffect(() => {
+    if (!open || typeof document === 'undefined') return
+    if (!document.addEventListener || !document.removeEventListener) return
+    const handlePointer = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node | null
+      if (target && containerRef.current?.contains(target)) return
+      setOpen(false)
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handlePointer)
+    document.addEventListener('touchstart', handlePointer, { passive: true })
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handlePointer)
+      document.removeEventListener('touchstart', handlePointer)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
+
+  const toggleHost = (host: string) => {
+    const next = new Set(selectedSet)
+    if (next.has(host)) {
+      next.delete(host)
+    } else {
+      next.add(host)
+    }
+    const ordered = hosts.filter((value) => next.has(value))
+    onSelect(ordered)
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={menuId}
+        aria-label="Filter by host"
+        onClick={() => setOpen((value) => !value)}
+        className="flex h-6 max-w-[9rem] items-center gap-1 rounded border border-border bg-base px-2 text-[11px] text-primary hover:bg-hover focus:border-accent focus:outline-none"
+        title={selectedTitle}
+      >
+        <span className="truncate">{selectedLabel}</span>
+        <ChevronDownIcon className="h-3 w-3 shrink-0 text-muted" />
+      </button>
+      {open && (
+        <div
+          id={menuId}
+          role="menu"
+          className="absolute right-0 z-20 mt-1 w-48 rounded border border-border bg-surface p-2 text-xs shadow-lg"
+        >
+          <label className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-primary hover:bg-hover">
+            <input
+              type="checkbox"
+              checked={selectedHosts.length === 0}
+              onChange={() => onSelect([])}
+              className="h-3.5 w-3.5 accent-approval"
+            />
+            <span>All Hosts</span>
+          </label>
+          <div className="my-2 h-px bg-border" />
+          {hosts.length === 0 ? (
+            <div className="px-2 py-1 text-muted">No hosts</div>
+          ) : (
+            <div className="max-h-48 overflow-y-auto pr-1">
+              {hosts.map((host) => {
+                const status = statusMap.get(host)
+                const isOffline = status ? !status.ok : false
+                return (
+                  <label
+                    key={host}
+                    className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-primary hover:bg-hover"
+                    title={status?.error ? `${host}: ${status.error}` : host}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedSet.has(host)}
+                      onChange={() => toggleHost(host)}
+                      className="h-3.5 w-3.5 accent-approval"
+                    />
+                    <span className="truncate">{host}</span>
+                    {isOffline && (
+                      <span className="ml-auto text-[10px] uppercase text-danger">offline</span>
+                    )}
+                  </label>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/client/components/SessionList.tsx
+++ b/src/client/components/SessionList.tsx
@@ -24,7 +24,7 @@ import ChevronRightIcon from '@untitledui-icons/react/line/esm/ChevronRightIcon'
 import Edit05Icon from '@untitledui-icons/react/line/esm/Edit05Icon'
 import Pin02Icon from '@untitledui-icons/react/line/esm/Pin02Icon'
 import type { AgentSession, Session } from '@shared/types'
-import { getSessionOrderKey, getUniqueProjects, sortSessions } from '../utils/sessions'
+import { getSessionOrderKey, getUniqueHosts, getUniqueProjects, sortSessions } from '../utils/sessions'
 import { formatRelativeTime } from '../utils/time'
 import { getPathLeaf } from '../utils/sessionLabel'
 import { getSessionIdShort } from '../utils/sessionId'
@@ -36,6 +36,8 @@ import { useExitCleanup } from '../hooks/useExitCleanup'
 import AgentIcon from './AgentIcon'
 import InactiveSessionItem from './InactiveSessionItem'
 import ProjectBadge from './ProjectBadge'
+import HostBadge from './HostBadge'
+import HostFilterDropdown from './HostFilterDropdown'
 import ProjectFilterDropdown from './ProjectFilterDropdown'
 import SessionPreviewModal from './SessionPreviewModal'
 
@@ -166,10 +168,13 @@ export default function SessionList({
   )
   const projectFilters = useSettingsStore((state) => state.projectFilters)
   const setProjectFilters = useSettingsStore((state) => state.setProjectFilters)
+  const hostFilters = useSettingsStore((state) => state.hostFilters)
+  const setHostFilters = useSettingsStore((state) => state.setHostFilters)
 
   // Get exiting sessions from store (for kill-failed rollback only)
   const exitingSessions = useSessionStore((state) => state.exitingSessions)
   const clearExitingSession = useSessionStore((state) => state.clearExitingSession)
+  const hostStatuses = useSessionStore((state) => state.hostStatuses)
 
   // Clean up exiting session state after animations
   useExitCleanup(sessions, exitingSessions, clearExitingSession, EXIT_DURATION)
@@ -211,14 +216,45 @@ export default function SessionList({
     [sessions, inactiveSessions]
   )
 
+  const uniqueHosts = useMemo(() => {
+    const sessionHosts = getUniqueHosts(sessions, inactiveSessions)
+    const statusHosts = hostStatuses.map((status) => status.host)
+    const seen = new Set<string>()
+    const merged: string[] = []
+
+    for (const host of statusHosts) {
+      if (!host || seen.has(host)) continue
+      seen.add(host)
+      merged.push(host)
+    }
+
+    for (const host of sessionHosts) {
+      if (!host || seen.has(host)) continue
+      seen.add(host)
+      merged.push(host)
+    }
+
+    return merged
+  }, [sessions, inactiveSessions, hostStatuses])
+
   const filteredSessions = useMemo(() => {
-    if (projectFilters.length === 0) return sortedSessions
-    return sortedSessions.filter((session) => projectFilters.includes(session.projectPath))
-  }, [sortedSessions, projectFilters])
+    let next = sortedSessions
+    if (projectFilters.length > 0) {
+      next = next.filter((session) => projectFilters.includes(session.projectPath))
+    }
+    if (hostFilters.length > 0) {
+      next = next.filter((session) => hostFilters.includes(session.host ?? ''))
+    }
+    return next
+  }, [sortedSessions, projectFilters, hostFilters])
 
   const filterKey = useMemo(
-    () => (projectFilters.length === 0 ? 'all-projects' : projectFilters.join('|')),
-    [projectFilters]
+    () => {
+      const projectKey = projectFilters.length === 0 ? 'all-projects' : projectFilters.join('|')
+      const hostKey = hostFilters.length === 0 ? 'all-hosts' : hostFilters.join('|')
+      return `${projectKey}::${hostKey}`
+    },
+    [projectFilters, hostFilters]
   )
 
   // Track sessions that became visible due to filter changes (for entry animation)
@@ -256,11 +292,15 @@ export default function SessionList({
   }, [newlyFilteredInIds])
 
   const filteredInactiveSessions = useMemo(() => {
-    if (projectFilters.length === 0) return inactiveSessions
-    return inactiveSessions.filter(
-      (session) => projectFilters.includes(session.projectPath)
-    )
-  }, [inactiveSessions, projectFilters])
+    let next = inactiveSessions
+    if (projectFilters.length > 0) {
+      next = next.filter((session) => projectFilters.includes(session.projectPath))
+    }
+    if (hostFilters.length > 0) {
+      next = next.filter((session) => hostFilters.includes(session.host ?? ''))
+    }
+    return next
+  }, [inactiveSessions, projectFilters, hostFilters])
 
   const hiddenPermissionCount = useMemo(() => {
     if (projectFilters.length === 0) return 0
@@ -280,6 +320,15 @@ export default function SessionList({
       setProjectFilters(nextFilters)
     }
   }, [projectFilters, uniqueProjects, setProjectFilters])
+
+  useEffect(() => {
+    if (hostFilters.length === 0 || uniqueHosts.length === 0) return
+    const validHosts = new Set(uniqueHosts)
+    const nextFilters = hostFilters.filter((host) => validHosts.has(host))
+    if (nextFilters.length !== hostFilters.length) {
+      setHostFilters(nextFilters)
+    }
+  }, [hostFilters, uniqueHosts, setHostFilters])
 
   // Drag-and-drop setup
   const sensors = useSensors(
@@ -397,6 +446,12 @@ export default function SessionList({
             Sessions
           </span>
           <div className="flex items-center gap-4">
+            <HostFilterDropdown
+              hosts={uniqueHosts}
+              selectedHosts={hostFilters}
+              onSelect={setHostFilters}
+              statuses={hostStatuses}
+            />
             <ProjectFilterDropdown
               projects={uniqueProjects}
               selectedProjects={projectFilters}
@@ -444,6 +499,7 @@ export default function SessionList({
                   {filteredSessions.map((session, index) => {
                     const isTrulyNew = newlyActiveIds.has(session.id)
                     const isFilteredIn = newlyFilteredInIds.has(session.id)
+                    const isRemote = session.remote === true
                     // Calculate drop indicator position
                     const activeIndex = activeId
                       ? filteredSessions.findIndex((s) => s.id === activeId)
@@ -470,8 +526,8 @@ export default function SessionList({
                         onStartEdit={() => setEditingSessionId(session.id)}
                         onCancelEdit={() => setEditingSessionId(null)}
                         onRename={(newName) => handleRename(session.id, newName)}
-                        onKill={onKill ? () => onKill(session.id) : undefined}
-                        onDuplicate={onDuplicate ? () => onDuplicate(session.id) : undefined}
+                        onKill={onKill && !isRemote ? () => onKill(session.id) : undefined}
+                        onDuplicate={onDuplicate && !isRemote ? () => onDuplicate(session.id) : undefined}
                         onSetPinned={onSetPinned && session.agentSessionId ? (isPinned) => onSetPinned(session.agentSessionId!.trim(), isPinned) : undefined}
                       />
                     )
@@ -733,6 +789,7 @@ function SessionRow({
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null)
   const directoryLeaf = getPathLeaf(session.projectPath)
+  const hostLabel = session.host?.trim()
   const needsInput = session.status === 'permission'
   const agentSessionId = session.agentSessionId?.trim()
   const sessionIdPrefix =
@@ -740,6 +797,7 @@ function SessionRow({
       ? getSessionIdShort(agentSessionId)
       : ''
   const showDirectory = showProjectName && Boolean(directoryLeaf)
+  const showHostBadge = Boolean(hostLabel)
   const showMessage = showLastUserMessage && Boolean(session.lastUserMessage)
 
   // Track previous status for transition animation
@@ -917,8 +975,9 @@ function SessionRow({
         </div>
 
         {/* Line 2: Project badge + last user message (up to 2 lines total) */}
-        {(showDirectory || showMessage) && (
+        {(showDirectory || showHostBadge || showMessage) && (
           <div className="flex flex-wrap items-center gap-1 pl-[1.375rem]">
+            {showHostBadge && <HostBadge name={hostLabel!} />}
             {showDirectory && (
               <ProjectBadge name={directoryLeaf!} fullPath={session.projectPath} />
             )}

--- a/src/client/stores/sessionStore.ts
+++ b/src/client/stores/sessionStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
-import type { AgentSession, Session } from '@shared/types'
+import type { AgentSession, HostStatus, Session } from '@shared/types'
 import { sortSessions } from '../utils/sessions'
 import { useSettingsStore } from './settingsStore'
 import { safeStorage } from '../utils/storage'
@@ -15,6 +15,7 @@ export type ConnectionStatus =
 interface SessionState {
   sessions: Session[]
   agentSessions: { active: AgentSession[]; inactive: AgentSession[] }
+  hostStatuses: HostStatus[]
   // Sessions being animated out - keyed by session ID, value is the session data
   exitingSessions: Map<string, Session>
   selectedSessionId: string | null
@@ -23,6 +24,7 @@ interface SessionState {
   connectionError: string | null
   setSessions: (sessions: Session[]) => void
   setAgentSessions: (active: AgentSession[], inactive: AgentSession[]) => void
+  setHostStatuses: (hosts: HostStatus[]) => void
   updateSession: (session: Session) => void
   setSelectedSessionId: (sessionId: string | null) => void
   setConnectionStatus: (status: ConnectionStatus) => void
@@ -38,6 +40,7 @@ export const useSessionStore = create<SessionState>()(
     (set, get) => ({
       sessions: [],
       agentSessions: { active: [], inactive: [] },
+      hostStatuses: [],
       exitingSessions: new Map(),
       selectedSessionId: null,
       hasLoaded: false,
@@ -96,6 +99,7 @@ export const useSessionStore = create<SessionState>()(
         set({
           agentSessions: { active, inactive },
         }),
+      setHostStatuses: (hosts) => set({ hostStatuses: hosts }),
       updateSession: (session) =>
         set((state) => ({
           sessions: state.sessions.map((existing) =>

--- a/src/client/stores/settingsStore.ts
+++ b/src/client/stores/settingsStore.ts
@@ -140,6 +140,8 @@ interface SettingsState {
   setSidebarWidth: (width: number) => void
   projectFilters: string[]
   setProjectFilters: (filters: string[]) => void
+  hostFilters: string[]
+  setHostFilters: (filters: string[]) => void
   // Sound notifications
   soundOnPermission: boolean
   setSoundOnPermission: (enabled: boolean) => void
@@ -205,6 +207,8 @@ export const useSettingsStore = create<SettingsState>()(
         }),
       projectFilters: [],
       setProjectFilters: (filters) => set({ projectFilters: filters }),
+      hostFilters: [],
+      setHostFilters: (filters) => set({ hostFilters: filters }),
       // Sound notifications
       soundOnPermission: false,
       setSoundOnPermission: (enabled) => set({ soundOnPermission: enabled }),

--- a/src/client/utils/sessions.ts
+++ b/src/client/utils/sessions.ts
@@ -103,3 +103,38 @@ export function getUniqueProjects(
     return bTime - aTime
   })
 }
+
+export function getUniqueHosts(
+  sessions: Session[],
+  inactiveSessions: AgentSession[]
+): string[] {
+  const hostActivity = new Map<string, number>()
+
+  for (const session of sessions) {
+    const host = session.host?.trim()
+    if (host) {
+      const timestamp = Date.parse(session.lastActivity) || 0
+      const existing = hostActivity.get(host) || 0
+      if (timestamp > existing) {
+        hostActivity.set(host, timestamp)
+      }
+    }
+  }
+
+  for (const session of inactiveSessions) {
+    const host = session.host?.trim()
+    if (host) {
+      const timestamp = Date.parse(session.lastActivityAt) || 0
+      const existing = hostActivity.get(host) || 0
+      if (timestamp > existing) {
+        hostActivity.set(host, timestamp)
+      }
+    }
+  }
+
+  return Array.from(hostActivity.keys()).sort((a, b) => {
+    const aTime = hostActivity.get(a) || 0
+    const bTime = hostActivity.get(b) || 0
+    return bTime - aTime
+  })
+}

--- a/src/server/SessionRegistry.ts
+++ b/src/server/SessionRegistry.ts
@@ -141,6 +141,8 @@ function sessionsEqual(a: Session, b: Session): boolean {
     a.agentSessionName === b.agentSessionName &&
     a.logFilePath === b.logFilePath &&
     a.lastUserMessage === b.lastUserMessage &&
-    a.isPinned === b.isPinned
+    a.isPinned === b.isPinned &&
+    a.host === b.host &&
+    a.remote === b.remote
   )
 }

--- a/src/server/__tests__/config.test.ts
+++ b/src/server/__tests__/config.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test'
+import os from 'node:os'
 
 const ORIGINAL_ENV = {
   PORT: process.env.PORT,
@@ -20,6 +21,13 @@ const ORIGINAL_ENV = {
   CODEX_HOME: process.env.CODEX_HOME,
   CLAUDE_RESUME_CMD: process.env.CLAUDE_RESUME_CMD,
   CODEX_RESUME_CMD: process.env.CODEX_RESUME_CMD,
+  AGENTBOARD_HOST: process.env.AGENTBOARD_HOST,
+  AGENTBOARD_REMOTE_HOSTS: process.env.AGENTBOARD_REMOTE_HOSTS,
+  AGENTBOARD_REMOTE_POLL_MS: process.env.AGENTBOARD_REMOTE_POLL_MS,
+  AGENTBOARD_REMOTE_TIMEOUT_MS: process.env.AGENTBOARD_REMOTE_TIMEOUT_MS,
+  AGENTBOARD_REMOTE_STALE_MS: process.env.AGENTBOARD_REMOTE_STALE_MS,
+  AGENTBOARD_REMOTE_SSH_OPTS: process.env.AGENTBOARD_REMOTE_SSH_OPTS,
+  AGENTBOARD_REMOTE_ALLOW_CONTROL: process.env.AGENTBOARD_REMOTE_ALLOW_CONTROL,
 }
 
 const ENV_KEYS = Object.keys(ORIGINAL_ENV) as Array<keyof typeof ORIGINAL_ENV>
@@ -58,6 +66,13 @@ async function loadConfig(tag: string) {
     codexHomeDir: string
     claudeResumeCmd: string
     codexResumeCmd: string
+    hostLabel: string
+    remoteHosts: string[]
+    remotePollMs: number
+    remoteTimeoutMs: number
+    remoteStaleMs: number
+    remoteSshOpts: string
+    remoteAllowControl: boolean
   }
 }
 
@@ -89,6 +104,13 @@ describe('config', () => {
     expect(config.logMatchProfile).toBe(false)
     expect(config.claudeResumeCmd).toBe('claude --resume {sessionId}')
     expect(config.codexResumeCmd).toBe('codex resume {sessionId}')
+    expect(config.hostLabel).toBe(os.hostname())
+    expect(config.remoteHosts).toEqual([])
+    expect(config.remotePollMs).toBe(15000)
+    expect(config.remoteTimeoutMs).toBe(4000)
+    expect(config.remoteStaleMs).toBe(45000)
+    expect(config.remoteSshOpts).toBe('')
+    expect(config.remoteAllowControl).toBe(false)
   })
 
   test('parses env overrides and trims discover prefixes', async () => {
@@ -111,6 +133,13 @@ describe('config', () => {
     process.env.CODEX_HOME = '/tmp/codex'
     process.env.CLAUDE_RESUME_CMD = 'claude --resume={sessionId}'
     process.env.CODEX_RESUME_CMD = 'codex --resume={sessionId}'
+    process.env.AGENTBOARD_HOST = 'blade'
+    process.env.AGENTBOARD_REMOTE_HOSTS = 'mba,carbon,worm'
+    process.env.AGENTBOARD_REMOTE_POLL_MS = '12000'
+    process.env.AGENTBOARD_REMOTE_TIMEOUT_MS = '9000'
+    process.env.AGENTBOARD_REMOTE_STALE_MS = '50000'
+    process.env.AGENTBOARD_REMOTE_SSH_OPTS = '-o StrictHostKeyChecking=accept-new'
+    process.env.AGENTBOARD_REMOTE_ALLOW_CONTROL = 'true'
 
     const config = await loadConfig('overrides')
     expect(config.port).toBe(9090)
@@ -132,5 +161,12 @@ describe('config', () => {
     expect(config.codexHomeDir).toBe('/tmp/codex')
     expect(config.claudeResumeCmd).toBe('claude --resume={sessionId}')
     expect(config.codexResumeCmd).toBe('codex --resume={sessionId}')
+    expect(config.hostLabel).toBe('blade')
+    expect(config.remoteHosts).toEqual(['mba', 'carbon', 'worm'])
+    expect(config.remotePollMs).toBe(12000)
+    expect(config.remoteTimeoutMs).toBe(9000)
+    expect(config.remoteStaleMs).toBe(50000)
+    expect(config.remoteSshOpts).toBe('-o StrictHostKeyChecking=accept-new')
+    expect(config.remoteAllowControl).toBe(true)
   })
 })

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -462,8 +462,14 @@ describe('server message handlers', () => {
     }
     websocket.open?.(ws as never)
 
-    expect(sent[0]).toEqual({ type: 'sessions', sessions: [baseSession] })
-    expect(sent[1]).toMatchObject({ type: 'agent-sessions' })
+    expect(sent.find((message) => message.type === 'sessions')).toEqual({
+      type: 'sessions',
+      sessions: [baseSession],
+    })
+    expect(sent.find((message) => message.type === 'host-status')).toBeTruthy()
+    expect(sent.find((message) => message.type === 'agent-sessions')).toMatchObject({
+      type: 'agent-sessions',
+    })
 
     const nextSession = { ...baseSession, id: 'session-2', name: 'beta' }
     registryInstance.emit('session-update', nextSession)

--- a/src/server/agentSessions.ts
+++ b/src/server/agentSessions.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import type { AgentSession } from '../shared/types'
+import { config } from './config'
 import type { AgentSessionRecord } from './db'
 
 export function toAgentSession(record: AgentSessionRecord): AgentSession {
@@ -12,6 +13,7 @@ export function toAgentSession(record: AgentSessionRecord): AgentSession {
     createdAt: record.createdAt,
     lastActivityAt: record.lastActivityAt,
     isActive: record.currentWindow !== null,
+    host: config.hostLabel,
     lastUserMessage: record.lastUserMessage ?? undefined,
     isPinned: record.isPinned,
     lastResumeError: record.lastResumeError ?? undefined,

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,3 +1,4 @@
+import os from 'node:os'
 import path from 'node:path'
 
 const terminalModeRaw = process.env.TERMINAL_MODE
@@ -86,9 +87,31 @@ const claudeConfigDir =
 const codexHomeDir =
   process.env.CODEX_HOME || path.join(homeDir, '.codex')
 
+const hostLabel = process.env.AGENTBOARD_HOST?.trim() || os.hostname()
+
+const remoteHosts = (process.env.AGENTBOARD_REMOTE_HOSTS || '')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean)
+
+const remotePollMsRaw = Number(process.env.AGENTBOARD_REMOTE_POLL_MS)
+const remotePollMs = Number.isFinite(remotePollMsRaw) ? remotePollMsRaw : 15000
+
+const remoteTimeoutMsRaw = Number(process.env.AGENTBOARD_REMOTE_TIMEOUT_MS)
+const remoteTimeoutMs = Number.isFinite(remoteTimeoutMsRaw) ? remoteTimeoutMsRaw : 4000
+
+const remoteStaleMsRaw = Number(process.env.AGENTBOARD_REMOTE_STALE_MS)
+const remoteStaleMs = Number.isFinite(remoteStaleMsRaw)
+  ? remoteStaleMsRaw
+  : Math.max(remotePollMs * 3, 15000)
+
+const remoteSshOpts = process.env.AGENTBOARD_REMOTE_SSH_OPTS || ''
+const remoteAllowControl = process.env.AGENTBOARD_REMOTE_ALLOW_CONTROL === 'true'
+
 export const config = {
   port: Number(process.env.PORT) || 4040,
   hostname: process.env.HOSTNAME || '0.0.0.0',
+  hostLabel,
   tmuxSession: process.env.TMUX_SESSION || 'agentboard',
   refreshIntervalMs: Number(process.env.REFRESH_INTERVAL_MS) || 2000,
   discoverPrefixes: (process.env.DISCOVER_PREFIXES || '')
@@ -119,4 +142,10 @@ export const config = {
   skipMatchingPatterns,
   logLevel,
   logFile,
+  remoteHosts,
+  remotePollMs,
+  remoteTimeoutMs,
+  remoteStaleMs,
+  remoteSshOpts,
+  remoteAllowControl,
 }

--- a/src/server/remoteSessions.ts
+++ b/src/server/remoteSessions.ts
@@ -1,0 +1,255 @@
+import { inferAgentType } from './agentDetection'
+import { logger } from './logger'
+import type { HostStatus, Session } from '../shared/types'
+
+const DEFAULT_SSH_OPTIONS = ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=3']
+const TMUX_LIST_FORMAT =
+  '#{session_name}\\t#{window_index}\\t#{window_id}\\t#{window_name}\\t#{pane_current_path}\\t#{window_activity}\\t#{window_creation_time}\\t#{pane_start_command}'
+
+interface RemoteHostSnapshot {
+  host: string
+  sessions: Session[]
+  ok: boolean
+  error?: string
+  updatedAt: number
+}
+
+export interface RemoteSessionPollerOptions {
+  hosts: string[]
+  pollIntervalMs: number
+  timeoutMs: number
+  staleAfterMs: number
+  sshOptions?: string
+  onUpdate?: (hosts: HostStatus[]) => void
+}
+
+export class RemoteSessionPoller {
+  private readonly hosts: string[]
+  private readonly pollIntervalMs: number
+  private readonly timeoutMs: number
+  private readonly staleAfterMs: number
+  private readonly sshOptions: string[]
+  private readonly onUpdate?: (hosts: HostStatus[]) => void
+  private timer: Timer | null = null
+  private inFlight = false
+  private lastStatusSnapshot = ''
+  private snapshots = new Map<string, RemoteHostSnapshot>()
+
+  constructor(options: RemoteSessionPollerOptions) {
+    this.hosts = options.hosts
+    this.pollIntervalMs = options.pollIntervalMs
+    this.timeoutMs = options.timeoutMs
+    this.staleAfterMs = options.staleAfterMs
+    this.sshOptions = [
+      ...DEFAULT_SSH_OPTIONS,
+      ...splitSshOptions(options.sshOptions ?? ''),
+    ]
+    this.onUpdate = options.onUpdate
+  }
+
+  start(): void {
+    if (this.timer || this.hosts.length === 0) {
+      return
+    }
+    void this.poll()
+    this.timer = setInterval(() => {
+      void this.poll()
+    }, this.pollIntervalMs)
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+  }
+
+  getSessions(): Session[] {
+    const now = Date.now()
+    const sessions: Session[] = []
+    for (const snapshot of this.snapshots.values()) {
+      if (!snapshot.ok) continue
+      if (now - snapshot.updatedAt > this.staleAfterMs) continue
+      sessions.push(...snapshot.sessions)
+    }
+    return sessions
+  }
+
+  getHostStatuses(): HostStatus[] {
+    const now = Date.now()
+    return this.hosts.map((host) => {
+      const snapshot = this.snapshots.get(host)
+      if (!snapshot) {
+        return {
+          host,
+          ok: false,
+          lastUpdated: new Date(0).toISOString(),
+        }
+      }
+      const stale = now - snapshot.updatedAt > this.staleAfterMs
+      const ok = snapshot.ok && !stale
+      return {
+        host,
+        ok,
+        lastUpdated: new Date(snapshot.updatedAt).toISOString(),
+        error: ok ? undefined : snapshot.error ?? (stale ? 'stale' : undefined),
+      }
+    })
+  }
+
+  private async poll(): Promise<void> {
+    if (this.inFlight) {
+      return
+    }
+    this.inFlight = true
+    try {
+      const results = await Promise.allSettled(
+        this.hosts.map((host) => pollHost(host, this.sshOptions, this.timeoutMs))
+      )
+
+      results.forEach((result, index) => {
+        const host = this.hosts[index]
+        if (!host) return
+        if (result.status === 'fulfilled') {
+          this.snapshots.set(host, result.value)
+        } else {
+          this.snapshots.set(host, {
+            host,
+            sessions: [],
+            ok: false,
+            error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+            updatedAt: Date.now(),
+          })
+        }
+      })
+
+      const statuses = this.getHostStatuses()
+      const nextSnapshot = JSON.stringify(statuses)
+      if (nextSnapshot !== this.lastStatusSnapshot) {
+        this.lastStatusSnapshot = nextSnapshot
+        this.onUpdate?.(statuses)
+      }
+    } finally {
+      this.inFlight = false
+    }
+  }
+}
+
+async function pollHost(
+  host: string,
+  sshOptions: string[],
+  timeoutMs: number
+): Promise<RemoteHostSnapshot> {
+  const startedAt = Date.now()
+  const args = ['ssh', ...sshOptions, host, 'tmux', 'list-windows', '-a', '-F', TMUX_LIST_FORMAT]
+  const proc = Bun.spawn(args, { stdout: 'pipe', stderr: 'pipe' })
+
+  const timeout = setTimeout(() => {
+    try {
+      proc.kill()
+    } catch {
+      // ignore
+    }
+  }, timeoutMs)
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
+
+  clearTimeout(timeout)
+
+  if (exitCode !== 0) {
+    const message = stderr.trim() || `ssh exited with code ${exitCode}`
+    logger.warn('remote_host_poll_failed', { host, message })
+    return {
+      host,
+      sessions: [],
+      ok: false,
+      error: message,
+      updatedAt: Date.now(),
+    }
+  }
+
+  const sessions = parseTmuxWindows(host, stdout)
+  return {
+    host,
+    sessions,
+    ok: true,
+    updatedAt: Date.now(),
+  }
+}
+
+function parseTmuxWindows(host: string, output: string): Session[] {
+  const lines = output.split('\n').map((line) => line.trim()).filter(Boolean)
+  const now = Date.now()
+  const sessions: Session[] = []
+
+  for (const line of lines) {
+    const parts = line.split('\\t')
+    if (parts.length < 8) {
+      continue
+    }
+    const [
+      sessionName,
+      windowIndex,
+      windowId,
+      windowName,
+      cwd,
+      activityRaw,
+      createdRaw,
+      command,
+    ] = parts
+
+    if (!sessionName || !windowIndex) {
+      continue
+    }
+
+    const tmuxWindow = `${sessionName}:${windowIndex}`
+    const createdAt = toIsoFromSeconds(createdRaw, now)
+    const lastActivity = toIsoFromSeconds(activityRaw, now)
+    const agentType = inferAgentType(command || '')
+    const id = buildRemoteSessionId(host, sessionName, windowIndex, windowId)
+
+    sessions.push({
+      id,
+      name: windowName || tmuxWindow,
+      tmuxWindow,
+      projectPath: (cwd || '').trim(),
+      status: 'unknown',
+      lastActivity,
+      createdAt,
+      agentType,
+      source: 'external',
+      host,
+      remote: true,
+      command: command || undefined,
+    })
+  }
+
+  return sessions
+}
+
+function buildRemoteSessionId(
+  host: string,
+  sessionName: string,
+  windowIndex: string,
+  windowId?: string
+): string {
+  const suffix = windowId?.trim() ? windowId.trim() : windowIndex.trim()
+  return `remote:${host}:${sessionName}:${suffix}`
+}
+
+function toIsoFromSeconds(value: string | undefined, fallbackMs: number): string {
+  const parsed = Number.parseInt(value ?? '', 10)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return new Date(fallbackMs).toISOString()
+  }
+  return new Date(parsed * 1000).toISOString()
+}
+
+function splitSshOptions(value: string): string[] {
+  if (!value.trim()) return []
+  return value.split(/\s+/).map((part) => part.trim()).filter(Boolean)
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -24,6 +24,8 @@ export interface Session {
   createdAt: string
   agentType?: AgentType
   source: SessionSource
+  host?: string
+  remote?: boolean
   command?: string
   agentSessionId?: string
   agentSessionName?: string
@@ -41,9 +43,17 @@ export interface AgentSession {
   createdAt: string
   lastActivityAt: string
   isActive: boolean
+  host?: string
   lastUserMessage?: string
   isPinned?: boolean
   lastResumeError?: string
+}
+
+export interface HostStatus {
+  host: string
+  ok: boolean
+  lastUpdated: string
+  error?: string
 }
 
 // Directory browser types
@@ -69,6 +79,7 @@ export type ServerMessage =
   | { type: 'session-update'; session: Session }
   | { type: 'session-created'; session: Session }
   | { type: 'session-removed'; sessionId: string }
+  | { type: 'host-status'; hosts: HostStatus[] }
   | { type: 'agent-sessions'; active: AgentSession[]; inactive: AgentSession[] }
   | { type: 'session-orphaned'; session: AgentSession }
   | { type: 'session-activated'; session: AgentSession; window: string }


### PR DESCRIPTION
## Summary
- Poll remote hosts over SSH with cache + host-status broadcast
- Tag sessions with host/remote flags and add host badge + filter in UI
- Treat remote sessions as read-only in the terminal (no attach/kill)

## Env vars / defaults
- `AGENTBOARD_REMOTE_HOSTS`: comma-separated hostnames; enables polling
- `AGENTBOARD_REMOTE_POLL_MS`: default `15000`
- `AGENTBOARD_REMOTE_TIMEOUT_MS`: default `4000` (increase for slow SSH or cold connections)
- `AGENTBOARD_REMOTE_STALE_MS`: default `max(poll * 3, 15000)`
- `AGENTBOARD_REMOTE_SSH_OPTS`: extra ssh args (split on whitespace; keep args simple)
- `AGENTBOARD_HOST`: override host label (defaults to `hostname`)
- `AGENTBOARD_REMOTE_ALLOW_CONTROL`: default `false` (reserved for enabling remote control)
- SSH prerequisites: passwordless keys (or Tailscale SSH) to each host and `tmux` installed

## Limitations
- Remote sessions are read-only in the UI; control is intentionally disabled unless control gating is wired (future `AGENTBOARD_REMOTE_ALLOW_CONTROL=true`)
- Poller relies on `tmux list-windows`; malformed/unexpected lines are skipped and will not appear (use tmux output for troubleshooting)
- SSH options parsing does not support quoted args or paths with spaces

## Testing
- [ ] Not run (not requested)
