### PR TITLE
docs: add wip.md tracking active agentboard sessions

### DIFF
--- a/wip.md
+++ b/wip.md
@@ -1,0 +1,9 @@
+# WIP — Active Agentboard Sessions
+
+- **new-UX** — "Agentic Work OS" vision & plan: goal-tree-driven UI, living specs, AI course-correction loop *(no doc yet)*
+- **initial-msgs** — Initial message / attachment support → [docs/initial-message-attachments-spec.md](docs/initial-message-attachments-spec.md)
+- **agent-git** — Research on agent log tracking, git-ai integration, provenance indexing *(no doc yet)*
+- **stt** — Speech-to-text input for agentboard → [docs/stt-implementation-plan.md](docs/stt-implementation-plan.md)
+- **onboarding** — First-run onboarding UX → [docs/onboarding-ux-proposal.md](docs/onboarding-ux-proposal.md)
+- **file-refs** — File reference detection in agent output → [docs/file-reference-detection.md](docs/file-reference-detection.md)
+- **mac-app** — Native macOS app packaging → [docs/MAC_APP_PLAN.md](docs/MAC_APP_PLAN.md)


### PR DESCRIPTION
## Summary
- Adds `wip.md` listing active agentboard sessions with links to their associated spec/plan docs
- Extracted from live tmux session data in agentboard

## Test plan
- [x] Lint, typecheck, and tests pass
- [ ] Verify doc links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)