### PR TITLE
Add Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,8 +24,8 @@ Instead, please report them via:
 
 | Version | Supported |
 |---------|-----------|
-| Latest release on master branch | Yes |
-| Latest npm release (`@gbasin/agentboard`) | Yes |
+| Latest commit on the default branch | Yes |
+| Latest published npm package (`@gbasin/agentboard`) | Yes |
 | All other versions | No |
 
 


### PR DESCRIPTION
Added a section for reporting security issues and outlined the reporting process and disclosure policy.

<img width="874" height="303" alt="image" src="https://github.com/user-attachments/assets/b146bd45-713f-417d-92b3-a2d2846d4643" />


At AutoGPT, we had a hard time managing security reports, so we enabled Private Security Reporting via GitHub.

You can enable it here: https://github.com/gbasin/agentboard/settings/security_analysis

I'd also encourage you to check this link out now that the project is so popular: https://securitylab.github.com/protect-your-project.html

The pr assumes you've enabled the Private Security Reporting feature. :)