### PR TITLE
fix(server): prevent stale terminal attach errors on session switch

### DIFF
--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -384,6 +384,7 @@ function createWs() {
       currentTmuxTarget: null as string | null,
       connectionId: 'ws-test',
       terminalHost: null as string | null,
+      terminalAttachSeq: 0,
     },
     send: (payload: string) => {
       sent.push(JSON.parse(payload) as ServerMessage)


### PR DESCRIPTION
## Problem
Switching from a remote SSH session back to a local session could surface a global terminal error in the UI. Stale async SSH attach/start failures were reported after the selection changed, often with `sessionId=null`.

## Fix
- Add a per-WebSocket attach sequence and ignore stale attach/detach completions.
- Report terminal attach/start errors against the requested `sessionId` (not `ws.currentSessionId` at failure time).
- Guard terminal output from replaced proxies.
- Harden Pty/Ssh proxy start/dispose races and make SSH attach use `tmux new-session -A` to avoid duplicate-session failures.

## Testing
- `bun run lint`
- `bun run typecheck`
- `bun run test`
