### PR TITLE
fix: use printable separator for tmux format strings

### DIFF
--- a/src/server/SessionManager.ts
+++ b/src/server/SessionManager.ts
@@ -34,10 +34,13 @@ type CapturePane = (tmuxWindow: string) => PaneCapture | null
 
 // Cache of pane content, dimensions, and last-changed timestamp for change detection
 const paneContentCache = new Map<string, PaneCacheState>()
+// Uses '|||' as separator instead of '\t' because tmux replaces tab characters
+// with underscores when LANG is unset (common in launchd/systemd environments).
+const FIELD_SEPARATOR = '|||'
 const WINDOW_LIST_FORMAT =
-  '#{window_id}\t#{window_name}\t#{pane_current_path}\t#{window_activity}\t#{window_creation_time}\t#{pane_start_command}'
+  `#{window_id}${FIELD_SEPARATOR}#{window_name}${FIELD_SEPARATOR}#{pane_current_path}${FIELD_SEPARATOR}#{window_activity}${FIELD_SEPARATOR}#{window_creation_time}${FIELD_SEPARATOR}#{pane_start_command}`
 const WINDOW_LIST_FORMAT_FALLBACK =
-  '#{window_id}\t#{window_name}\t#{pane_current_path}\t#{window_activity}\t#{window_activity}\t#{pane_current_command}'
+  `#{window_id}${FIELD_SEPARATOR}#{window_name}${FIELD_SEPARATOR}#{pane_current_path}${FIELD_SEPARATOR}#{window_activity}${FIELD_SEPARATOR}#{window_activity}${FIELD_SEPARATOR}#{pane_current_command}`
 
 export class SessionManager {
   private sessionName: string
@@ -256,9 +259,9 @@ export class SessionManager {
         '-t',
         tmuxWindow,
         '-p',
-        '#{window_name}\t#{pane_current_path}',
+        `#{window_name}${FIELD_SEPARATOR}#{pane_current_path}`,
       ])
-      const [name, path] = info.trim().split('\t')
+      const [name, path] = info.trim().split(FIELD_SEPARATOR)
       logger.info('window_killed', { tmuxWindow, name, path })
     } catch {
       // Window may already be gone, log what we know
@@ -480,7 +483,7 @@ export class SessionManager {
 
 function parseWindow(line: string): WindowInfo {
   const [id, name, panePath, activityRaw, creationRaw, command] =
-    line.split('\t')
+    line.split(FIELD_SEPARATOR)
   const activity = Number.parseInt(activityRaw || '0', 10)
   const creation = Number.parseInt(creationRaw || '0', 10)
 
@@ -556,7 +559,7 @@ function capturePaneWithDimensions(tmuxWindow: string): PaneCapture | null {
         '-t',
         tmuxWindow,
         '-p',
-        '#{pane_width}\t#{pane_height}',
+        `#{pane_width}${FIELD_SEPARATOR}#{pane_height}`,
       ],
       { stdout: 'pipe', stderr: 'pipe' }
     )
@@ -567,7 +570,7 @@ function capturePaneWithDimensions(tmuxWindow: string): PaneCapture | null {
     const [widthText, heightText] = dimsResult.stdout
       .toString()
       .trim()
-      .split('\t')
+      .split(FIELD_SEPARATOR)
     const width = Number.parseInt(widthText ?? '', 10) || 80
     const height = Number.parseInt(heightText ?? '', 10) || 24
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -119,7 +119,7 @@ function pruneOrphanedWsSessions(): void {
   let result: ReturnType<typeof Bun.spawnSync>
   try {
     result = Bun.spawnSync(
-      ['tmux', 'list-sessions', '-F', '#{session_name}\t#{session_attached}'],
+      ['tmux', 'list-sessions', '-F', '#{session_name}|||#{session_attached}'],
       {
         stdout: 'pipe',
         stderr: 'pipe',
@@ -143,7 +143,7 @@ function pruneOrphanedWsSessions(): void {
   for (const line of lines) {
     const trimmed = line.trim()
     if (!trimmed) continue
-    const [name, attachedRaw] = trimmed.split('\t')
+    const [name, attachedRaw] = trimmed.split('|||')
     if (!name || !name.startsWith(prefix)) continue
     const attached = Number.parseInt(attachedRaw ?? '', 10)
     if (Number.isNaN(attached) || attached > 0) continue
@@ -1440,7 +1440,7 @@ async function handleRemoteCreate(
       // Session exists — add a new window to it
       createResult = await runRemoteTmux(host, [
         'new-window', '-P',
-        '-F', '#{window_index}\t#{window_id}',
+        '-F', '#{window_index}|||#{window_id}',
         '-t', tmuxSession, '-n', windowName, '-c', trimmedPath, wrappedCommand,
       ])
     } else {
@@ -1448,7 +1448,7 @@ async function handleRemoteCreate(
       // (avoids an orphan window 0 from a separate new-session call)
       createResult = await runRemoteTmux(host, [
         'new-session', '-d', '-P',
-        '-F', '#{window_index}\t#{window_id}',
+        '-F', '#{window_index}|||#{window_id}',
         '-s', tmuxSession, '-n', windowName, '-c', trimmedPath, wrappedCommand,
       ])
     }
@@ -1458,9 +1458,9 @@ async function handleRemoteCreate(
       return
     }
 
-    // Parse window info from -P output (e.g. "3\t@5")
+    // Parse window info from -P output (e.g. "3|||@5")
     const printOutput = createResult.stdout?.trim() ?? ''
-    const parts = printOutput.split('\t')
+    const parts = printOutput.split('|||')
     const now = Date.now()
 
     if (parts.length < 2 || !parts[0]) {

--- a/src/server/remoteSessions.ts
+++ b/src/server/remoteSessions.ts
@@ -18,8 +18,11 @@ function sanitizeForId(s: string): string {
 }
 
 const DEFAULT_SSH_OPTIONS = ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=3']
+// Uses '|||' as separator instead of '\t' because tmux replaces tab characters
+// with underscores when LANG is unset (common in launchd/systemd environments).
+const FIELD_SEPARATOR = '|||'
 const TMUX_LIST_FORMAT =
-  '#{session_name}\t#{window_index}\t#{window_id}\t#{window_name}\t#{pane_current_path}\t#{window_activity}\t#{window_creation_time}\t#{pane_start_command}'
+  `#{session_name}${FIELD_SEPARATOR}#{window_index}${FIELD_SEPARATOR}#{window_id}${FIELD_SEPARATOR}#{window_name}${FIELD_SEPARATOR}#{pane_current_path}${FIELD_SEPARATOR}#{window_activity}${FIELD_SEPARATOR}#{window_creation_time}${FIELD_SEPARATOR}#{pane_start_command}`
 
 // Cache of remote pane content for change detection (mirrors paneContentCache in SessionManager)
 const remoteContentCache = new Map<string, PaneCacheState>()
@@ -378,7 +381,7 @@ function parseTmuxWindows(
   const wsPrefix = `${tmuxSessionPrefix}-ws-`
 
   for (const line of lines) {
-    const parts = line.split('\t')
+    const parts = line.split(FIELD_SEPARATOR)
     if (parts.length < 8) {
       continue
     }

--- a/src/server/sessionRefreshWorker.ts
+++ b/src/server/sessionRefreshWorker.ts
@@ -16,11 +16,14 @@ import {
 } from './statusInference'
 import type { Session, SessionStatus, SessionSource } from '../shared/types'
 
-// Format string for batched window listing
+// Format string for batched window listing.
+// Uses '|||' as separator instead of '\t' because tmux replaces tab characters
+// with underscores when LANG is unset (common in launchd/systemd environments).
+const FIELD_SEPARATOR = '|||'
 const BATCH_WINDOW_FORMAT =
-  '#{session_name}\t#{window_id}\t#{window_name}\t#{pane_current_path}\t#{window_activity}\t#{window_creation_time}\t#{pane_start_command}\t#{pane_width}\t#{pane_height}'
+  `#{session_name}${FIELD_SEPARATOR}#{window_id}${FIELD_SEPARATOR}#{window_name}${FIELD_SEPARATOR}#{pane_current_path}${FIELD_SEPARATOR}#{window_activity}${FIELD_SEPARATOR}#{window_creation_time}${FIELD_SEPARATOR}#{pane_start_command}${FIELD_SEPARATOR}#{pane_width}${FIELD_SEPARATOR}#{pane_height}`
 const BATCH_WINDOW_FORMAT_FALLBACK =
-  '#{session_name}\t#{window_id}\t#{window_name}\t#{pane_current_path}\t#{window_activity}\t#{window_activity}\t#{pane_current_command}\t#{pane_width}\t#{pane_height}'
+  `#{session_name}${FIELD_SEPARATOR}#{window_id}${FIELD_SEPARATOR}#{window_name}${FIELD_SEPARATOR}#{pane_current_path}${FIELD_SEPARATOR}#{window_activity}${FIELD_SEPARATOR}#{window_activity}${FIELD_SEPARATOR}#{pane_current_command}${FIELD_SEPARATOR}#{pane_width}${FIELD_SEPARATOR}#{pane_height}`
 
 const LAST_USER_MESSAGE_SCROLLBACK_LINES = 200
 
@@ -161,7 +164,7 @@ function listAllWindowData(): WindowData[] {
     .map((line) => line.trim())
     .filter(Boolean)
     .map((line) => {
-      const parts = line.split('\t')
+      const parts = line.split(FIELD_SEPARATOR)
       return {
         sessionName: parts[0] ?? '',
         windowId: parts[1] ?? '',


### PR DESCRIPTION
## Summary

- Replace `\t` (tab) with `|||` as field separator in all tmux format strings
- Fixes ERR_INVALID_WINDOW for **all** external sessions when running as a launchd/systemd service

## Problem

tmux replaces tab characters (0x09) with underscores (`_`) when `LANG` is unset. Since launchd provides a minimal environment without `LANG`, every `split('\t')` call fails — the entire line becomes a single field, producing mangled session IDs like `tg-bridge_@15_afreecatv3_/Users/...` instead of `tg-bridge:@15`.

**Reproduction:**
```bash
# Works (LANG set):
LANG=en_US.UTF-8 tmux list-windows -a -F "$(printf '#{session_name}\t#{window_id}')" | xxd | head -1
# → 09 (real tab)

# Broken (LANG unset, like launchd):
env -i HOME=$HOME PATH=/opt/homebrew/bin:/usr/bin tmux list-windows -a -F "$(printf '#{session_name}\t#{window_id}')" | xxd | head -1
# → 5f (underscore!)
```

## Changes

| File | Change |
|---|---|
| `sessionRefreshWorker.ts` | `BATCH_WINDOW_FORMAT` + `BATCH_WINDOW_FORMAT_FALLBACK`: `\t` → `\|\|\|` |
| `SessionManager.ts` | `WINDOW_LIST_FORMAT` + `WINDOW_LIST_FORMAT_FALLBACK` + `parseWindow` + `capturePaneWithDimensions`: `\t` → `\|\|\|` |
| `remoteSessions.ts` | `TMUX_LIST_FORMAT` + parse: `\t` → `\|\|\|` |
| `index.ts` | `list-sessions` format + `new-window -P` format: `\t` → `\|\|\|` |

## Test plan

- [ ] Verify agentboard starts and discovers managed + external sessions
- [ ] Verify external session terminals load (no ERR_INVALID_WINDOW)
- [ ] Verify remote sessions (SSH) still parse correctly
- [ ] Test with `LANG` unset: `env -i HOME=$HOME PATH=... agentboard`

Fixes #102