### PR TITLE
fix: v0.2.26 — detect Codex suggested messages in idle input field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/server/__tests__/logMatcher.test.ts
+++ b/src/server/__tests__/logMatcher.test.ts
@@ -829,6 +829,26 @@ Enter to select · Esc to cancel`
     // The ⏺ after the block proves this was a submitted message, not AskUserQuestion
     expect(userMessages).toContain('1. Audit auth flow')
   })
+
+  test('Codex: skips suggested message in idle input field with "N% left" status', () => {
+    // Codex shows a suggested next message in the input field when idle.
+    // The status line below uses "N% left" without the word "context".
+    const scrollback = `› is there any benefit for Effect on client side
+
+⏺ Yes, but mostly for client workflows, not for rendering itself.
+
+› Explain this codebase
+
+  gpt-5.4 xhigh fast · 68% left · ~/Documents/GitHub/usonia`
+
+    const userMessages = extractRecentUserMessagesFromTmux(scrollback)
+    // Should NOT include the suggested message in the input field
+    expect(userMessages).not.toContain('Explain this codebase')
+    // Should find the real submitted message
+    expect(userMessages).toContain(
+      'is there any benefit for Effect on client side'
+    )
+  })
 })
 
 describe('extractActionFromUserAction', () => {

--- a/src/server/logMatcher.ts
+++ b/src/server/logMatcher.ts
@@ -1053,7 +1053,7 @@ function extractUserFromPrompt(line: string): string {
 function isCurrentInputField(rawLines: string[], promptIdx: number): boolean {
   for (let i = promptIdx + 1; i < Math.min(promptIdx + 4, rawLines.length); i++) {
     const line = rawLines[i]?.trim() ?? ''
-    if (/\d+%\s*context\s*left/i.test(line)) return true
+    if (/\d+%\s*(?:context\s*)?left/i.test(line)) return true
     if (/\[\d+%\]/.test(line)) return true
     if (/\?\s*for\s*shortcuts/i.test(line)) return true
   }


### PR DESCRIPTION
## Summary
- `isCurrentInputField` regex required `N% context left` to detect the current input field, but Codex's status line shows `N% left` (no "context" word)
- This caused Codex's suggested next-message text (e.g. "Explain this codebase") to be captured as the last real user message
- Made "context" optional in the regex so both Claude and Codex status lines are correctly detected

## Test plan
- [x] Added regression test with real Codex terminal output
- [x] Verified regex matches both `68% left` (Codex) and `100% context left` (Claude)
- [x] All 629 unit tests pass
- [x] Lint and typecheck clean