### PR TITLE
perf: v0.2.40 — cache terminal snapshots for instant session switching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -15,6 +15,7 @@ import {
 } from './stores/settingsStore'
 import { useThemeStore } from './stores/themeStore'
 import { useWebSocket } from './hooks/useWebSocket'
+import { invalidateSnapshotCache } from './hooks/useTerminal'
 import { useVisualViewport } from './hooks/useVisualViewport'
 import { sortSessions } from './utils/sessions'
 import { flushSync } from 'react-dom'
@@ -258,6 +259,7 @@ export default function App() {
         // Keeping the entry in pendingKills filters
         // those stale broadcasts.  Cleanup happens on reconnect (epoch mismatch)
         // or kill-failed (rollback).
+        invalidateSnapshotCache(message.sessionId)
         const currentSessions = useSessionStore.getState().sessions
         const nextSessions = currentSessions.filter(
           (session) => session.id !== message.sessionId
@@ -452,6 +454,7 @@ export default function App() {
   const pendingKills = useRef<Map<string, { session: Session; wasSelected: boolean; epoch: number }>>(new Map())
 
   const handleKillSession = useCallback((sessionId: string) => {
+    invalidateSnapshotCache(sessionId)
     // Snapshot session and selection state before removal for kill-failed rollback
     const { sessions: currentSessions, selectedSessionId: currentSelected } = useSessionStore.getState()
     const session = currentSessions.find(s => s.id === sessionId)

--- a/src/client/__tests__/useTerminal.test.tsx
+++ b/src/client/__tests__/useTerminal.test.tsx
@@ -146,7 +146,9 @@ class WebglAddonMock {
 class ClipboardAddonMock {}
 
 class SearchAddonMock {}
-class SerializeAddonMock {}
+class SerializeAddonMock {
+  serialize() { return '\x1b[mtest-snapshot-data' }
+}
 class ProgressAddonMock {}
 
 mock.module('@xterm/xterm', () => ({ Terminal: TerminalMock }))
@@ -158,7 +160,7 @@ mock.module('@xterm/addon-serialize', () => ({ SerializeAddon: SerializeAddonMoc
 mock.module('@xterm/addon-progress', () => ({ ProgressAddon: ProgressAddonMock }))
 mock.module('@xterm/addon-web-links', () => ({ WebLinksAddon: class {} }))
 
-const { forceTextPresentation, sanitizeLink, useTerminal } = await import('../hooks/useTerminal')
+const { forceTextPresentation, sanitizeLink, useTerminal, invalidateSnapshotCache, clearSnapshotCache } = await import('../hooks/useTerminal')
 
 // Tracks a registered event listener with its capture flag
 interface ListenerEntry {
@@ -2380,5 +2382,161 @@ describe('useTerminal', () => {
     const pasteEntriesAfter = listenerEntries.get('paste')
     const hasCaptureListenerAfter = pasteEntriesAfter?.some((e) => e.capture) ?? false
     expect(hasCaptureListenerAfter).toBe(false)
+  })
+
+  test('captures terminal snapshot on session switch and restores on switch-back', async () => {
+    globalAny.navigator = {
+      userAgent: 'Chrome',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      clipboard: { writeText: () => Promise.resolve() },
+    } as unknown as Navigator
+
+    // Start fresh
+    clearSnapshotCache()
+
+    const sendCalls: Array<Record<string, unknown>> = []
+    const { container } = createContainerMock()
+
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          sendMessage={(message) => sendCalls.push(message)}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+        { createNodeMock: () => container },
+      )
+      await Promise.resolve()
+    })
+
+    const terminal = TerminalMock.instances[0]
+    if (!terminal) throw new Error('Expected terminal instance')
+
+    // Switch to session-2 — should capture snapshot of session-1
+    await act(async () => {
+      renderer.update(
+        <TerminalHarness
+          sessionId="session-2"
+          tmuxTarget="agentboard:@2"
+          sendMessage={(message) => sendCalls.push(message)}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+      )
+      await Promise.resolve()
+    })
+
+    // Verify detach was sent (snapshot captured before detach)
+    expect(sendCalls).toContainEqual({
+      type: 'terminal-detach',
+      sessionId: 'session-1',
+    })
+
+    // Switch back to session-1 — should write cached snapshot
+    await act(async () => {
+      renderer.update(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          sendMessage={(message) => sendCalls.push(message)}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+      )
+      await Promise.resolve()
+    })
+
+    // Terminal should have had reset() + write(cached) called for the snapshot restore
+    expect(terminal.resetCalls).toBeGreaterThan(0)
+    // The cached snapshot content should have been written
+    expect(terminal.writes).toContainEqual('\x1b[mtest-snapshot-data')
+
+    act(() => {
+      renderer.unmount()
+    })
+  })
+
+  test('invalidateSnapshotCache removes entry and clearSnapshotCache removes all', async () => {
+    clearSnapshotCache()
+
+    globalAny.navigator = {
+      userAgent: 'Chrome',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      clipboard: { writeText: () => Promise.resolve() },
+    } as unknown as Navigator
+
+    const { container } = createContainerMock()
+
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    // Attach to session-1
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          sendMessage={() => {}}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+        { createNodeMock: () => container },
+      )
+      await Promise.resolve()
+    })
+
+    // Switch to session-2 (caches session-1)
+    await act(async () => {
+      renderer.update(
+        <TerminalHarness
+          sessionId="session-2"
+          tmuxTarget="agentboard:@2"
+          sendMessage={() => {}}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+      )
+      await Promise.resolve()
+    })
+
+    const terminal = TerminalMock.instances[0]
+    if (!terminal) throw new Error('Expected terminal instance')
+
+    // Invalidate session-1's cache
+    invalidateSnapshotCache('session-1')
+
+    // Switch back to session-1 — should NOT write cached snapshot (it was invalidated)
+    terminal.writes.length = 0
+    terminal.resetCalls = 0
+    await act(async () => {
+      renderer.update(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          sendMessage={() => {}}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+      )
+      await Promise.resolve()
+    })
+
+    // No snapshot data should have been written (cache was invalidated)
+    expect(terminal.writes).not.toContainEqual('\x1b[mtest-snapshot-data')
+
+    act(() => {
+      renderer.unmount()
+    })
   })
 })

--- a/src/client/hooks/useTerminal.ts
+++ b/src/client/hooks/useTerminal.ts
@@ -11,6 +11,21 @@ import type { SendClientMessage, ServerMessageWithDiagnostics, SubscribeServerMe
 import { clientLog } from '../utils/clientLog'
 import type { ConnectionStatus } from '../stores/sessionStore'
 
+// Module-level snapshot cache: sessionId → serialized terminal content.
+// Survives component remounts and avoids stale-closure issues in effects.
+const snapshotCache = new Map<string, string>()
+const MAX_SNAPSHOT_ENTRIES = 20
+
+/** Remove a single session's cached terminal snapshot. */
+export function invalidateSnapshotCache(sessionId: string): void {
+  snapshotCache.delete(sessionId)
+}
+
+/** Clear all cached terminal snapshots (e.g. on reconnect). */
+export function clearSnapshotCache(): void {
+  snapshotCache.clear()
+}
+
 // URL regex that matches standard URLs and IP:port patterns
 const URL_REGEX = /https?:\/\/[^\s"'<>]+|\b(?:localhost|\d{1,3}(?:\.\d{1,3}){3}):\d{1,5}(?:\/[^\s"'<>]*)?\b/
 const TRAILING_PUNCTUATION_REGEX = /[.,;:!?]+$/
@@ -928,6 +943,8 @@ export function useTerminal({
         focusAfterAttachSessionRef.current = null
         inTmuxCopyModeRef.current = false
       }
+      // Server state may have changed — all snapshots are potentially stale
+      clearSnapshotCache()
       needsResetRef.current = false
       setIsSwitching(false)
       return
@@ -935,6 +952,20 @@ export function useTerminal({
 
     // Detach from previous session first
     if (prevAttached && prevAttached !== sessionId) {
+      // Capture terminal snapshot before detach for instant restore on switch-back
+      try {
+        const serialized = serializeAddonRef.current?.serialize()
+        if (serialized) {
+          snapshotCache.set(prevAttached, serialized)
+          // Evict oldest entry if over limit
+          if (snapshotCache.size > MAX_SNAPSHOT_ENTRIES) {
+            const oldest = snapshotCache.keys().next().value
+            if (oldest) snapshotCache.delete(oldest)
+          }
+        }
+      } catch {
+        // serialize() can fail on a disposed terminal — ignore
+      }
       sendMessageRef.current({ type: 'terminal-detach', sessionId: prevAttached })
       attachedSessionRef.current = null
       attachedTargetRef.current = null
@@ -974,6 +1005,14 @@ export function useTerminal({
       }
       needsResetRef.current = true
       setIsSwitching(true)
+
+      // Instantly show cached snapshot for the target session (if available)
+      const cached = snapshotCache.get(sessionId)
+      if (cached) {
+        terminal.reset()
+        terminal.write(cached)
+        // needsResetRef stays true — live history will replace the snapshot
+      }
 
       // Fit terminal first to get accurate dimensions
       const fitAddon = fitAddonRef.current


### PR DESCRIPTION
## Summary

- Serialize terminal buffer on detach via `SerializeAddon.serialize()` and cache in a module-level `Map<sessionId, string>` (max 20 entries)
- On switch-to, immediately `reset()` + `write(cached)` so the user sees the target session's last-known content instantly — no blank flash, no wrong-session content
- Live history replaces the snapshot atomically via the existing deferred-reset path (no changes to that flow)
- Invalidate cache on session kill and `session-removed`; clear all on disconnect

### Before vs After

| Scenario | Before (v0.2.39) | After (v0.2.40) |
|---|---|---|
| Switch to visited session | Old session's content + spinner | Target session's cached content + spinner |
| Switch to new session | Old session's content + spinner | Blank + spinner (no cache yet) |
| Live history arrives | Atomic swap | Atomic swap (unchanged) |

## Test plan

- [x] `bun run lint && bun run typecheck && bun run test` — all 666 tests pass
- [ ] Switch A→B→A — A's cached snapshot shown instantly on return
- [ ] Kill session → switch to it — no stale cache (invalidated)
- [ ] Reconnect after disconnect — cache cleared, fresh history loaded
- [ ] Rapid A→B→C switching — no stale data leaks