### PR TITLE
fix: detect Codex suggested messages without N% left in status line

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/server/__tests__/logMatcher.test.ts
+++ b/src/server/__tests__/logMatcher.test.ts
@@ -950,6 +950,54 @@ Enter to select · Esc to cancel`
     )
   })
 
+  test('Codex: skips suggested message in idle input field without "N% left"', () => {
+    // Codex may omit the "N% left" portion from the status line,
+    // showing only "model config · ~/path".
+    const scrollback = `› should we restart windowserver to see if that helps
+
+⏺ I would not restart WindowServer first.
+
+› Run /review on my current changes
+
+  gpt-5.4 xhigh fast · ~/Documents/GitHub`
+
+    const userMessages = extractRecentUserMessagesFromTmux(scrollback)
+    expect(userMessages).not.toContain('Run /review on my current changes')
+    expect(userMessages).toContain(
+      'should we restart windowserver to see if that helps'
+    )
+  })
+
+  test('Codex: skips suggested message with model-only status line (no path)', () => {
+    // Custom /statusline config: model + git branch, no CurrentDir
+    const scrollback = `› fix the flaky test
+
+⏺ Done — the race condition is resolved.
+
+› Refactor the auth module
+
+  gpt-5.4 xhigh fast · main`
+
+    const userMessages = extractRecentUserMessagesFromTmux(scrollback)
+    expect(userMessages).not.toContain('Refactor the auth module')
+    expect(userMessages).toContain('fix the flaky test')
+  })
+
+  test('Codex: skips suggested message with path-first status line', () => {
+    // Custom /statusline config: current-dir comes before other items
+    const scrollback = `› deploy to staging
+
+⏺ Deployed.
+
+› Check the CI pipeline
+
+  ~/projects/myapp · main`
+
+    const userMessages = extractRecentUserMessagesFromTmux(scrollback)
+    expect(userMessages).not.toContain('Check the CI pipeline')
+    expect(userMessages).toContain('deploy to staging')
+  })
+
   test('Claude: skips idle input above box-drawing separator', () => {
     // Claude Code draws ─────── as the input field border. Any prompt
     // at the bottom of the scrollback above this separator is the idle

--- a/src/server/__tests__/logMatcher.test.ts
+++ b/src/server/__tests__/logMatcher.test.ts
@@ -1027,6 +1027,32 @@ Enter to select · Esc to cancel`
     expect(userMessages).toContain('what model are you using')
   })
 
+  test('assistant output with ⏺ on same line as status-like text is not idle', () => {
+    // The ⏺ marker must take precedence over status-line heuristics
+    // even when both appear on the same scanned line.
+    const scrollback = `› show me the config
+
+⏺ gpt-5.4 xhigh fast · main`
+
+    const userMessages = extractRecentUserMessagesFromTmux(scrollback)
+    expect(userMessages).toContain('show me the config')
+  })
+
+  test('Codex: skips suggested message with unhyphenated model name (o3)', () => {
+    // Model names like "o3" have no hyphen after the prefix
+    const scrollback = `› fix the tests
+
+⏺ All tests pass now.
+
+› Add error handling for edge cases
+
+  o3 · main`
+
+    const userMessages = extractRecentUserMessagesFromTmux(scrollback)
+    expect(userMessages).not.toContain('Add error handling for edge cases')
+    expect(userMessages).toContain('fix the tests')
+  })
+
   test('Claude: skips idle input above box-drawing separator', () => {
     // Claude Code draws ─────── as the input field border. Any prompt
     // at the bottom of the scrollback above this separator is the idle

--- a/src/server/__tests__/logMatcher.test.ts
+++ b/src/server/__tests__/logMatcher.test.ts
@@ -998,6 +998,35 @@ Enter to select · Esc to cancel`
     expect(userMessages).toContain('deploy to staging')
   })
 
+  test('does not false-positive when assistant output resembles a status line', () => {
+    // If the assistant response contains text that looks like a Codex status
+    // line (e.g., "~/repo · main"), the submitted user message above must NOT
+    // be filtered out. The ⏺ marker between prompt and status-like text proves
+    // the prompt was submitted.
+    const scrollback = `› explain the status line
+
+⏺ Example:
+  ~/projects/myapp · main
+
+› another real question
+
+⏺ Sure, here's the answer.`
+
+    const userMessages = extractRecentUserMessagesFromTmux(scrollback)
+    expect(userMessages).toContain('explain the status line')
+    expect(userMessages).toContain('another real question')
+  })
+
+  test('does not false-positive when assistant mentions a model name with middle dot', () => {
+    const scrollback = `› what model are you using
+
+⏺ I'm running:
+  gpt-5.4 xhigh fast · with streaming enabled`
+
+    const userMessages = extractRecentUserMessagesFromTmux(scrollback)
+    expect(userMessages).toContain('what model are you using')
+  })
+
   test('Claude: skips idle input above box-drawing separator', () => {
     // Claude Code draws ─────── as the input field border. Any prompt
     // at the bottom of the scrollback above this separator is the idle

--- a/src/server/logMatcher.ts
+++ b/src/server/logMatcher.ts
@@ -1071,6 +1071,8 @@ function isCurrentInputField(rawLines: string[], promptIdx: number): boolean {
   const nearBottom = rawLines.length - promptIdx <= BOX_SEPARATOR_BOTTOM_MARGIN
   for (let i = promptIdx + 1; i < Math.min(promptIdx + 4, rawLines.length); i++) {
     const line = rawLines[i]?.trim() ?? ''
+    // Assistant output (⏺) below the prompt means it was submitted, not idle
+    if (/⏺/.test(line)) break
     if (/\d+%\s*(?:context\s*)?left/i.test(line)) return true
     if (/\[\d+%\]/.test(line)) return true
     if (/\?\s*for\s*shortcuts/i.test(line)) return true
@@ -1083,18 +1085,7 @@ function isCurrentInputField(rawLines: string[], promptIdx: number): boolean {
     // 2. Line starting with a known model prefix + · (ModelName + anything)
     if (/^(?:gpt|o[1-4]|codex|claude)-\S+.*·/.test(line)) return true
     // Claude Code input box border — only trust near the bottom of scrollback
-    // and only if no assistant output (⏺) appears between the prompt and the
-    // separator, which would mean the prompt was already submitted.
-    if (nearBottom && BOX_SEPARATOR_PATTERN.test(line)) {
-      let hasAssistantOutput = false
-      for (let j = promptIdx + 1; j < i; j++) {
-        if (/⏺/.test(rawLines[j] ?? '')) {
-          hasAssistantOutput = true
-          break
-        }
-      }
-      if (!hasAssistantOutput) return true
-    }
+    if (nearBottom && BOX_SEPARATOR_PATTERN.test(line)) return true
   }
   return false
 }

--- a/src/server/logMatcher.ts
+++ b/src/server/logMatcher.ts
@@ -1083,7 +1083,7 @@ function isCurrentInputField(rawLines: string[], promptIdx: number): boolean {
     // 1. Any line with both ~/path and · (CurrentDir/ProjectRoot + anything)
     if (/~\//.test(line) && /·/.test(line)) return true
     // 2. Line starting with a known model prefix + · (ModelName + anything)
-    if (/^(?:gpt|o[1-4]|codex|claude)-\S+.*·/.test(line)) return true
+    if (/^(?:gpt|o[1-4]|codex|claude)\S*\s.*·/.test(line)) return true
     // Claude Code input box border — only trust near the bottom of scrollback
     if (nearBottom && BOX_SEPARATOR_PATTERN.test(line)) return true
   }

--- a/src/server/logMatcher.ts
+++ b/src/server/logMatcher.ts
@@ -1074,6 +1074,14 @@ function isCurrentInputField(rawLines: string[], promptIdx: number): boolean {
     if (/\d+%\s*(?:context\s*)?left/i.test(line)) return true
     if (/\[\d+%\]/.test(line)) return true
     if (/\?\s*for\s*shortcuts/i.test(line)) return true
+    // Codex configurable status line: items joined by " · " (middle dot).
+    // Default items: model-with-reasoning, context-remaining, current-dir.
+    // context-remaining is caught by the "N% left" check above, but any
+    // other combination may omit it. Two patterns cover the remaining cases:
+    // 1. Any line with both ~/path and · (CurrentDir/ProjectRoot + anything)
+    if (/~\//.test(line) && /·/.test(line)) return true
+    // 2. Line starting with a known model prefix + · (ModelName + anything)
+    if (/^(?:gpt|o[1-4]|codex|claude)-\S+.*·/.test(line)) return true
     // Claude Code input box border — only trust near the bottom of scrollback
     // and only if no assistant output (⏺) appears between the prompt and the
     // separator, which would mean the prompt was already submitted.


### PR DESCRIPTION
## Summary
- Codex shows a "suggested next message" in its idle input field (e.g., `› Run /review on my current changes`). `isCurrentInputField` only recognized the status line below when it contained `N% left`, but Codex's configurable `/statusline` can omit `context-remaining`, producing lines like `gpt-5.4 xhigh fast · ~/Documents/GitHub`.
- Adds two new patterns to `isCurrentInputField` to cover remaining Codex status line variants:
  - `~/path` + `·` on same line (any config with `CurrentDir` or `ProjectRoot`)
  - Known model prefix (`gpt-*`, `o[1-4]-*`, `codex-*`, `claude-*`) + `·` (model name + any other item)
- Adds 3 test cases: status line without percentage, model-only status line (no path), and path-first status line

## Test plan
- [x] New test: `Codex: skips suggested message in idle input field without "N% left"`
- [x] New test: `Codex: skips suggested message with model-only status line (no path)`
- [x] New test: `Codex: skips suggested message with path-first status line`
- [x] Existing test: `Codex: skips suggested message in idle input field with "N% left" status` still passes
- [x] All 669 tests pass, lint and typecheck clean