### PR TITLE
feat: add launchd setup for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npx @gbasin/agentboard
 
 Then open `http://localhost:4040` (or `http://<your-machine>:4040` from another device).
 
-For persistent deployment on Linux, see [systemd/README.md](systemd/README.md).
+For persistent deployment, see [systemd/README.md](systemd/README.md) (Linux) or [launchd/README.md](launchd/README.md) (macOS).
 
 ### From source
 
@@ -100,7 +100,7 @@ bun run build
 bun run start
 ```
 
-For persistent deployment on Linux, see [systemd/README.md](systemd/README.md).
+For persistent deployment, see [systemd/README.md](systemd/README.md) (Linux) or [launchd/README.md](launchd/README.md) (macOS).
 
 ## Dependency Risk Scanner
 

--- a/launchd/README.md
+++ b/launchd/README.md
@@ -100,6 +100,7 @@ cat > ~/Library/LaunchAgents/com.agentboard.tmux-watchdog.plist << EOF
   <key>StandardErrorPath</key><string>/tmp/agentboard-tmux-watchdog.log</string>
 </dict>
 </plist>
+EOF
 launchctl load -w ~/Library/LaunchAgents/com.agentboard.tmux-watchdog.plist
 ```
 

--- a/launchd/README.md
+++ b/launchd/README.md
@@ -104,7 +104,7 @@ EOF
 launchctl load -w ~/Library/LaunchAgents/com.agentboard.tmux-watchdog.plist
 ```
 
-The watchdog checks `tmux has-session -t agentboard` every 30s. If the session is gone (server crashed, or session killed), it runs `launchctl kickstart -k com.agentboard` which triggers agentboard's startup path — `ensureSession()` recreates the base session and `resurrectPinnedSessions()` rebuilds pinned windows from SQLite.
+The watchdog checks `tmux has-session -t agentboard` every 30s. If the session is gone (server crashed, or session killed), it runs `launchctl kickstart -k gui/$(id -u)/com.agentboard` which triggers agentboard's startup path — `ensureSession()` recreates the base session and `resurrectPinnedSessions()` rebuilds pinned windows from SQLite.
 
 Note: if you `tmux kill-session -t agentboard` while agentboard is loaded, the watchdog will restore it within 30s. To stop cleanly, `launchctl unload ~/Library/LaunchAgents/com.agentboard.plist` first.
 

--- a/launchd/README.md
+++ b/launchd/README.md
@@ -1,0 +1,115 @@
+# launchd User Agents (macOS)
+
+Run agentboard as a persistent launchd user agent that starts at login and restarts on crash. Parallel to [`systemd/`](../systemd/) for Linux.
+
+## Prerequisites
+
+- macOS
+- `bun` in PATH (`brew install oven-sh/bun/bun`)
+- `tmux` in PATH (`brew install tmux`)
+- Repository cloned locally (service runs `bun run start` from the repo directory)
+
+## Installation
+
+```bash
+./launchd/install.sh
+```
+
+The install script will:
+1. Detect `bun` and `tmux` paths
+2. Generate a wrapper script and a log-rotate script in `~/.agentboard/bin/`
+3. Generate two plists in `~/Library/LaunchAgents/`
+4. Load them via `launchctl`
+
+Installs two agents:
+
+- **`com.agentboard`** — supervises agentboard. `KeepAlive` respawns on crash or non-zero exit, `ThrottleInterval: 10` prevents tight restart loops.
+- **`com.agentboard.logrotate`** — hourly. Rotates `~/.agentboard/agentboard.log` at 50MB using a copytruncate pattern (preserves pino's open file descriptor), keeps 5 gzipped archives.
+
+After install, agentboard listens on `http://localhost:4040`.
+
+## Commands
+
+```bash
+# Status
+launchctl list | grep agentboard
+
+# Tail logs (structured JSON, same as in systemd setups)
+tail -f ~/.agentboard/agentboard.log
+
+# Launchd stdout/stderr (captures startup errors)
+tail ~/.agentboard/launchd.{out,err}.log
+
+# Force restart
+launchctl kickstart -k gui/$(id -u)/com.agentboard
+
+# Stop (e.g. before running `bun run dev` against port 4040)
+launchctl unload ~/Library/LaunchAgents/com.agentboard.plist
+
+# Re-enable
+launchctl load -w ~/Library/LaunchAgents/com.agentboard.plist
+
+# Manual log rotation (no-op below 50MB)
+~/.agentboard/bin/agentboard-log-rotate.sh
+```
+
+## Uninstall
+
+```bash
+for label in com.agentboard com.agentboard.logrotate; do
+  launchctl unload ~/Library/LaunchAgents/$label.plist 2>/dev/null || true
+  rm -f ~/Library/LaunchAgents/$label.plist
+done
+rm -rf ~/.agentboard/bin
+# To also remove data: rm -rf ~/.agentboard
+```
+
+## Optional: tmux-crash watchdog
+
+Agentboard resurrects pinned sessions at startup from `~/.agentboard/agentboard.db`. But when the tmux server crashes mid-flight, agentboard's process keeps running with stale handles — attached PTYs are dead and pinned windows don't come back (the backend poller deliberately won't recreate the session to avoid orphan shells). Until agentboard is restarted, the UI stays broken.
+
+A small 30-second polling agent that kickstarts agentboard whenever the base session disappears solves this. Opt-in because it's only needed if you've actually seen tmux crash on your machine.
+
+Create the script:
+
+```bash
+cat > ~/.agentboard/bin/tmux-agentboard-watchdog.sh << 'EOF'
+#!/bin/bash
+export PATH="$(dirname "$(command -v tmux)"):/usr/local/bin:/usr/bin:/bin"
+SESSION="${TMUX_SESSION:-agentboard}"
+tmux has-session -t "$SESSION" 2>/dev/null || \
+  launchctl kickstart -k "gui/$(id -u)/com.agentboard"
+EOF
+chmod +x ~/.agentboard/bin/tmux-agentboard-watchdog.sh
+```
+
+Create the plist:
+
+```bash
+cat > ~/Library/LaunchAgents/com.agentboard.tmux-watchdog.plist << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.agentboard.tmux-watchdog</string>
+  <key>ProgramArguments</key>
+  <array><string>$HOME/.agentboard/bin/tmux-agentboard-watchdog.sh</string></array>
+  <key>StartInterval</key><integer>30</integer>
+  <key>RunAtLoad</key><true/>
+  <key>StandardOutPath</key><string>/tmp/agentboard-tmux-watchdog.log</string>
+  <key>StandardErrorPath</key><string>/tmp/agentboard-tmux-watchdog.log</string>
+</dict>
+</plist>
+launchctl load -w ~/Library/LaunchAgents/com.agentboard.tmux-watchdog.plist
+```
+
+The watchdog checks `tmux has-session -t agentboard` every 30s. If the session is gone (server crashed, or session killed), it runs `launchctl kickstart -k com.agentboard` which triggers agentboard's startup path — `ensureSession()` recreates the base session and `resurrectPinnedSessions()` rebuilds pinned windows from SQLite.
+
+Note: if you `tmux kill-session -t agentboard` while agentboard is loaded, the watchdog will restore it within 30s. To stop cleanly, `launchctl unload ~/Library/LaunchAgents/com.agentboard.plist` first.
+
+## Notes
+
+- The plist sets `LANG=en_US.UTF-8`. LaunchAgents start with a bare environment; without this, tmux renders non-ASCII characters as `?` or stripped bytes.
+- The wrapper script `cd`s into the repo directory before `bun run start`, matching the Linux systemd setup.
+- Override the log path via the `LOG_FILE` env var (respected by agentboard and the rotate script).
+- Override the tmux session name via `TMUX_SESSION` (respected by agentboard and the watchdog).

--- a/launchd/install.sh
+++ b/launchd/install.sh
@@ -23,6 +23,18 @@ if [ -z "$TMUX_PATH" ]; then
 fi
 TMUX_DIR="$(dirname "$TMUX_PATH")"
 
+# Guard against paths containing characters that would corrupt plist XML or
+# break shell quoting in the generated scripts. The LaunchAgent plist is XML,
+# so angle brackets, ampersands, and quotes in any substituted path would
+# produce invalid plists that fail `plutil -lint`.
+for var in HOME REPO_DIR BUN_PATH TMUX_PATH; do
+    case "${!var}" in
+        *[\<\>\&\"\']*)
+            echo "Error: \$$var contains characters unsafe for plist XML: ${!var}"
+            exit 1 ;;
+    esac
+done
+
 mkdir -p "$LAUNCH_AGENTS" "$BIN_DIR"
 
 echo "Installing agentboard LaunchAgents with:"
@@ -106,7 +118,10 @@ cat > "$LAUNCH_AGENTS/com.agentboard.logrotate.plist" << EOF
   <key>ProgramArguments</key>
   <array><string>$BIN_DIR/agentboard-log-rotate.sh</string></array>
   <key>StartInterval</key><integer>3600</integer>
-  <key>RunAtLoad</key><true/>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key><string>$HOME</string>
+  </dict>
   <key>StandardOutPath</key><string>/tmp/agentboard-logrotate.log</string>
   <key>StandardErrorPath</key><string>/tmp/agentboard-logrotate.log</string>
 </dict>

--- a/launchd/install.sh
+++ b/launchd/install.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Install agentboard as a persistent launchd user agent on macOS.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
+AGENTBOARD_DIR="$HOME/.agentboard"
+BIN_DIR="$AGENTBOARD_DIR/bin"
+
+BUN_PATH="$(which bun)"
+if [ -z "$BUN_PATH" ]; then
+    echo "Error: bun not found in PATH (brew install oven-sh/bun/bun)"
+    exit 1
+fi
+BUN_DIR="$(dirname "$BUN_PATH")"
+
+TMUX_PATH="$(which tmux)"
+if [ -z "$TMUX_PATH" ]; then
+    echo "Error: tmux not found in PATH (brew install tmux)"
+    exit 1
+fi
+TMUX_DIR="$(dirname "$TMUX_PATH")"
+
+mkdir -p "$LAUNCH_AGENTS" "$BIN_DIR"
+
+echo "Installing agentboard LaunchAgents with:"
+echo "  Repo:  $REPO_DIR"
+echo "  Bun:   $BUN_PATH"
+echo "  Tmux:  $TMUX_PATH"
+echo ""
+
+# --- Wrapper script: sets PATH + UTF-8 locale, then execs bun run start.
+# LaunchAgents start with a bare env; without LANG set, tmux mangles unicode.
+cat > "$BIN_DIR/agentboard-run.sh" << EOF
+#!/bin/bash
+export PATH="$BUN_DIR:$TMUX_DIR:/usr/local/bin:/usr/bin:/bin"
+export HOME="$HOME"
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+export LC_CTYPE=en_US.UTF-8
+cd "$REPO_DIR"
+exec "$BUN_PATH" run start
+EOF
+chmod +x "$BIN_DIR/agentboard-run.sh"
+
+# --- Logrotate script: copytruncate pattern so pino's open fd stays valid.
+cat > "$BIN_DIR/agentboard-log-rotate.sh" << 'EOF'
+#!/bin/bash
+set -u
+LOG="${LOG_FILE:-$HOME/.agentboard/agentboard.log}"
+MAX_BYTES=$((50 * 1024 * 1024))
+KEEP=5
+
+[ -f "$LOG" ] || exit 0
+SIZE=$(stat -f%z "$LOG" 2>/dev/null || echo 0)
+[ "$SIZE" -ge "$MAX_BYTES" ] || exit 0
+
+rm -f "$LOG.$KEEP.gz"
+for i in $(seq $((KEEP - 1)) -1 1); do
+    [ -f "$LOG.$i.gz" ] && mv "$LOG.$i.gz" "$LOG.$((i+1)).gz"
+done
+
+cp "$LOG" "$LOG.1"
+: > "$LOG"
+gzip -f "$LOG.1"
+EOF
+chmod +x "$BIN_DIR/agentboard-log-rotate.sh"
+
+# --- Main service plist.
+cat > "$LAUNCH_AGENTS/com.agentboard.plist" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.agentboard</string>
+  <key>ProgramArguments</key>
+  <array><string>$BIN_DIR/agentboard-run.sh</string></array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>Crashed</key><true/>
+    <key>SuccessfulExit</key><false/>
+  </dict>
+  <key>ThrottleInterval</key><integer>10</integer>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>LANG</key><string>en_US.UTF-8</string>
+    <key>LC_ALL</key><string>en_US.UTF-8</string>
+    <key>LC_CTYPE</key><string>en_US.UTF-8</string>
+  </dict>
+  <key>StandardOutPath</key><string>$AGENTBOARD_DIR/launchd.out.log</string>
+  <key>StandardErrorPath</key><string>$AGENTBOARD_DIR/launchd.err.log</string>
+</dict>
+</plist>
+EOF
+
+# --- Logrotate plist.
+cat > "$LAUNCH_AGENTS/com.agentboard.logrotate.plist" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.agentboard.logrotate</string>
+  <key>ProgramArguments</key>
+  <array><string>$BIN_DIR/agentboard-log-rotate.sh</string></array>
+  <key>StartInterval</key><integer>3600</integer>
+  <key>RunAtLoad</key><true/>
+  <key>StandardOutPath</key><string>/tmp/agentboard-logrotate.log</string>
+  <key>StandardErrorPath</key><string>/tmp/agentboard-logrotate.log</string>
+</dict>
+</plist>
+EOF
+
+# --- Load (idempotent: unload first if already loaded).
+for label in com.agentboard com.agentboard.logrotate; do
+    launchctl unload "$LAUNCH_AGENTS/$label.plist" 2>/dev/null || true
+    launchctl load -w "$LAUNCH_AGENTS/$label.plist"
+done
+
+echo "Agentboard LaunchAgents installed and loaded."
+echo ""
+echo "Useful commands:"
+echo "  launchctl list | grep agentboard                              # Status"
+echo "  tail -f ~/.agentboard/agentboard.log                          # Logs"
+echo "  launchctl kickstart -k gui/\$(id -u)/com.agentboard            # Restart"
+echo "  launchctl unload ~/Library/LaunchAgents/com.agentboard.plist  # Stop"
+echo ""
+echo "See launchd/README.md for optional tmux-crash watchdog."

--- a/launchd/install.sh
+++ b/launchd/install.sh
@@ -24,13 +24,15 @@ fi
 TMUX_DIR="$(dirname "$TMUX_PATH")"
 
 # Guard against paths containing characters that would corrupt plist XML or
-# break shell quoting in the generated scripts. The LaunchAgent plist is XML,
-# so angle brackets, ampersands, and quotes in any substituted path would
-# produce invalid plists that fail `plutil -lint`.
+# allow shell re-evaluation inside the generated wrapper. The generated scripts
+# embed these paths inside double-quoted shell strings, so shell metachars
+# (especially $, `, \) could trigger command substitution at service launch
+# even if the user's path only looked unusual (e.g. a repo cloned under
+# /tmp/foo$(bar)). Reject up front instead of trying to escape correctly.
 for var in HOME REPO_DIR BUN_PATH TMUX_PATH; do
     case "${!var}" in
-        *[\<\>\&\"\']*)
-            echo "Error: \$$var contains characters unsafe for plist XML: ${!var}"
+        *[\<\>\&\"\'\$\`\\\;\|\(\)]*)
+            echo "Error: \$$var contains characters unsafe for plist XML or shell: ${!var}"
             exit 1 ;;
     esac
 done
@@ -52,6 +54,7 @@ cat > "$BIN_DIR/agentboard-run.sh" << EOF
 #!/bin/bash
 export PATH="$BUN_DIR:$TMUX_DIR:$HOME/.local/bin:$HOME/bin:$HOME/.cargo/bin:$HOME/go/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
 export HOME="$HOME"
+export NODE_ENV=production
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 export LC_CTYPE=en_US.UTF-8
@@ -64,6 +67,7 @@ chmod +x "$BIN_DIR/agentboard-run.sh"
 cat > "$BIN_DIR/agentboard-log-rotate.sh" << 'EOF'
 #!/bin/bash
 set -u
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 LOG="${LOG_FILE:-$HOME/.agentboard/agentboard.log}"
 MAX_BYTES=$((50 * 1024 * 1024))
 KEEP=5

--- a/launchd/install.sh
+++ b/launchd/install.sh
@@ -45,9 +45,12 @@ echo ""
 
 # --- Wrapper script: sets PATH + UTF-8 locale, then execs bun run start.
 # LaunchAgents start with a bare env; without LANG set, tmux mangles unicode.
+# PATH covers common agent install locations (~/.local/bin for tools like
+# claude and cursor-agent, Homebrew, ~/.cargo/bin, ~/go/bin) so that tmux
+# windows spawned by agentboard can find whichever CLI the user launches.
 cat > "$BIN_DIR/agentboard-run.sh" << EOF
 #!/bin/bash
-export PATH="$BUN_DIR:$TMUX_DIR:/usr/local/bin:/usr/bin:/bin"
+export PATH="$BUN_DIR:$TMUX_DIR:$HOME/.local/bin:$HOME/bin:$HOME/.cargo/bin:$HOME/go/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
 export HOME="$HOME"
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",


### PR DESCRIPTION
## Summary

Mirrors `systemd/` for macOS. Adds a turnkey install for running agentboard as persistent user LaunchAgents.

- `launchd/install.sh` — detects `bun`/`tmux`, generates wrapper + logrotate scripts in `~/.agentboard/bin/`, writes two plists to `~/Library/LaunchAgents/`, loads them
- `launchd/README.md` — docs + opt-in tmux-crash watchdog recipe
- Parallel macOS callout in root README
- Patch version bump to 0.2.43

What the agents do:
- **`com.agentboard`** — supervises `bun run start` with `KeepAlive` on crash and non-zero exit, `ThrottleInterval: 10` to prevent tight restart loops, `EnvironmentVariables` for `LANG=en_US.UTF-8` so tmux renders non-ASCII correctly (LaunchAgents get a bare env by default)
- **`com.agentboard.logrotate`** — hourly copytruncate of `~/.agentboard/agentboard.log` at 50MB, keeps 5 gzipped archives. Uses `cp + truncate` rather than `mv` because pino holds the file fd open — a rename would leave it writing to the renamed inode

Wrapper `PATH` covers common agent install locations (`~/.local/bin`, `~/bin`, `~/.cargo/bin`, `~/go/bin`, Homebrew, `/usr/local/*`, system) so tmux windows spawning `claude`, `codex`, `cursor-agent`, etc. all work. Slightly wider than systemd's default for better macOS-specific coverage.

Install.sh has an upfront guard that rejects paths containing characters that would either corrupt plist XML or allow shell command substitution inside the generated wrapper.

## Context

Two rounds of review applied; all blockers addressed.

Deferred as follow-ups (reviewer agreed):
- `optionalDependencies` version skew — `scripts/update-optional-deps.js` reconciles at publish time via `release.yml`
- `~/.agentboard/launchd.{out,err}.log` unbounded (small volume, separate from pino logs)
- Install overwrites customized plists silently (rare, adds UX complexity)

## Test plan

Done:
- [x] `bash -n` on `install.sh` and both generated scripts
- [x] Sandboxed install in tmpdir with stubbed `launchctl`
- [x] `plutil -lint` on both generated plists
- [x] Path-safety guard correctly rejects `<>&"'$\`\;|()` in `$HOME`/`$REPO_DIR`/`$BUN_PATH`/`$TMUX_PATH`
- [x] Lint, typecheck, full test suite pass (pre-commit hooks, every commit)
- [x] End-to-end on author's Mac: agentboard under launchd survives `kill`, browser reconnects; `claude --dangerously-skip-permissions` spawns cleanly in new tmux windows; 155MB live log rotated to 7.9MB gzip archive

For a reviewer:
- [ ] Clone fresh, run `./launchd/install.sh`, confirm `launchctl list | grep agentboard` shows both agents with status 0 and agentboard is reachable at `http://localhost:4040`
- [ ] Create a new tmux window via the UI with each of your installed CLI agents; verify they exec successfully (no "Failed to create tmux window")
- [ ] Optionally install the tmux-crash watchdog per README; verify it restarts agentboard after `tmux kill-server`

## Commit history

5 commits on the branch: initial feature + chore version bump + three rounds of review fixes. Happy to squash into a single `feat:` commit on merge — let me know your preference.