### PR TITLE
feat: optional window-name labels (gated, supersedes #131)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ TMUX_SESSION=agentboard
 REFRESH_INTERVAL_MS=5000
 DISCOVER_PREFIXES=work,external
 PRUNE_WS_SESSIONS=true
+AGENTBOARD_PREFER_WINDOW_NAME=false
 TERMINAL_MODE=pty
 TERMINAL_MONITOR_TARGETS=true
 VITE_ALLOWED_HOSTS=nuc,myserver
@@ -172,6 +173,8 @@ AGENTBOARD_LOG_WATCH_MODE=watch
 `DISCOVER_PREFIXES` lets you discover and control windows from other tmux sessions. If unset, all sessions except the managed one are discovered.
 
 `PRUNE_WS_SESSIONS` removes orphaned `agentboard-ws-*` tmux sessions on startup (set to `false` to disable).
+
+`AGENTBOARD_PREFER_WINDOW_NAME` (default `false`) controls how externally-discovered sessions are labeled. When `false`, the tmux session name is used (more meaningful than auto-renamed window names that follow the running process under tmux `automatic-rename on`). Set to `true` to use the tmux window name when it is non-empty and distinct from the session name — useful when you keep one shared session (e.g. `dev`) with one explicitly-named window per project (`myapp`, `infra`, ...).
 
 `TERMINAL_MODE` selects terminal I/O strategy: `pty` (default, grouped session) or `pipe-pane` (PTY-less, works in daemon/systemd/docker without `-t`).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.2.45",
+  "version": "0.2.46",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -87,6 +87,7 @@ export default function App() {
   const setRemoteAllowControl = useSessionStore((state) => state.setRemoteAllowControl)
   const setRemoteAllowAttach = useSessionStore((state) => state.setRemoteAllowAttach)
   const setHostLabel = useSessionStore((state) => state.setHostLabel)
+  const setPreferWindowName = useSessionStore((state) => state.setPreferWindowName)
   const hostStatuses = useSessionStore((state) => state.hostStatuses)
   const remoteAllowControl = useSessionStore((state) => state.remoteAllowControl)
   const hostLabel = useSessionStore((state) => state.hostLabel)
@@ -287,6 +288,7 @@ export default function App() {
         setRemoteAllowControl(message.remoteAllowControl)
         setRemoteAllowAttach(message.remoteAllowAttach)
         setHostLabel(message.hostLabel)
+        setPreferWindowName(message.preferWindowName)
         if (message.clientLogLevel) {
           setClientLogLevel(message.clientLogLevel)
         }
@@ -495,6 +497,7 @@ export default function App() {
     setRemoteAllowControl,
     setRemoteAllowAttach,
     setHostLabel,
+    setPreferWindowName,
     subscribe,
     updateSession,
   ])

--- a/src/client/__tests__/terminal.test.tsx
+++ b/src/client/__tests__/terminal.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, mock } from 'bun:test'
 import TestRenderer, { act } from 'react-test-renderer'
 import type { AgentSession, Session } from '@shared/types'
 import { useThemeStore } from '../stores/themeStore'
+import { useSessionStore } from '../stores/sessionStore'
 
 const globalAny = globalThis as typeof globalThis & {
   document?: Document
@@ -237,6 +238,7 @@ beforeEach(() => {
   }
 
   useThemeStore.setState({ theme: 'dark' })
+  useSessionStore.setState({ preferWindowName: false })
 })
 
 afterEach(() => {
@@ -696,6 +698,110 @@ describe('Terminal', () => {
     })
 
     expect(renamed).toEqual([])
+
+    act(() => {
+      renderer.unmount()
+    })
+  })
+
+  test('mobile session switcher shows numeric labels when preferWindowName is false even with distinct names', () => {
+    if (globalAny.window) {
+      globalAny.window.matchMedia = (() => ({
+        matches: true,
+        media: '',
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      })) as unknown as typeof window.matchMedia
+    }
+    useSessionStore.setState({ preferWindowName: false })
+
+    const { createNodeMock } = createContainerMock()
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    act(() => {
+      renderer = TestRenderer.create(
+        <Terminal
+          session={baseSession}
+          sessions={[baseSession, secondSession]}
+          connectionStatus="connected"
+          sendMessage={() => {}}
+          subscribe={() => () => {}}
+          onClose={() => {}}
+          onSelectSession={() => {}}
+          onNewSession={() => {}}
+          onKillSession={() => {}}
+          onRenameSession={() => {}}
+          onResumeSession={() => {}}
+          onOpenSettings={() => {}}
+        />,
+        { createNodeMock }
+      )
+    })
+
+    const labels = renderer.root
+      .findAllByType('button')
+      .map((button) => button.props.children)
+      .filter((child) => child === 1 || child === 2 || child === 'alpha' || child === 'beta')
+
+    expect(labels).toContain(1)
+    expect(labels).toContain(2)
+    expect(labels).not.toContain('alpha')
+    expect(labels).not.toContain('beta')
+
+    act(() => {
+      renderer.unmount()
+    })
+  })
+
+  test('mobile session switcher shows name labels when preferWindowName is true and names are distinct', () => {
+    if (globalAny.window) {
+      globalAny.window.matchMedia = (() => ({
+        matches: true,
+        media: '',
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      })) as unknown as typeof window.matchMedia
+    }
+    useSessionStore.setState({ preferWindowName: true })
+
+    const { createNodeMock } = createContainerMock()
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    act(() => {
+      renderer = TestRenderer.create(
+        <Terminal
+          session={baseSession}
+          sessions={[baseSession, secondSession]}
+          connectionStatus="connected"
+          sendMessage={() => {}}
+          subscribe={() => () => {}}
+          onClose={() => {}}
+          onSelectSession={() => {}}
+          onNewSession={() => {}}
+          onKillSession={() => {}}
+          onRenameSession={() => {}}
+          onResumeSession={() => {}}
+          onOpenSettings={() => {}}
+        />,
+        { createNodeMock }
+      )
+    })
+
+    const labels = renderer.root
+      .findAllByType('button')
+      .map((button) => button.props.children)
+      .filter((child) => child === 1 || child === 2 || child === 'alpha' || child === 'beta')
+
+    expect(labels).toContain('alpha')
+    expect(labels).toContain('beta')
 
     act(() => {
       renderer.unmount()

--- a/src/client/components/Terminal.tsx
+++ b/src/client/components/Terminal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { clientLog } from '../utils/clientLog'
 import type {
   AgentSession,
@@ -925,6 +925,15 @@ export default function Terminal({
     }
   }, [containerRef, isiOS, isSelectingText])
 
+  // Use session names as mobile tab labels only when every session has a
+  // distinct, non-empty name. Otherwise tabs would repeat the same label and
+  // numeric indices remain the better signal.
+  const mobileTabsUseNames = useMemo(() => {
+    if (sessions.length === 0) return false
+    const names = sessions.map((s) => s.name?.trim()).filter(Boolean) as string[]
+    return names.length === sessions.length && new Set(names).size === sessions.length
+  }, [sessions])
+
   return (
     <section
       className={`flex flex-1 flex-col bg-base terminal-mobile-overlay md:relative md:inset-auto ${isiOS ? 'ios-native-term-selection' : ''}`}
@@ -1106,13 +1115,19 @@ export default function Terminal({
           >
             {sessions.map((s, index) => {
               const isActive = s.id === session.id
+              // Use session name as the label when all sessions have a distinct,
+              // non-empty name (e.g. with AGENTBOARD_PREFER_WINDOW_NAME=true and
+              // user-named windows). Otherwise fall back to numeric index — names
+              // would just repeat (e.g. all `dev`) and add no signal.
+              const label = mobileTabsUseNames ? s.name : String(index + 1)
               return (
                 <button
                   key={s.id}
                   type="button"
                   className={`
                     flex items-center justify-center shrink-0 snap-start
-                    h-8 w-8 text-sm font-extrabold rounded-lg
+                    h-8 ${mobileTabsUseNames ? 'min-w-[2rem] px-2.5 max-w-[8rem] truncate' : 'w-8'}
+                    text-sm font-extrabold rounded-lg
                     active:scale-95 transition-all duration-75
                     select-none touch-manipulation
                     ${isActive ? statusButtonActive[s.status] : statusButtonBase[s.status]}
@@ -1121,8 +1136,9 @@ export default function Terminal({
                     triggerHaptic()
                     onSelectSession(s.id)
                   }}
+                  title={mobileTabsUseNames ? s.name : undefined}
                 >
-                  {index + 1}
+                  {label}
                 </button>
               )
             })}

--- a/src/client/components/Terminal.tsx
+++ b/src/client/components/Terminal.tsx
@@ -137,6 +137,7 @@ export default function Terminal({
   const isRemoteSession = session?.remote === true
   const remoteAllowControl = useSessionStore((s) => s.remoteAllowControl)
   const remoteAllowAttach = useSessionStore((s) => s.remoteAllowAttach)
+  const preferWindowName = useSessionStore((s) => s.preferWindowName)
   const isReadOnly = isRemoteSession && !remoteAllowAttach
   const canControl = !isRemoteSession || (remoteAllowControl && session?.source === 'managed')
   const hibernatingDisplayName = hibernatingSession
@@ -925,14 +926,15 @@ export default function Terminal({
     }
   }, [containerRef, isiOS, isSelectingText])
 
-  // Use session names as mobile tab labels only when every session has a
-  // distinct, non-empty name. Otherwise tabs would repeat the same label and
-  // numeric indices remain the better signal.
+  // Use session names as mobile tab labels only when AGENTBOARD_PREFER_WINDOW_NAME is
+  // enabled AND every session has a distinct, non-empty name. Otherwise tabs would
+  // repeat the same label and numeric indices remain the better signal.
   const mobileTabsUseNames = useMemo(() => {
+    if (!preferWindowName) return false
     if (sessions.length === 0) return false
-    const names = sessions.map((s) => s.name?.trim()).filter(Boolean) as string[]
+    const names = sessions.map((s) => s.name.trim()).filter(Boolean)
     return names.length === sessions.length && new Set(names).size === sessions.length
-  }, [sessions])
+  }, [preferWindowName, sessions])
 
   return (
     <section
@@ -1119,7 +1121,7 @@ export default function Terminal({
               // non-empty name (e.g. with AGENTBOARD_PREFER_WINDOW_NAME=true and
               // user-named windows). Otherwise fall back to numeric index — names
               // would just repeat (e.g. all `dev`) and add no signal.
-              const label = mobileTabsUseNames ? s.name : String(index + 1)
+              const label = mobileTabsUseNames ? s.name.trim() : index + 1
               return (
                 <button
                   key={s.id}

--- a/src/client/stores/sessionStore.ts
+++ b/src/client/stores/sessionStore.ts
@@ -82,6 +82,8 @@ interface SessionState {
   setRemoteAllowAttach: (value: boolean) => void
   hostLabel: string | null
   setHostLabel: (value: string | null) => void
+  preferWindowName: boolean
+  setPreferWindowName: (value: boolean) => void
   // Mark a session as exiting (preserves data for exit animation)
   markSessionExiting: (sessionId: string) => void
   // Clear a session from exiting state (after animation completes)
@@ -113,6 +115,7 @@ export const useSessionStore = create<SessionState>()(
       remoteAllowControl: false,
       remoteAllowAttach: false,
       hostLabel: null,
+      preferWindowName: false,
       setSessions: (sessions) => {
         const state = get()
         const selected = state.selectedSessionId
@@ -224,6 +227,7 @@ export const useSessionStore = create<SessionState>()(
       setRemoteAllowControl: (value) => set({ remoteAllowControl: value }),
       setRemoteAllowAttach: (value) => set({ remoteAllowAttach: value }),
       setHostLabel: (value) => set({ hostLabel: value }),
+      setPreferWindowName: (value) => set({ preferWindowName: value }),
       markSessionExiting: (sessionId) => {
         const session = get().sessions.find((s) => s.id === sessionId)
         if (session) {

--- a/src/server/SessionManager.ts
+++ b/src/server/SessionManager.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import { inferAgentType, normalizePaneStartCommand } from './agentDetection'
 import { config } from './config'
+import { resolveExternalDisplayName } from './displayName'
 import { normalizeProjectPath } from './logDiscovery'
 import { generateSessionName } from './nameGenerator'
 import { logger } from './logger'
@@ -571,8 +572,11 @@ export class SessionManager {
           this.capturePaneContent,
           this.now
         )
-        // For external sessions, use session name as display name (more meaningful than window name)
-        const displayName = source === 'external' ? sessionName : window.name
+        // For external sessions, use session name as display name (more meaningful than window name).
+        // With AGENTBOARD_PREFER_WINDOW_NAME=true, use window name when distinct from session name.
+        const displayName = source === 'external'
+          ? resolveExternalDisplayName(sessionName, window.name, config.preferWindowName)
+          : window.name
         const normalizedPath = normalizeProjectPath(window.path)
         return {
           id: `${sessionName}:${window.id}`,

--- a/src/server/__tests__/displayName.test.ts
+++ b/src/server/__tests__/displayName.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveExternalDisplayName } from '../displayName'
+
+describe('resolveExternalDisplayName', () => {
+  test('returns session name when preferWindowName is false', () => {
+    expect(resolveExternalDisplayName('dev', 'myapp', false)).toBe('dev')
+  })
+
+  test('returns window name when preferWindowName is true and distinct', () => {
+    expect(resolveExternalDisplayName('dev', 'myapp', true)).toBe('myapp')
+  })
+
+  test('falls back to session name when window name equals session name', () => {
+    expect(resolveExternalDisplayName('dev', 'dev', true)).toBe('dev')
+  })
+
+  test('falls back to session name when window name is empty', () => {
+    expect(resolveExternalDisplayName('dev', '', true)).toBe('dev')
+  })
+
+  test('falls back to session name when window name is undefined', () => {
+    expect(resolveExternalDisplayName('dev', undefined, true)).toBe('dev')
+  })
+
+  test('trims whitespace and falls back when window name is whitespace-only', () => {
+    expect(resolveExternalDisplayName('dev', '   ', true)).toBe('dev')
+  })
+
+  test('trims whitespace from window name when distinct', () => {
+    expect(resolveExternalDisplayName('dev', '  myapp  ', true)).toBe('myapp')
+  })
+})

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -152,6 +152,11 @@ export const config = {
     .map((value) => value.trim())
     .filter(Boolean),
   pruneWsSessions: process.env.PRUNE_WS_SESSIONS !== 'false',
+  // Prefer tmux window names over session names when displaying externally-discovered
+  // sessions. Off by default, since window names often auto-rename to the running
+  // process under tmux `automatic-rename on`. Enable when each window has a stable,
+  // user-chosen name (e.g. one window per project in a shared session).
+  preferWindowName: process.env.AGENTBOARD_PREFER_WINDOW_NAME === 'true',
   terminalMode,
   terminalMonitorTargets: process.env.TERMINAL_MONITOR_TARGETS !== 'false',
   // Allow killing external (discovered) sessions from UI

--- a/src/server/displayName.ts
+++ b/src/server/displayName.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolve the display name for an externally-discovered tmux window.
+ *
+ * By default, agentboard uses the tmux session name for external windows,
+ * because window names often auto-rename to the running process (e.g. `node`,
+ * `zsh`) under tmux `automatic-rename on`, which is rarely meaningful.
+ *
+ * When `preferWindowName` is enabled (via `AGENTBOARD_PREFER_WINDOW_NAME=true`)
+ * and the window name is non-empty and distinct from the session name, the
+ * window name is used instead. This is useful for users who explicitly name
+ * each window after the project they are working on (so all windows in a
+ * shared `dev` session show up as `myapp`, `infra`, ... rather than `dev`).
+ */
+export function resolveExternalDisplayName(
+  sessionName: string,
+  windowName: string | undefined,
+  preferWindowName: boolean
+): string {
+  if (!preferWindowName) return sessionName
+  const trimmed = (windowName ?? '').trim()
+  if (!trimmed || trimmed === sessionName) return sessionName
+  return trimmed
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1453,6 +1453,7 @@ const websocketHandlers = {
       remoteAllowControl: config.remoteAllowControl,
       remoteAllowAttach: config.remoteAllowAttach,
       hostLabel: config.hostLabel,
+      preferWindowName: config.preferWindowName,
       clientLogLevel: logLevel,
     })
     const agentSessions = registry.getAgentSessions()

--- a/src/server/remoteSessions.ts
+++ b/src/server/remoteSessions.ts
@@ -1,5 +1,6 @@
 import { inferAgentType, normalizePaneStartCommand } from './agentDetection'
 import { config } from './config'
+import { resolveExternalDisplayName } from './displayName'
 import { logger } from './logger'
 import { shellQuote } from './shellQuote'
 import {
@@ -438,7 +439,7 @@ function parseTmuxWindows(
     const isManagedSession = sessionName === tmuxSessionPrefix
     const displayName = isManagedSession
       ? (windowName || tmuxWindow)
-      : (sessionName || tmuxWindow)
+      : (resolveExternalDisplayName(sessionName, windowName, config.preferWindowName) || tmuxWindow)
 
     sessions.push({
       id,

--- a/src/server/sessionRefreshWorker.ts
+++ b/src/server/sessionRefreshWorker.ts
@@ -5,6 +5,7 @@
  */
 import { inferAgentType, normalizePaneStartCommand } from './agentDetection'
 import { config } from './config'
+import { resolveExternalDisplayName } from './displayName'
 import { normalizeProjectPath } from './logDiscovery'
 import { extractRecentUserMessagesFromTmux } from './logMatcher'
 import {
@@ -326,7 +327,9 @@ function listAllWindows(managedSession: string, discoverPrefixes: string[]): Ses
     )
 
     const creationTimestamp = window.creation ? window.creation * 1000 : now
-    const displayName = source === 'external' ? sessionName : window.windowName
+    const displayName = source === 'external'
+      ? resolveExternalDisplayName(sessionName, window.windowName, config.preferWindowName)
+      : window.windowName
     const normalizedPath = normalizeProjectPath(window.path)
 
     sessions.push({

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -109,7 +109,7 @@ export type ServerMessage =
     }
   | { type: 'terminal-ready'; sessionId: string }
   | { type: 'tmux-copy-mode-status'; sessionId: string; inCopyMode: boolean }
-  | { type: 'server-config'; remoteAllowControl: boolean; remoteAllowAttach: boolean; hostLabel: string; clientLogLevel?: string }
+  | { type: 'server-config'; remoteAllowControl: boolean; remoteAllowAttach: boolean; hostLabel: string; preferWindowName: boolean; clientLogLevel?: string }
   | { type: 'pong'; seq?: number }
   | { type: 'error'; message: string }
   | { type: 'kill-failed'; sessionId: string; message: string }


### PR DESCRIPTION
Supersedes #131. Carries chuqk's original commit (`432dff1`) and adds the gating fix on top.

## Why a new PR

PR #131 is from a fork (`chuqk/agentboard`); maintainer-edit pushes don't fire `pull_request` events on the upstream PR, so CI never runs on the fix. This branch is in the same repo, so CI fires immediately. Chuqk's commit and authorship are preserved.

## What this adds vs #131

In #131 the mobile session-switcher rule swapped numeric `1..N` tabs for session names whenever names were distinct — client-only, not gated on `AGENTBOARD_PREFER_WINDOW_NAME`. That contradicts the "opt-in only" intent: a default user with two distinct external sessions would already see name labels.

This commit:
- Plumbs `config.preferWindowName` through the `server-config` WS message into the client session store (`src/shared/types.ts`, `src/server/index.ts`, `src/client/stores/sessionStore.ts`, `src/client/App.tsx`).
- Gates `mobileTabsUseNames` on `preferWindowName && namesAreDistinct` (`src/client/components/Terminal.tsx`).
- Fixes a regression: the original PR rendered `String(index + 1)` while the existing `mobile layout opens drawer and switches sessions` test asserted on numeric children. Reverted to numeric label and trimmed the name when used.
- Adds two red→green client tests covering both flag values.
- Bumps patch to `0.2.46`.

## Tests

- `bun run lint`, `bun run typecheck`, `bun run test` — all green locally (830 tests, 0 fail).
- The pre-existing CI failure in #131 (`Terminal > mobile layout opens drawer`) is fixed by this change.

## Test plan

- [ ] CI green
- [ ] With `AGENTBOARD_PREFER_WINDOW_NAME=false` (default): mobile tabs render `1/2/...`
- [ ] With `AGENTBOARD_PREFER_WINDOW_NAME=true` and distinct window names: mobile tabs render names
- [ ] With `AGENTBOARD_PREFER_WINDOW_NAME=true` and repeated names: falls back to numeric

## Credit

Original window-name preference behavior + helper authored by @chuqk in #131.