### PR TITLE
fix: filter Claude Code wrapper tags from session previews (v0.2.47)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ systemd/agentboard.service
 .nightshift-plan
 /.cachebro
 /.agentcache
+.claude/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.2.46",
+  "version": "0.2.47",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/server/__tests__/logMatcher.test.ts
+++ b/src/server/__tests__/logMatcher.test.ts
@@ -322,6 +322,18 @@ describe('logMatcher', () => {
     expect(extractCommandInvocation('please fix the login bug')).toBeNull()
   })
 
+  test('extractCommandInvocation requires <command-message> wrapper (rejects pasted command-name fragments)', () => {
+    // User pasting a fragment of a Claude log without the full block shape — should not be misinterpreted.
+    const text = 'see this log line: <command-name>/cmd</command-name><command-args>args</command-args>'
+    expect(extractCommandInvocation(text)).toBeNull()
+  })
+
+  test('extractCommandInvocation requires slash-prefixed name (rejects bare names)', () => {
+    const text =
+      '<command-message>foo</command-message><command-name>just-a-name</command-name><command-args>args</command-args>'
+    expect(extractCommandInvocation(text)).toBeNull()
+  })
+
   test('extractLastUserMessageFromLog renders slash-command invocations as readable preview', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-last-user-'))
     const logPath = path.join(tempDir, 'session.jsonl')

--- a/src/server/__tests__/logMatcher.test.ts
+++ b/src/server/__tests__/logMatcher.test.ts
@@ -15,6 +15,7 @@ import {
   extractRecentUserMessagesFromTmux,
   extractPiUserMessagesFromAnsi,
   extractActionFromUserAction,
+  extractCommandInvocation,
   extractLastUserMessageFromLog,
   hasMessageInValidUserContext,
   isToolNotificationText,
@@ -302,6 +303,44 @@ describe('logMatcher', () => {
     )
 
     expect(extractLastUserMessageFromLog(logPath)).toBe('fix the login bug')
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  test('extractCommandInvocation returns "/cmd args" form for slash-command messages', () => {
+    const text =
+      '<command-message>mcp__RepoPrompt__rp-review</command-message>\n<command-name>/mcp__RepoPrompt__rp-review</command-name>\n<command-args>the pr</command-args>'
+    expect(extractCommandInvocation(text)).toBe('/mcp__RepoPrompt__rp-review the pr')
+  })
+
+  test('extractCommandInvocation handles empty args', () => {
+    const text =
+      '<command-message>mcp</command-message>\n<command-name>/mcp</command-name>\n<command-args></command-args>'
+    expect(extractCommandInvocation(text)).toBe('/mcp')
+  })
+
+  test('extractCommandInvocation returns null for non-command text', () => {
+    expect(extractCommandInvocation('please fix the login bug')).toBeNull()
+  })
+
+  test('extractLastUserMessageFromLog renders slash-command invocations as readable preview', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-last-user-'))
+    const logPath = path.join(tempDir, 'session.jsonl')
+
+    // Real on-disk format from ~/.claude/projects/*.jsonl when a user runs a slash command:
+    // type:"user" entry whose content wraps <command-message>/<command-name>/<command-args>.
+    await fs.writeFile(
+      logPath,
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content:
+            '<command-message>mcp__RepoPrompt__rp-review</command-message>\n<command-name>/mcp__RepoPrompt__rp-review</command-name>\n<command-args>the pr</command-args>',
+        },
+      })
+    )
+
+    expect(extractLastUserMessageFromLog(logPath)).toBe('/mcp__RepoPrompt__rp-review the pr')
     await fs.rm(tempDir, { recursive: true, force: true })
   })
 

--- a/src/server/__tests__/logMatcher.test.ts
+++ b/src/server/__tests__/logMatcher.test.ts
@@ -236,6 +236,75 @@ describe('logMatcher', () => {
     await fs.rm(tempDir, { recursive: true, force: true })
   })
 
+  test('extractLastUserMessageFromLog skips Claude <local-command-stdout> auto-compact entries and falls back to prior real user message', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-last-user-'))
+    const logPath = path.join(tempDir, 'session.jsonl')
+
+    // Real on-disk format from ~/.claude/projects/*.jsonl after ctrl+o auto-compact:
+    // user-role JSONL entry whose content is `<local-command-stdout>[2mCompacted...[22m</local-command-stdout>`.
+    await fs.writeFile(
+      logPath,
+      [
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: 'fix the login bug' },
+          timestamp: '2026-05-04T10:00:00.000Z',
+        }),
+        JSON.stringify({
+          type: 'user',
+          message: {
+            role: 'user',
+            content:
+              '<local-command-stdout>[2mCompacted (ctrl+o to see full summary)[22m</local-command-stdout>',
+          },
+          timestamp: '2026-05-04T10:05:00.000Z',
+        }),
+      ].join('\n')
+    )
+
+    expect(extractLastUserMessageFromLog(logPath)).toBe('fix the login bug')
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  test('extractLastUserMessageFromLog returns null when only <local-command-stdout> exists', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-last-user-'))
+    const logPath = path.join(tempDir, 'session.jsonl')
+
+    await fs.writeFile(
+      logPath,
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content:
+            '<local-command-stdout>[2mCompacted (ctrl+o to see full summary)[22m</local-command-stdout>',
+        },
+      })
+    )
+
+    expect(extractLastUserMessageFromLog(logPath)).toBeNull()
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  test('extractLastUserMessageFromLog strips ANSI escapes from real user messages', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-last-user-'))
+    const logPath = path.join(tempDir, 'session.jsonl')
+
+    await fs.writeFile(
+      logPath,
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: '[31mfix the login bug[0m',
+        },
+      })
+    )
+
+    expect(extractLastUserMessageFromLog(logPath)).toBe('fix the login bug')
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
   test('extractLastUserMessageFromLog skips Claude isMeta system-reminder entries', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-last-user-'))
     const logPath = path.join(tempDir, 'session.jsonl')

--- a/src/server/__tests__/logMatcher.test.ts
+++ b/src/server/__tests__/logMatcher.test.ts
@@ -305,6 +305,34 @@ describe('logMatcher', () => {
     await fs.rm(tempDir, { recursive: true, force: true })
   })
 
+  test('extractLastUserMessageFromLog filters tool-notification markers wrapped in ANSI escapes', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-last-user-'))
+    const logPath = path.join(tempDir, 'session.jsonl')
+    const ESC = String.fromCharCode(27)
+
+    // Hypothetical future format where Claude wraps a marker tag in ANSI dim.
+    // The fix must strip ANSI before the marker check so this still gets filtered.
+    await fs.writeFile(
+      logPath,
+      [
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: 'real prior message' },
+        }),
+        JSON.stringify({
+          type: 'user',
+          message: {
+            role: 'user',
+            content: `${ESC}[2m<local-command-stdout>compacted${ESC}[22m</local-command-stdout>`,
+          },
+        }),
+      ].join('\n')
+    )
+
+    expect(extractLastUserMessageFromLog(logPath)).toBe('real prior message')
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
   test('extractLastUserMessageFromLog skips Claude isMeta system-reminder entries', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-last-user-'))
     const logPath = path.join(tempDir, 'session.jsonl')

--- a/src/server/__tests__/logMatcher.test.ts
+++ b/src/server/__tests__/logMatcher.test.ts
@@ -1494,6 +1494,15 @@ describe('isToolNotificationText', () => {
     test('allows whitespace only', () => {
       expect(isToolNotificationText('   ')).toBe(false)
     })
+
+    test('filters Claude Code <local-command-stdout> auto-compact output', () => {
+      const text = '<local-command-stdout>[2mCompacted (ctrl+o to see full summary)[22m</local-command-stdout>'
+      expect(isToolNotificationText(text)).toBe(true)
+    })
+
+    test('filters <local-command-stderr> output', () => {
+      expect(isToolNotificationText('<local-command-stderr>error</local-command-stderr>')).toBe(true)
+    })
   })
 })
 

--- a/src/server/logMatcher.ts
+++ b/src/server/logMatcher.ts
@@ -341,11 +341,7 @@ const TOOL_NOTIFICATION_MARKERS = [
   '<local-command-stderr>',
 ] as const
 
-const ANSI_ESCAPE_PATTERN = /\[[0-9;?]*[a-zA-Z]/g
 
-export function stripAnsiEscapes(text: string): string {
-  return text.replace(ANSI_ESCAPE_PATTERN, '')
-}
 
 /**
  * Pattern for Codex CLI tool-use warnings injected as user messages.
@@ -1419,12 +1415,14 @@ function shouldIncludeRole(role: string, mode: LogTextMode): boolean {
  * Returns the processed text or null if it should be skipped.
  */
 function processUserMessageText(text: string): string | null {
-  if (!text.trim()) return null
-  if (isToolNotificationText(text)) return null
-  const action = extractActionFromUserAction(text)
+  // Strip ANSI first so marker checks see clean text — guards against future
+  // log entries that wrap markers in ANSI (e.g., `\x1b[2m<task-notification>...`).
+  const cleaned = stripAnsi(text)
+  if (!cleaned.trim()) return null
+  if (isToolNotificationText(cleaned)) return null
+  const action = extractActionFromUserAction(cleaned)
   if (action) return action
-  const stripped = stripAnsiEscapes(text)
-  return stripped.trim() ? stripped : null
+  return cleaned
 }
 
 function extractRoleTextFromEntry(

--- a/src/server/logMatcher.ts
+++ b/src/server/logMatcher.ts
@@ -339,6 +339,11 @@ const TOOL_NOTIFICATION_MARKERS = [
   // Claude Code slash-command / auto-compact stdout/stderr (e.g. `<local-command-stdout>\x1b[2mCompacted...\x1b[22m</local-command-stdout>`)
   '<local-command-stdout>',
   '<local-command-stderr>',
+  // Raw slash-command invocations. Live extraction prefers the "/cmd args"
+  // form via extractCommandInvocation; this marker exists so the cache-refresh
+  // path in logPoller treats any pre-fix cached `<command-message>...` payload
+  // as stale and re-runs extraction.
+  '<command-message>',
 ] as const
 
 
@@ -377,6 +382,21 @@ export function extractActionFromUserAction(text: string): string | null {
     return actionMatch[1].trim()
   }
   return null
+}
+
+/**
+ * Extract a human-readable slash command invocation from a Claude Code
+ * `<command-message>...</command-message><command-name>/cmd</command-name><command-args>args</command-args>`
+ * user message. Returns "/cmd args" (or "/cmd" with no args) or null if not a command invocation.
+ */
+export function extractCommandInvocation(text: string): string | null {
+  if (!text.includes('<command-name>')) return null
+  const nameMatch = text.match(/<command-name>\s*([^<]+?)\s*<\/command-name>/i)
+  if (!nameMatch?.[1]) return null
+  const name = nameMatch[1].trim()
+  const argsMatch = text.match(/<command-args>\s*([\s\S]*?)\s*<\/command-args>/i)
+  const args = argsMatch?.[1]?.trim() ?? ''
+  return args ? `${name} ${args}` : name
 }
 
 function readLogTail(logPath: string, byteLimit = DEFAULT_LOG_TAIL_BYTES): string {
@@ -1419,6 +1439,11 @@ function processUserMessageText(text: string): string | null {
   // log entries that wrap markers in ANSI (e.g., `\x1b[2m<task-notification>...`).
   const cleaned = stripAnsi(text)
   if (!cleaned.trim()) return null
+  // Slash-command invocations come through as user messages wrapped in
+  // <command-message>/<command-name>/<command-args>. Extract a readable
+  // "/cmd args" form before the generic marker filter would discard them.
+  const invocation = extractCommandInvocation(cleaned)
+  if (invocation) return invocation
   if (isToolNotificationText(cleaned)) return null
   const action = extractActionFromUserAction(cleaned)
   if (action) return action

--- a/src/server/logMatcher.ts
+++ b/src/server/logMatcher.ts
@@ -388,12 +388,16 @@ export function extractActionFromUserAction(text: string): string | null {
  * Extract a human-readable slash command invocation from a Claude Code
  * `<command-message>...</command-message><command-name>/cmd</command-name><command-args>args</command-args>`
  * user message. Returns "/cmd args" (or "/cmd" with no args) or null if not a command invocation.
+ *
+ * To avoid false positives on user-authored prose containing `<command-name>` tags,
+ * we require the full Claude block shape (both `<command-message>` and `<command-name>`)
+ * and require the extracted name to be a slash command.
  */
 export function extractCommandInvocation(text: string): string | null {
-  if (!text.includes('<command-name>')) return null
+  if (!text.includes('<command-message>') || !text.includes('<command-name>')) return null
   const nameMatch = text.match(/<command-name>\s*([^<]+?)\s*<\/command-name>/i)
-  if (!nameMatch?.[1]) return null
-  const name = nameMatch[1].trim()
+  const name = nameMatch?.[1]?.trim()
+  if (!name || !name.startsWith('/')) return null
   const argsMatch = text.match(/<command-args>\s*([\s\S]*?)\s*<\/command-args>/i)
   const args = argsMatch?.[1]?.trim() ?? ''
   return args ? `${name} ${args}` : name

--- a/src/server/logMatcher.ts
+++ b/src/server/logMatcher.ts
@@ -336,7 +336,16 @@ const TOOL_NOTIFICATION_MARKERS = [
   '<instructions>',
   '# agents.md instructions',
   '<environment_context>',
+  // Claude Code slash-command / auto-compact stdout/stderr (e.g. `<local-command-stdout>\x1b[2mCompacted...\x1b[22m</local-command-stdout>`)
+  '<local-command-stdout>',
+  '<local-command-stderr>',
 ] as const
+
+const ANSI_ESCAPE_PATTERN = /\[[0-9;?]*[a-zA-Z]/g
+
+export function stripAnsiEscapes(text: string): string {
+  return text.replace(ANSI_ESCAPE_PATTERN, '')
+}
 
 /**
  * Pattern for Codex CLI tool-use warnings injected as user messages.
@@ -1414,7 +1423,8 @@ function processUserMessageText(text: string): string | null {
   if (isToolNotificationText(text)) return null
   const action = extractActionFromUserAction(text)
   if (action) return action
-  return text
+  const stripped = stripAnsiEscapes(text)
+  return stripped.trim() ? stripped : null
 }
 
 function extractRoleTextFromEntry(


### PR DESCRIPTION
## Summary

Hibernating sessions were displaying raw Claude Code internals as the "last user message" preview — `<local-command-stdout>\x1b[2mCompacted...\x1b[22m</local-command-stdout>` after auto-compact, or `<command-message>mcp__RepoPrompt__rp-…</command-message>` after a slash command.

Root cause: agentboard's `processUserMessageText` had no awareness of these wrapper tags, and ANSI escapes were never stripped from the preview text.

## Changes

- **Filter** `<local-command-stdout>` and `<local-command-stderr>` (auto-compact / slash-command stdout) — falls back to the prior real user message
- **Extract** slash commands (`<command-message>...</command-message><command-name>/cmd</command-name><command-args>args</command-args>`) and render as `/cmd args` — surfaces the user's real action rather than a stale prior message
- **Strip ANSI escapes** in `processUserMessageText` (reusing the existing `stripAnsi` from `terminal/tmuxText.ts`) — defense-in-depth for any future wrapper tags
- **Strip-before-marker-check ordering** so future log entries that wrap markers in ANSI still get filtered
- **Hardened** `extractCommandInvocation` against false positives: requires both `<command-message>` and `<command-name>` tags AND a slash-prefixed name (so user prose containing `<command-name>` fragments isn't rewritten)
- **Cache refresh** triggers automatically on next poll: pre-fix cached values match the new markers via `isToolNotificationText`, which the existing `startupLastMessageBackfillPending` path uses to re-extract
- `.gitignore` `.claude/` harness artifacts
- Patch bump 0.2.46 → 0.2.47

## Test plan

- [x] Unit tests: `bun test src/server/__tests__/logMatcher.test.ts` — 107 pass (10 new)
- [x] Full suite: `bun run test` — 731 + 25 + 97 pass
- [x] Lint clean (`bun run lint`)
- [x] Typecheck clean (`bun run typecheck`)
- [x] Locally verified by running this branch via launchd-managed server; previews resolved to `/cmd args` form for slash commands and to prior real messages for auto-compact entries
- [ ] Known follow-up (not blocking): when a session's log contains *only* noise (no real prior user message and no extractable slash command), the cached junk preview is not cleared because the refresh paths can only write truthy values. Needs a `clearLastUserMessage` plumbing through the worker→poller boundary. Rare orphan case.