### PR TITLE
fix: skip hydrateSessionsWithAgentSessions when input sessions is empty

### DIFF
--- a/scripts/test-runner.ts
+++ b/scripts/test-runner.ts
@@ -48,9 +48,13 @@ async function main() {
     // must run in a separate process so they don't race with other test files.
     // PipePaneTerminalProxy reads Bun.spawnSync at construction time — if another
     // test file has patched it, the proxy gets a mock and start() becomes undefined.
+    // hydrateSessionsEmptyGuard imports `../index` with an active Bun.spawnSync /
+    // Bun.serve / setInterval mock; isolation keeps that mock window from
+    // overlapping with any other test that captures globals at module load.
     const ISOLATED_FILES = new Set([
       'sessionRefreshWorker.test.ts',
       'pipePaneTerminalProxy.test.ts',
+      'hydrateSessionsEmptyGuard.test.ts',
     ])
 
     const serverTests: string[] = []

--- a/src/server/__tests__/hydrateSessionsEmptyGuard.test.ts
+++ b/src/server/__tests__/hydrateSessionsEmptyGuard.test.ts
@@ -1,0 +1,212 @@
+// Regression test for the orphan-judgment bug in hydrateSessionsWithAgentSessions.
+//
+// Symptom observed in production: when the tmux-query path that produces the
+// `sessions` argument transiently returns an empty array (e.g. the tmux server
+// is briefly unresponsive or a parse path returns []), every active session in
+// the DB is treated as orphaned because `windowSet.size === 0` and none of the
+// DB-recorded `currentWindow` values can match. The post-orphan branch then
+// calls `sessionManager.killWindow(currentWindow)` for each, deleting all of
+// the user's working tmux windows in one pass.
+//
+// This test reproduces that case: it seeds the DB with several active sessions
+// pointing at tmux windows, mocks Bun.spawnSync so we can observe tmux calls,
+// and invokes hydrateSessionsWithAgentSessions with an empty `sessions` array.
+//
+// Expected behaviour: no `tmux kill-window` is issued.
+// Pre-patch behaviour: N `tmux kill-window` calls are issued.
+//
+// All process-wide mutations (env vars, Bun.spawnSync override, setInterval
+// stub, Bun.serve stub) are confined to beforeAll / afterAll so this file
+// can run in the same bun:test process as the rest of the suite without
+// leaking state.
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { initDatabase } from '../db'
+
+const bunAny = Bun as typeof Bun & {
+  serve: typeof Bun.serve
+  spawnSync: typeof Bun.spawnSync
+}
+
+type TmuxCall = { args: readonly string[] }
+// All `tmux ...` invocations observed, full argv including `tmux` and any
+// flags like `-u`, so callers can filter without worrying about the position
+// of the verb (which sits at index 1 or 2 depending on flags).
+const tmuxCalls: TmuxCall[] = []
+
+function makeSpawnSyncMock(): typeof Bun.spawnSync {
+  return ((...args: Parameters<typeof Bun.spawnSync>) => {
+    const first = args[0] as unknown
+    let cmdArr: string[] = []
+    if (Array.isArray(first)) {
+      cmdArr = first as string[]
+    } else if (first && typeof first === 'object' && Array.isArray((first as { cmd?: unknown }).cmd)) {
+      cmdArr = (first as { cmd: string[] }).cmd
+    }
+    if (cmdArr[0] === 'tmux') {
+      tmuxCalls.push({ args: cmdArr })
+    }
+    return {
+      exitCode: 0,
+      stdout: Buffer.from(''),
+      stderr: Buffer.from(''),
+      success: true,
+    } as unknown as ReturnType<typeof Bun.spawnSync>
+  }) as typeof Bun.spawnSync
+}
+
+describe('hydrateSessionsWithAgentSessions — empty windowSet guard', () => {
+  let hydrate: (sessions: unknown[], opts?: unknown) => unknown[]
+  let tempDir: string
+  let tempDbPath: string
+
+  // Snapshots captured at beforeAll so we can fully restore in afterAll.
+  let originalServe: typeof Bun.serve
+  let originalSpawnSync: typeof Bun.spawnSync
+  let originalSetInterval: typeof globalThis.setInterval
+  const envSnapshot: Record<string, string | undefined> = {}
+  const ENV_KEYS = [
+    'AGENTBOARD_DB_PATH',
+    'LOG_FILE',
+    'CLAUDE_CONFIG_DIR',
+    'CODEX_HOME',
+    'AGENTBOARD_LOG_MATCH_WORKER',
+    'NODE_ENV',
+  ]
+
+  function seedActiveSession(sessionId: string, currentWindow: string, displayName: string) {
+    const seedDb = initDatabase({ path: tempDbPath })
+    const now = new Date('2026-05-19T07:11:00.000Z').toISOString()
+    const logPath = path.join(tempDir, `${sessionId}.jsonl`)
+    if (!fs.existsSync(logPath)) {
+      fs.writeFileSync(logPath, '')
+    }
+    seedDb.insertSession({
+      sessionId,
+      logFilePath: logPath,
+      projectPath: path.join(tempDir, sessionId),
+      slug: null,
+      agentType: 'claude',
+      displayName,
+      createdAt: now,
+      lastActivityAt: now,
+      lastUserMessage: null,
+      currentWindow,
+      isPinned: false,
+      lastResumeError: null,
+      wakeStartedAt: null,
+      lastKnownLogSize: null,
+      isCodexExec: false,
+      launchCommand: null,
+    })
+    ;(seedDb as unknown as { db: { close: () => void } }).db.close()
+  }
+
+  beforeAll(async () => {
+    // Snapshot env so we can restore exactly (including deletion).
+    for (const k of ENV_KEYS) {
+      envSnapshot[k] = process.env[k]
+    }
+    // Snapshot global mutables.
+    originalServe = bunAny.serve
+    originalSpawnSync = bunAny.spawnSync
+    originalSetInterval = globalThis.setInterval
+
+    // Prepare isolated dirs under tmpdir.
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ab-hydrate-empty-guard-'))
+    tempDbPath = path.join(tempDir, 'agentboard.db')
+    const tempLogFile = path.join(tempDir, 'agentboard.log')
+    const tempClaudeDir = path.join(tempDir, 'claude')
+    const tempCodexDir = path.join(tempDir, 'codex')
+    fs.mkdirSync(path.join(tempClaudeDir, 'projects'), { recursive: true })
+    fs.mkdirSync(path.join(tempCodexDir, 'sessions'), { recursive: true })
+
+    process.env.AGENTBOARD_DB_PATH = tempDbPath
+    process.env.LOG_FILE = tempLogFile
+    process.env.CLAUDE_CONFIG_DIR = tempClaudeDir
+    process.env.CODEX_HOME = tempCodexDir
+    process.env.AGENTBOARD_LOG_MATCH_WORKER = 'false'
+    if (process.env.NODE_ENV === 'production' || !process.env.NODE_ENV) {
+      process.env.NODE_ENV = 'test'
+    }
+
+    // Install mocks. The module under test creates a SessionManager on import
+    // that captures Bun.spawnSync into an instance property, so the mock must
+    // be in place before the import below evaluates.
+    bunAny.spawnSync = makeSpawnSyncMock()
+    bunAny.serve = ((_options: unknown) => ({} as unknown)) as unknown as typeof Bun.serve
+    globalThis.setInterval = ((..._a: unknown[]) => 0) as unknown as typeof globalThis.setInterval
+
+    // Import the module under test. Cache-buster forces a fresh evaluation
+    // so we don't share module state across reruns.
+    const mod = await import(
+      `../index?test=hydrate-empty-guard-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    )
+    hydrate = (mod as { hydrateSessionsWithAgentSessions: typeof hydrate }).hydrateSessionsWithAgentSessions
+  })
+
+  afterAll(() => {
+    // Restore globals first so subsequent tests in this process see the real
+    // Bun.spawnSync / Bun.serve / setInterval again.
+    bunAny.serve = originalServe
+    bunAny.spawnSync = originalSpawnSync
+    globalThis.setInterval = originalSetInterval
+
+    // Restore env keys to their original state (including deletion when the
+    // key was originally unset).
+    for (const k of ENV_KEYS) {
+      const original = envSnapshot[k]
+      if (original === undefined) {
+        delete process.env[k]
+      } else {
+        process.env[k] = original
+      }
+    }
+
+    try { fs.rmSync(tempDir, { recursive: true, force: true }) } catch { /* ignore */ }
+  })
+
+  beforeEach(() => {
+    // Clear the shared DB so each test starts from a known state.
+    const cleanDb = initDatabase({ path: tempDbPath })
+    ;(cleanDb as unknown as { db: { exec: (sql: string) => void; close: () => void } })
+      .db.exec('DELETE FROM agent_sessions')
+    ;(cleanDb as unknown as { db: { close: () => void } }).db.close()
+    tmuxCalls.length = 0
+  })
+
+  test('does NOT call `tmux kill-window` when sessions=[] but DB has active sessions', () => {
+    expect(typeof hydrate).toBe('function')
+
+    // Seed: 5 active sessions, each currently bound to a live tmux window.
+    for (let i = 1; i <= 5; i++) {
+      seedActiveSession(`test-session-${i}`, `target:@${100 + i}`, `proj-${i}`)
+    }
+
+    // Sanity: confirm the SUT can see the seeded rows.
+    const probeBefore = initDatabase({ path: tempDbPath })
+    const activeBefore = probeBefore.getActiveSessions().length
+    ;(probeBefore as unknown as { db: { close: () => void } }).db.close()
+    expect(activeBefore).toBe(5)
+
+    // Snapshot tmux calls *before* the call under test so we ignore any
+    // bookkeeping calls the SUT made on import.
+    const callCountBefore = tmuxCalls.length
+
+    // Simulate the transient tmux-query failure that motivated this regression:
+    // listWindows() returned an empty Session[] even though the DB still has
+    // multiple active sessions pointing at live tmux windows.
+    hydrate([])
+
+    // A `tmux kill-window` invocation has 'kill-window' as a verb in argv:
+    //   ['tmux', 'kill-window', '-t', '<window>']           or
+    //   ['tmux', '-u', 'kill-window', '-t', '<window>']
+    const callsDuringHydrate = tmuxCalls.slice(callCountBefore)
+    const killCalls = callsDuringHydrate.filter((c) => c.args.includes('kill-window'))
+
+    expect(killCalls).toHaveLength(0)
+  })
+})

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -596,11 +596,26 @@ async function verifyAllSessions(
   return new Map(entries)
 }
 
-function hydrateSessionsWithAgentSessions(
+export function hydrateSessionsWithAgentSessions(
   sessions: Session[],
   { verifyAssociations = false, precomputedVerifications }: HydrateSessionsOptions = {}
 ): Session[] {
   const activeSessions = db.getActiveSessions()
+  // Sanity guard: callers ultimately source `sessions` from a tmux query (e.g.
+  // sessionRefreshWorker.refresh or listWindowsSyncOrNull). When that query
+  // transiently returns an empty array — but the DB still tracks live
+  // sessions — every active session would fail the windowSet membership check
+  // below and be treated as orphaned, which then triggers
+  // sessionManager.killWindow() for each. That mass-kills the user's working
+  // tmux windows in one pass. Skip this cycle and let the next refresh
+  // observe a real state. completeStartupVerification() already applies an
+  // equivalent guard before hydrating.
+  if (activeSessions.length > 0 && sessions.length === 0) {
+    logger.warn('hydrate_sessions_skipped_empty_input', {
+      activeSessionCount: activeSessions.length,
+    })
+    return sessions
+  }
   const windowSet = new Set(sessions.map((session) => session.tmuxWindow))
   const activeMap = new Map<string, typeof activeSessions[number]>()
   const orphaned: AgentSession[] = []


### PR DESCRIPTION
## Summary

`hydrateSessionsWithAgentSessions` (in `src/server/index.ts`, ~line 599) walks every active DB session and, for each one whose `currentWindow` is not present in the input `windowSet`, calls `sessionManager.killWindow(currentWindow)`.

If the `sessions` argument arrives empty while the DB still tracks live sessions, every active session fails the membership check at once and the post-orphan branch issues `tmux kill-window` for each. The user's working tmux windows are closed in a single pass.

## What I saw in production

I run agentboard against a long-lived tmux server with several tracked Claude Code windows. In one stretch of about nine seconds, agentboard's own log records ten consecutive `session_orphaned` events all reporting:

```
windowSetSize: 0
windowSetSample: []
event: "session_orphaned"
```

Each is immediately followed by `event: "window_killed"`. tmux loses all ten windows in a single pass. The DB rows are then orphaned (`current_window = NULL`).

I couldn't reproduce the *original* empty-input condition deterministically — it appears to be a transient tmux-query failure — but the *downstream behaviour* (mass kill when the input happens to be `[]`) is reproducible in isolation.

## Fix

Add an early-return guard at the top of `hydrateSessionsWithAgentSessions`, mirroring the one already present in `completeStartupVerification()` (~ line 1014). That existing guard only proceeds with hydration when both `activeSessions` and `localSessions` are non-empty. The runtime refresh paths (lines 825, 852, 894) didn't have the equivalent check.

```ts
if (activeSessions.length > 0 && sessions.length === 0) {
  logger.warn('hydrate_sessions_skipped_empty_input', {
    activeSessionCount: activeSessions.length,
  })
  return sessions
}
```

## Reproduction test

`src/server/__tests__/hydrateSessionsEmptyGuard.test.ts`:

1. Mock `Bun.spawnSync` so all tmux calls are observable.
2. Seed five rows into the DB with non-null `current_window` values.
3. Call `hydrateSessionsWithAgentSessions([])` to simulate an empty query result.
4. Assert: no `tmux kill-window` is issued.

On the un-patched code this test fails with `Expected length: 0 / Received length: 5` — five `kill-window` calls were issued for the seeded windows. After the guard it passes.

The function is exported as part of this PR so the test can target it directly. The new test file is also registered in `scripts/test-runner.ts`'s `ISOLATED_FILES` set so its `Bun.spawnSync` / `Bun.serve` / `setInterval` mocks can't race with other test files at module-load time.

## Test plan

- [x] `bun test src/server/__tests__/hydrateSessionsEmptyGuard.test.ts` — fails without the guard, passes with it.
- [x] `bun scripts/test-runner.ts` — full suite passes locally (no regressions).

## A note on the failing CI checks

The 8 failures in the `ci` job look like pre-existing flakes unrelated to this PR:

- The same 8 tests fail in the same call sites both before and after adding `hydrateSessionsEmptyGuard.test.ts` to `ISOLATED_FILES` in `scripts/test-runner.ts` — isolation reduced the count by 0.
- On my local machine, `bun scripts/test-runner.ts` against clean `upstream/master` (no patch, no new test file) produces 0 failures. Applying the patch + the new test on top still produces 0 failures locally; only the unrelated `double-attach dedup integration` test occasionally flakes.
- Running each failing test file individually with the patch applied also produces 0 failures.

That points at something CI-specific (Linux + headless + coverage flag + test-file enumeration order) rather than anything in this PR. The most decisive check would be a fresh CI run on `master` HEAD in this repo — happy to be told I'm missing something obvious.

## Disclosure

This is a vibe-coder pull request: both the investigation and the patch were driven by an AI coding agent working from my agentboard log and the source. I've read the diff and it looks correct, but I'd appreciate any pushback on the shape of the guard, the wording of the comment, or the scope of the test.

Thank you for maintaining this project — finding the root cause in the logs is exactly the kind of debugging story I love. Happy to iterate on the patch.