### PR TITLE
test: isolate terminalProxyFactory mock leak; disable skipMatchingPatterns in test runner

### DIFF
--- a/scripts/test-runner.ts
+++ b/scripts/test-runner.ts
@@ -41,6 +41,12 @@ async function main() {
     CODEX_HOME: codexDir,
     LOG_FILE: tempLogFile,
     AGENTBOARD_DB_PATH: tempDbPath,
+    // Default skipMatchingPatterns excludes /tmp/* and /var/folders/* — both
+    // common locations for test working directories (worktrees, CI runners on
+    // some platforms). Tests that exercise matching logic from those paths
+    // would otherwise be silently skipped. Tests that need specific skip
+    // behavior pass patterns explicitly via the matcher API.
+    AGENTBOARD_SKIP_MATCHING_PATTERNS: '',
   }
 
   try {
@@ -55,6 +61,13 @@ async function main() {
       'sessionRefreshWorker.test.ts',
       'pipePaneTerminalProxy.test.ts',
       'hydrateSessionsEmptyGuard.test.ts',
+      // terminalProxyFactory.test.ts installs a top-level
+      // mock.module('../config', ...) whose replacement omits many real
+      // config fields. Bun's mock.restore() in afterAll does not fully
+      // unwind module-level mocks, so the stripped config can leak into
+      // any later test file that imports `../config` (notably
+      // logPoller.test.ts, which depends on skipMatchingPatterns).
+      'terminalProxyFactory.test.ts',
     ])
 
     // Client tests that install top-level mock.module(...) hooks must run in a

--- a/scripts/test-runner.ts
+++ b/scripts/test-runner.ts
@@ -103,21 +103,24 @@ async function main() {
     )
 
     // Always run global-mutating tests in a separate process to prevent races.
-    const isolatedFiles = Array.from(ISOLATED_FILES).map(
-      (f) => `src/server/__tests__/${f}`
-    )
-    await runCommand(
-      ['bun', 'test', ...passthroughArgs, ...isolatedFiles],
-      env
-    )
+    // Each file runs in its own bun process — isolation is from every other
+    // file, not just from the main suite. terminalProxyFactory.test.ts
+    // installs mock.module('../terminal/PipePaneTerminalProxy', ...) that
+    // would otherwise leak into pipePaneTerminalProxy.test.ts on readdir
+    // orderings where it loads first (Linux ext4).
+    for (const file of ISOLATED_FILES) {
+      await runCommand(
+        ['bun', 'test', ...passthroughArgs, `src/server/__tests__/${file}`],
+        env
+      )
+    }
 
-    const isolatedClientFiles = Array.from(ISOLATED_CLIENT_FILES).map(
-      (f) => `src/client/__tests__/${f}`
-    )
-    await runCommand(
-      ['bun', 'test', ...passthroughArgs, ...isolatedClientFiles],
-      env
-    )
+    for (const file of ISOLATED_CLIENT_FILES) {
+      await runCommand(
+        ['bun', 'test', ...passthroughArgs, `src/client/__tests__/${file}`],
+        env
+      )
+    }
 
     if (!skipIsolated) {
       await runCommand(


### PR DESCRIPTION
## Summary

Two latent test fragilities, both invisible on CI and on most contributors' machines but reproducible from a working tree under `/tmp` or `/var/folders` (worktrees, scratch clones, some CI configs).

- `logPoller.test.ts` builds project paths from `process.cwd()`. The default `config.skipMatchingPatterns` (`src/server/config.ts:65-71`) matches `/private/tmp/*`, `/tmp/*`, `/private/var/folders/*`, `/var/folders/*` — exactly where tmp-rooted checkouts live. The matcher then skips those projects, so the orphan-rematch tests silently fail (e.g. `rematches orphaned sessions on startup without new activity`, `clears resume error when orphaned session rematches during poll`). The patterns are a production safety net; they shouldn't gate test fixtures.

- `terminalProxyFactory.test.ts:42-44` installs a top-level `mock.module('../config', ...)` whose replacement omits many real-config fields. Bun's `mock.restore()` in `afterAll` does not fully unwind module-level mocks, so later files that import `../config` read through the stripped mock. On many readdir orderings this happened to mask issue (1) above — the stripped config has no skip patterns, so the orphan-rematch tests "passed" via mock leakage instead of legitimately.

## Fix

- Set `AGENTBOARD_SKIP_MATCHING_PATTERNS=''` in the runner's subprocess env so the matcher doesn't suppress test working directories.
- Add `terminalProxyFactory.test.ts` to `ISOLATED_FILES` so it runs in its own bun process and can't bleed module mocks into later files.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run test` from `/Users/garybasin/Code/agentboard` — all green
- [x] `bun run test` from `/tmp/test-fixes` worktree (the previously-failing case) — all green
- [x] No production source code changed; only `scripts/test-runner.ts`.

## Notes

- Tests that intentionally exercise skip-pattern logic (`logMatchGate.test.ts`) pass patterns directly to the matcher API, so they are unaffected.
- Direct `bun test <file>` invocations from a `/tmp`-rooted checkout still skip — only `bun run test` (the documented entry point and what CI/hooks use) is wired up. Adding the env wiring at the `bun test` layer would require either Bun's `preload` mechanism or every test file setting its own env, both of which are heavier than warranted here.