### PR TITLE
fix(server): cap browser-controlled payload sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,11 @@ AGENTBOARD_REMOTE_SSH_OPTS=-o BatchMode=yes -o ConnectTimeout=3
 AGENTBOARD_REMOTE_ALLOW_ATTACH=false
 AGENTBOARD_REMOTE_ALLOW_CONTROL=false
 AGENTBOARD_LOG_WATCH_MODE=watch
+AGENTBOARD_WS_MAX_PAYLOAD_BYTES=1048576
+AGENTBOARD_TERMINAL_INPUT_MAX_BYTES=65536
+AGENTBOARD_CLIENT_LOG_MAX_BYTES=65536
+AGENTBOARD_CLIENT_LOG_EVENT_MAX_BYTES=256
+AGENTBOARD_PASTE_IMAGE_MAX_BYTES=10485760
 ```
 
 `HOSTNAME` controls which interfaces the server binds to (default `127.0.0.1` for localhost-only). With the default localhost binding, if Tailscale is detected the server also binds to your Tailscale IP automatically. Set to `0.0.0.0` to listen on all interfaces.
@@ -203,6 +208,8 @@ All persistent data is stored in `~/.agentboard/`: session database (`agentboard
 `AGENTBOARD_REMOTE_ALLOW_CONTROL` enables destructive remote session management (create, kill, rename) via the UI. Setting this to `true` implies `REMOTE_ALLOW_ATTACH=true`. Kill and rename are restricted to agentboard-managed sessions — externally-discovered remote sessions cannot be killed or renamed even with control enabled.
 
 `AGENTBOARD_LOG_WATCH_MODE` selects the log detection strategy: `watch` (default) uses `fs.watch` for instant file-change detection, `poll` falls back to periodic directory scanning. Use `poll` if you experience issues with filesystem notifications (e.g., on network-mounted home directories). On Linux, watch mode automatically includes a 15-second fallback poll since `fs.watch({ recursive: true })` has known platform bugs.
+
+`AGENTBOARD_WS_MAX_PAYLOAD_BYTES`, `AGENTBOARD_TERMINAL_INPUT_MAX_BYTES`, `AGENTBOARD_CLIENT_LOG_MAX_BYTES`, `AGENTBOARD_CLIENT_LOG_EVENT_MAX_BYTES`, and `AGENTBOARD_PASTE_IMAGE_MAX_BYTES` cap browser-controlled payload sizes. Paste uploads are limited to PNG, JPEG, GIF, and WebP images.
 
 **SSH multiplexing (recommended):** Each poll cycle opens SSH connections to every remote host. Enable SSH connection multiplexing to reuse connections and reduce overhead from ~200-500ms to ~5ms per poll. Add to your `~/.ssh/config`:
 

--- a/src/server/__tests__/config.test.ts
+++ b/src/server/__tests__/config.test.ts
@@ -32,6 +32,11 @@ const ORIGINAL_ENV = {
   AGENTBOARD_REMOTE_ALLOW_CONTROL: process.env.AGENTBOARD_REMOTE_ALLOW_CONTROL,
   AGENTBOARD_TMUX_TIMEOUT_MS: process.env.AGENTBOARD_TMUX_TIMEOUT_MS,
   AGENTBOARD_TMUX_MUTATION_TIMEOUT_MS: process.env.AGENTBOARD_TMUX_MUTATION_TIMEOUT_MS,
+  AGENTBOARD_WS_MAX_PAYLOAD_BYTES: process.env.AGENTBOARD_WS_MAX_PAYLOAD_BYTES,
+  AGENTBOARD_TERMINAL_INPUT_MAX_BYTES: process.env.AGENTBOARD_TERMINAL_INPUT_MAX_BYTES,
+  AGENTBOARD_CLIENT_LOG_MAX_BYTES: process.env.AGENTBOARD_CLIENT_LOG_MAX_BYTES,
+  AGENTBOARD_CLIENT_LOG_EVENT_MAX_BYTES: process.env.AGENTBOARD_CLIENT_LOG_EVENT_MAX_BYTES,
+  AGENTBOARD_PASTE_IMAGE_MAX_BYTES: process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES,
 }
 
 const ENV_KEYS = Object.keys(ORIGINAL_ENV) as Array<keyof typeof ORIGINAL_ENV>
@@ -81,6 +86,11 @@ async function loadConfig(tag: string) {
     remoteAllowControl: boolean
     tmuxTimeoutMs: number
     tmuxMutationTimeoutMs: number
+    wsMaxPayloadBytes: number
+    terminalInputMaxBytes: number
+    clientLogMaxBytes: number
+    clientLogEventMaxBytes: number
+    pasteImageMaxBytes: number
   }
 }
 
@@ -123,6 +133,11 @@ describe('config', () => {
     expect(config.remoteAllowControl).toBe(false)
     expect(config.tmuxTimeoutMs).toBe(3000)
     expect(config.tmuxMutationTimeoutMs).toBe(15000)
+    expect(config.wsMaxPayloadBytes).toBe(1024 * 1024)
+    expect(config.terminalInputMaxBytes).toBe(64 * 1024)
+    expect(config.clientLogMaxBytes).toBe(64 * 1024)
+    expect(config.clientLogEventMaxBytes).toBe(256)
+    expect(config.pasteImageMaxBytes).toBe(10 * 1024 * 1024)
   })
 
   test('parses env overrides and trims discover prefixes', async () => {
@@ -156,6 +171,11 @@ describe('config', () => {
     process.env.AGENTBOARD_REMOTE_ALLOW_CONTROL = 'true'
     process.env.AGENTBOARD_TMUX_TIMEOUT_MS = '4500'
     process.env.AGENTBOARD_TMUX_MUTATION_TIMEOUT_MS = '12000'
+    process.env.AGENTBOARD_WS_MAX_PAYLOAD_BYTES = '2048'
+    process.env.AGENTBOARD_TERMINAL_INPUT_MAX_BYTES = '512'
+    process.env.AGENTBOARD_CLIENT_LOG_MAX_BYTES = '1024'
+    process.env.AGENTBOARD_CLIENT_LOG_EVENT_MAX_BYTES = '64'
+    process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES = '4096'
 
     const config = await loadConfig('overrides')
     expect(config.port).toBe(9090)
@@ -188,6 +208,11 @@ describe('config', () => {
     expect(config.remoteAllowControl).toBe(true)
     expect(config.tmuxTimeoutMs).toBe(4500)
     expect(config.tmuxMutationTimeoutMs).toBe(12000)
+    expect(config.wsMaxPayloadBytes).toBe(2048)
+    expect(config.terminalInputMaxBytes).toBe(512)
+    expect(config.clientLogMaxBytes).toBe(1024)
+    expect(config.clientLogEventMaxBytes).toBe(64)
+    expect(config.pasteImageMaxBytes).toBe(4096)
   })
 
   test('defaults to watch mode for invalid AGENTBOARD_LOG_WATCH_MODE', async () => {

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -81,6 +81,11 @@ const defaultConfig = {
   remoteAllowAttach: false,
   tmuxTimeoutMs: 3000,
   tmuxMutationTimeoutMs: 15000,
+  wsMaxPayloadBytes: 1024 * 1024,
+  terminalInputMaxBytes: 64 * 1024,
+  clientLogMaxBytes: 64 * 1024,
+  clientLogEventMaxBytes: 256,
+  pasteImageMaxBytes: 10 * 1024 * 1024,
 }
 
 const configState = { ...defaultConfig }
@@ -4468,6 +4473,61 @@ describe('server fetch handlers', () => {
     expect(payload.path.endsWith('.png')).toBe(true)
   })
 
+  test('rejects unsupported or oversized paste-image uploads', async () => {
+    const { serveOptions } = await loadIndex()
+    const fetchHandler = serveOptions.fetch
+    if (!fetchHandler) {
+      throw new Error('Fetch handler not configured')
+    }
+
+    const unsupported = new FormData()
+    unsupported.append(
+      'image',
+      new File([new Uint8Array([1, 2, 3])], 'paste.txt', {
+        type: 'text/plain',
+      })
+    )
+
+    const unsupportedResponse = await fetchHandler.call(
+      {} as Bun.Server<unknown>,
+      new Request('http://localhost/api/paste-image', {
+        method: 'POST',
+        body: unsupported,
+      }),
+      {} as Bun.Server<unknown>
+    )
+
+    if (!unsupportedResponse) {
+      throw new Error('Expected response for unsupported paste-image')
+    }
+
+    expect(unsupportedResponse.status).toBe(415)
+
+    configState.pasteImageMaxBytes = 2
+    const oversized = new FormData()
+    oversized.append(
+      'image',
+      new File([new Uint8Array([1, 2, 3])], 'paste.png', {
+        type: 'image/png',
+      })
+    )
+
+    const oversizedResponse = await fetchHandler.call(
+      {} as Bun.Server<unknown>,
+      new Request('http://localhost/api/paste-image', {
+        method: 'POST',
+        body: oversized,
+      }),
+      {} as Bun.Server<unknown>
+    )
+
+    if (!oversizedResponse) {
+      throw new Error('Expected response for oversized paste-image')
+    }
+
+    expect(oversizedResponse.status).toBe(413)
+  })
+
   test('returns 500 when paste-image upload fails', async () => {
     const { serveOptions } = await loadIndex()
     const fetchHandler = serveOptions.fetch
@@ -4693,6 +4753,52 @@ describe('server startup side effects', () => {
     expect(sent).toContainEqual({ type: 'pong', seq: 123 })
   })
 
+  test('websocket and terminal input payload caps reject oversized messages', async () => {
+    configState.wsMaxPayloadBytes = 40
+    configState.terminalInputMaxBytes = 2
+    const { serveOptions, registryInstance } = await loadIndex()
+    const websocket = serveOptions.websocket
+    if (!websocket) {
+      throw new Error('WebSocket handlers not configured')
+    }
+    expect(websocket.maxPayloadLength).toBe(40)
+
+    const { ws, sent } = createWs()
+    websocket.message?.(
+      ws as never,
+      JSON.stringify({ type: 'ping', data: 'this-message-is-too-large' })
+    )
+    expect(sent).toContainEqual({
+      type: 'error',
+      message: 'Message payload too large',
+    })
+
+    sent.length = 0
+    registryInstance.sessions = [baseSession]
+    ws.data.currentSessionId = baseSession.id
+    ws.data.terminal = new TerminalProxyMock({
+      connectionId: 'ws-test',
+      sessionName: 'agentboard-ws-test',
+      baseSession: 'agentboard',
+      onData: () => {},
+    })
+
+    websocket.message?.(
+      ws as never,
+      JSON.stringify({
+        type: 'terminal-input',
+        sessionId: baseSession.id,
+        data: 'abc',
+      })
+    )
+
+    expect(sent).toContainEqual({
+      type: 'error',
+      message: 'Terminal input payload too large',
+    })
+    expect(ws.data.terminal.writes).toEqual([])
+  })
+
   test('/api/client-log returns ok for valid JSON', async () => {
     const { serveOptions } = await loadIndex()
     const fetchHandler = serveOptions.fetch
@@ -4718,6 +4824,50 @@ describe('server startup side effects', () => {
     expect(response.status).toBe(200)
     const payload = (await response.json()) as { ok: boolean }
     expect(payload.ok).toBe(true)
+  })
+
+  test('/api/client-log rejects oversized requests and event names', async () => {
+    configState.clientLogMaxBytes = 32
+    configState.clientLogEventMaxBytes = 8
+    const { serveOptions } = await loadIndex()
+    const fetchHandler = serveOptions.fetch
+    if (!fetchHandler) {
+      throw new Error('Fetch handler not configured')
+    }
+
+    const server = {} as Bun.Server<unknown>
+    const oversizedResponse = await fetchHandler.call(
+      server,
+      new Request('http://localhost/api/client-log', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ event: 'test_event', data: { value: 'too-long' } }),
+      }),
+      server
+    )
+
+    if (!oversizedResponse) {
+      throw new Error('Expected response for oversized client-log')
+    }
+
+    expect(oversizedResponse.status).toBe(413)
+
+    configState.clientLogMaxBytes = 1024
+    const eventResponse = await fetchHandler.call(
+      server,
+      new Request('http://localhost/api/client-log', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ event: 'very_long_event_name' }),
+      }),
+      server
+    )
+
+    if (!eventResponse) {
+      throw new Error('Expected response for oversized client-log event')
+    }
+
+    expect(eventResponse.status).toBe(413)
   })
 
   test('/api/client-log handles malformed body gracefully', async () => {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -141,6 +141,11 @@ const tmuxMutationTimeoutMs = Number.isFinite(tmuxMutationTimeoutMsRaw) && tmuxM
   ? Math.max(Math.floor(tmuxMutationTimeoutMsRaw), tmuxTimeoutMs)
   : Math.max(tmuxTimeoutMs * 5, 15000)
 
+function positiveIntegerFromEnv(value: string | undefined, fallback: number): number {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback
+}
+
 export const config = {
   port: Number(process.env.PORT) || 4040,
   hostname: process.env.HOSTNAME || '127.0.0.1',
@@ -191,4 +196,24 @@ export const config = {
   remoteAllowAttach,
   tmuxTimeoutMs,
   tmuxMutationTimeoutMs,
+  wsMaxPayloadBytes: positiveIntegerFromEnv(
+    process.env.AGENTBOARD_WS_MAX_PAYLOAD_BYTES,
+    1024 * 1024
+  ),
+  terminalInputMaxBytes: positiveIntegerFromEnv(
+    process.env.AGENTBOARD_TERMINAL_INPUT_MAX_BYTES,
+    64 * 1024
+  ),
+  clientLogMaxBytes: positiveIntegerFromEnv(
+    process.env.AGENTBOARD_CLIENT_LOG_MAX_BYTES,
+    64 * 1024
+  ),
+  clientLogEventMaxBytes: positiveIntegerFromEnv(
+    process.env.AGENTBOARD_CLIENT_LOG_EVENT_MAX_BYTES,
+    256
+  ),
+  pasteImageMaxBytes: positiveIntegerFromEnv(
+    process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES,
+    10 * 1024 * 1024
+  ),
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -203,6 +203,13 @@ function pruneOrphanedWsSessions(): void {
 }
 
 const MAX_DIRECTORY_ENTRIES = 200
+const pasteImageMimeToExtension = new Map([
+  ['image/gif', 'gif'],
+  ['image/jpeg', 'jpg'],
+  ['image/png', 'png'],
+  ['image/webp', 'webp'],
+])
+const textEncoder = new TextEncoder()
 
 function createConnectionId(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -210,6 +217,21 @@ function createConnectionId(): string {
   }
 
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+function getUtf8ByteLength(value: string): number {
+  return textEncoder.encode(value).byteLength
+}
+
+function isContentLengthTooLarge(c: Context, maxBytes: number): boolean {
+  const header = c.req.header('content-length')
+  if (!header) return false
+  const contentLength = Number(header)
+  return Number.isFinite(contentLength) && contentLength > maxBytes
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 checkPortAvailable(config.port)
@@ -1068,10 +1090,32 @@ registry.on('agent-sessions-active', (active) => {
 })
 
 app.post('/api/client-log', async (c) => {
+  if (isContentLengthTooLarge(c, config.clientLogMaxBytes)) {
+    return c.json({ error: 'Payload too large' }, 413)
+  }
+
   try {
-    const body = await c.req.json() as { level?: string; event: string; data?: Record<string, unknown> }
-    const level = body.level === 'warn' || body.level === 'error' || body.level === 'info' ? body.level : 'debug'
-    logger[level]('client_' + body.event, body.data)
+    const text = await c.req.text()
+    if (getUtf8ByteLength(text) > config.clientLogMaxBytes) {
+      return c.json({ error: 'Payload too large' }, 413)
+    }
+
+    const body: unknown = JSON.parse(text)
+    if (!isRecord(body) || typeof body.event !== 'string') {
+      return c.json({ ok: true })
+    }
+    if (getUtf8ByteLength(body.event) > config.clientLogEventMaxBytes) {
+      return c.json({ error: 'Event name too large' }, 413)
+    }
+
+    const level =
+      body.level === 'warn' || body.level === 'error' || body.level === 'info'
+        ? body.level
+        : 'debug'
+    logger[level](
+      'client_' + body.event,
+      isRecord(body.data) ? body.data : undefined
+    )
   } catch {
     // ignore malformed
   }
@@ -1366,20 +1410,34 @@ app.put('/api/settings/inactive-max-age-hours', putHistoryMaxAgeHours)
 
 // Image upload endpoint for iOS clipboard paste
 app.post('/api/paste-image', async (c) => {
+  if (isContentLengthTooLarge(c, config.pasteImageMaxBytes)) {
+    return c.json({ error: 'Payload too large' }, 413)
+  }
+
   try {
     const formData = await c.req.formData()
-    const file = formData.get('image') as File | null
-    if (!file) {
+    const image = formData.get('image')
+    if (!(image instanceof File)) {
       return c.json({ error: 'No image provided' }, 400)
+    }
+    if (image.size > config.pasteImageMaxBytes) {
+      return c.json({ error: 'Image too large' }, 413)
+    }
+
+    const ext = pasteImageMimeToExtension.get(image.type)
+    if (!ext) {
+      return c.json({ error: 'Unsupported image type' }, 415)
     }
 
     // Generate unique filename in temp directory
-    const ext = file.type.split('/')[1] || 'png'
     const filename = `paste-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext}`
     const filepath = `/tmp/${filename}`
 
     // Write file
-    const buffer = await file.arrayBuffer()
+    const buffer = await image.arrayBuffer()
+    if (buffer.byteLength > config.pasteImageMaxBytes) {
+      return c.json({ error: 'Image too large' }, 413)
+    }
     await Bun.write(filepath, buffer)
 
     return c.json({ path: filepath })
@@ -1460,6 +1518,7 @@ function serverFetch(req: Request, server: Server<WSData>) {
 
 const websocketHandlers = {
   idleTimeout: 40,
+  maxPayloadLength: config.wsMaxPayloadBytes,
   sendPings: true,
   perMessageDeflate: true,
   open(ws: ServerWebSocket<WSData>) {
@@ -1613,6 +1672,10 @@ function handleMessage(
     typeof rawMessage === 'string'
       ? rawMessage
       : new TextDecoder().decode(rawMessage)
+  if (getUtf8ByteLength(text) > config.wsMaxPayloadBytes) {
+    send(ws, { type: 'error', message: 'Message payload too large' })
+    return
+  }
 
   let message: ClientMessage
   try {
@@ -1668,6 +1731,14 @@ function handleMessage(
 	      detachTerminalPersistent(ws, message.sessionId)
 	      return
     case 'terminal-input':
+      if (typeof message.data !== 'string') {
+        send(ws, { type: 'error', message: 'Invalid message payload' })
+        return
+      }
+      if (getUtf8ByteLength(message.data) > config.terminalInputMaxBytes) {
+        send(ws, { type: 'error', message: 'Terminal input payload too large' })
+        return
+      }
       handleTerminalInputPersistent(ws, message.sessionId, message.data)
       return
     case 'terminal-resize':


### PR DESCRIPTION
hey guys, not an open claw, I just wanted to use your project. I don't install stuff anymore, I just fork it and have codex polish rough edges that it finds, and when they sound worth upstreaming I let it open a PR or issue for it.

let me know if this is annoying, I won't open more PRs

Best
David

---

David's AICA here: This PR adds configurable size caps around browser-controlled payloads handled by the server.

Changes:
- Adds configurable WebSocket max payload and terminal-input payload caps.
- Adds size and event-name caps for `/api/client-log` while preserving malformed-log ignore behavior.
- Adds paste-image size checks and an explicit image MIME allowlist for PNG, JPEG, GIF, and WebP.
- Documents the new environment variables and adds focused config/handler coverage.

Validation:
- `bun test src/server/__tests__/config.test.ts src/server/__tests__/isolated/indexHandlers.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
