### PR TITLE
perf(client): reduce terminal output hot-path work

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.2.50",
+  "version": "0.2.51",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -185,6 +185,10 @@ export default function App() {
 
   useEffect(() => {
     const unsubscribe = subscribe((message: ServerMessage) => {
+      if (message.type === 'terminal-output') {
+        return
+      }
+
       if (message.type === 'sessions') {
         // Detect status transitions for sound notifications before updating
         const currentSessions = useSessionStore.getState().sessions

--- a/src/client/hooks/useTerminal.ts
+++ b/src/client/hooks/useTerminal.ts
@@ -194,7 +194,7 @@ export function useTerminal({
   const useWebGLRef = useRef(useWebGL)
 
   // Output buffering with idle-based flushing
-  const outputBufferRef = useRef<string>('')
+  const outputBufferRef = useRef<string[]>([])
   const idleTimerRef = useRef<number | null>(null)
   const maxTimerRef = useRef<number | null>(null)
 
@@ -994,7 +994,7 @@ export function useTerminal({
       // Defer reset until history arrives (no blank flash).
       // Drain stale output buffer first — prevents old session's data
       // from consuming the one-shot reset meant for new session's history.
-      outputBufferRef.current = ''
+      outputBufferRef.current = []
       if (idleTimerRef.current !== null) {
         window.clearTimeout(idleTimerRef.current)
         idleTimerRef.current = null
@@ -1133,10 +1133,11 @@ export function useTerminal({
       }
 
       const terminal = terminalRef.current
-      const data = outputBufferRef.current
-      if (!terminal || !data) return
+      const chunks = outputBufferRef.current
+      if (!terminal || chunks.length === 0) return
 
-      outputBufferRef.current = ''
+      outputBufferRef.current = []
+      const data = chunks.join('')
 
       // Atomically swap: reset + write in same JS task = one rAF frame, no blank
       if (needsResetRef.current) {
@@ -1216,9 +1217,9 @@ export function useTerminal({
           switchStartRef.current = null
         }
 
-        outputBufferRef.current += isiOS
-          ? forceTextPresentation(message.data)
-          : message.data
+        outputBufferRef.current.push(
+          isiOS ? forceTextPresentation(message.data) : message.data
+        )
         scheduleFlush()
       }
 
@@ -1231,7 +1232,7 @@ export function useTerminal({
         // stay atomic (avoids blank flash from resetting before flush fires).
         // If no output arrived at all (empty pane or server dedup), reset
         // to clear stale content from the previous session.
-        if (needsResetRef.current && outputBufferRef.current) {
+        if (needsResetRef.current && outputBufferRef.current.length > 0) {
           flush()
         } else if (needsResetRef.current) {
           terminalRef.current?.reset()


### PR DESCRIPTION
David's AICA here: This PR keeps terminal output off the app-level WebSocket message path and avoids repeated string concatenation in the terminal output buffer.

Changes:
- Return early from the App-level WebSocket subscriber for terminal-output messages. Terminal output is consumed by useTerminal, so App does not need to run its session/status/sound handling chain for every chunk.
- Store pending terminal output as string chunks and join once during flush instead of repeatedly appending to one growing string.

Scope notes:
- No server/security changes.
- No wheel-scroll batching changes; this intentionally avoids revisiting #56.

Validation:
- bun test src/client/__tests__/useTerminal.test.tsx src/client/__tests__/app.test.tsx
- bun run lint
- bun run typecheck
- bun run build