### PR TITLE
feat(server): paste-image MIME allowlist and size cap (v0.2.52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ AGENTBOARD_REMOTE_SSH_OPTS=-o BatchMode=yes -o ConnectTimeout=3
 AGENTBOARD_REMOTE_ALLOW_ATTACH=false
 AGENTBOARD_REMOTE_ALLOW_CONTROL=false
 AGENTBOARD_LOG_WATCH_MODE=watch
+AGENTBOARD_PASTE_IMAGE_MAX_BYTES=10485760
 ```
 
 `HOSTNAME` controls which interfaces the server binds to (default `127.0.0.1` for localhost-only). With the default localhost binding, if Tailscale is detected the server also binds to your Tailscale IP automatically. Set to `0.0.0.0` to listen on all interfaces.
@@ -203,6 +204,8 @@ All persistent data is stored in `~/.agentboard/`: session database (`agentboard
 `AGENTBOARD_REMOTE_ALLOW_CONTROL` enables destructive remote session management (create, kill, rename) via the UI. Setting this to `true` implies `REMOTE_ALLOW_ATTACH=true`. Kill and rename are restricted to agentboard-managed sessions — externally-discovered remote sessions cannot be killed or renamed even with control enabled.
 
 `AGENTBOARD_LOG_WATCH_MODE` selects the log detection strategy: `watch` (default) uses `fs.watch` for instant file-change detection, `poll` falls back to periodic directory scanning. Use `poll` if you experience issues with filesystem notifications (e.g., on network-mounted home directories). On Linux, watch mode automatically includes a 15-second fallback poll since `fs.watch({ recursive: true })` has known platform bugs.
+
+`AGENTBOARD_PASTE_IMAGE_MAX_BYTES` caps clipboard image uploads (default 10 MB). Paste uploads are limited to PNG, JPEG, GIF, and WebP images.
 
 **SSH multiplexing (recommended):** Each poll cycle opens SSH connections to every remote host. Enable SSH connection multiplexing to reuse connections and reduce overhead from ~200-500ms to ~5ms per poll. Add to your `~/.ssh/config`:
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ AGENTBOARD_REMOTE_SSH_OPTS=-o BatchMode=yes -o ConnectTimeout=3
 AGENTBOARD_REMOTE_ALLOW_ATTACH=false
 AGENTBOARD_REMOTE_ALLOW_CONTROL=false
 AGENTBOARD_LOG_WATCH_MODE=watch
-AGENTBOARD_PASTE_IMAGE_MAX_BYTES=10485760
+AGENTBOARD_PASTE_IMAGE_MAX_BYTES=41943040
 ```
 
 `HOSTNAME` controls which interfaces the server binds to (default `127.0.0.1` for localhost-only). With the default localhost binding, if Tailscale is detected the server also binds to your Tailscale IP automatically. Set to `0.0.0.0` to listen on all interfaces.
@@ -205,7 +205,7 @@ All persistent data is stored in `~/.agentboard/`: session database (`agentboard
 
 `AGENTBOARD_LOG_WATCH_MODE` selects the log detection strategy: `watch` (default) uses `fs.watch` for instant file-change detection, `poll` falls back to periodic directory scanning. Use `poll` if you experience issues with filesystem notifications (e.g., on network-mounted home directories). On Linux, watch mode automatically includes a 15-second fallback poll since `fs.watch({ recursive: true })` has known platform bugs.
 
-`AGENTBOARD_PASTE_IMAGE_MAX_BYTES` caps clipboard image uploads (default 10 MB). Paste uploads are limited to PNG, JPEG, GIF, and WebP images.
+`AGENTBOARD_PASTE_IMAGE_MAX_BYTES` caps clipboard image uploads (default 40 MB, enough for full-resolution photos pasted as PNG). Paste uploads are limited to PNG, JPEG, GIF, and WebP images.
 
 **SSH multiplexing (recommended):** Each poll cycle opens SSH connections to every remote host. Enable SSH connection multiplexing to reuse connections and reduce overhead from ~200-500ms to ~5ms per poll. Add to your `~/.ssh/config`:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.2.51",
+  "version": "0.2.52",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/__tests__/terminalControls.test.tsx
+++ b/src/client/__tests__/terminalControls.test.tsx
@@ -8,12 +8,30 @@ const globalAny = globalThis as typeof globalThis & {
 }
 
 const originalNavigator = globalAny.navigator
+const originalFetch = globalAny.fetch
 
 const { default: TerminalControls } = await import('../components/TerminalControls')
 
 afterEach(() => {
   globalAny.navigator = originalNavigator
+  globalAny.fetch = originalFetch
 })
+
+function clipboardWithImage() {
+  return {
+    read: () =>
+      Promise.resolve([
+        {
+          types: ['image/png'],
+          getType: () =>
+            Promise.resolve(
+              new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' })
+            ),
+        },
+      ]),
+    readText: () => Promise.reject(new Error('no text')),
+  }
+}
 
 function findPasteButton(renderer: TestRenderer.ReactTestRenderer) {
   const buttons = renderer.root.findAllByType('button')
@@ -181,5 +199,134 @@ describe('TerminalControls', () => {
     })
 
     expect(sent).toEqual(['manual'])
+  })
+
+  test('paste button uploads clipboard image and sends the stored path', async () => {
+    const sent: string[] = []
+    const requests: Array<{ url: string; init?: RequestInit }> = []
+
+    globalAny.navigator = {
+      vibrate: () => true,
+      clipboard: clipboardWithImage(),
+    } as unknown as Navigator
+
+    globalAny.fetch = (async (url: string, init?: RequestInit) => {
+      requests.push({ url, init })
+      return new Response(JSON.stringify({ path: '/tmp/paste-test.png' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as unknown as typeof fetch
+
+    const renderer = TestRenderer.create(
+      <TerminalControls
+        onSendKey={(key) => sent.push(key)}
+        sessions={[{ id: 'session-1', name: 'alpha', status: 'working' }]}
+        currentSessionId="session-1"
+        onSelectSession={() => {}}
+      />
+    )
+
+    const pasteButton = findPasteButton(renderer)
+    if (!pasteButton) {
+      throw new Error('Expected paste button')
+    }
+
+    await act(async () => {
+      await pasteButton.props.onClick()
+    })
+
+    expect(requests).toHaveLength(1)
+    expect(requests[0]?.url).toBe('/api/paste-image')
+    expect(sent).toEqual(['/tmp/paste-test.png'])
+  })
+
+  test('shows the server error when an image upload is rejected', async () => {
+    const sent: string[] = []
+
+    globalAny.navigator = {
+      vibrate: () => true,
+      clipboard: clipboardWithImage(),
+    } as unknown as Navigator
+
+    globalAny.fetch = (async () =>
+      new Response(JSON.stringify({ error: 'Image too large' }), {
+        status: 413,
+        headers: { 'content-type': 'application/json' },
+      })) as unknown as typeof fetch
+
+    const renderer = TestRenderer.create(
+      <TerminalControls
+        onSendKey={(key) => sent.push(key)}
+        sessions={[{ id: 'session-1', name: 'alpha', status: 'working' }]}
+        currentSessionId="session-1"
+        onSelectSession={() => {}}
+      />
+    )
+
+    const pasteButton = findPasteButton(renderer)
+    if (!pasteButton) {
+      throw new Error('Expected paste button')
+    }
+
+    await act(async () => {
+      await pasteButton.props.onClick()
+    })
+
+    // Nothing was pasted, and the paste modal opens showing the failure
+    expect(sent).toEqual([])
+    const alert = renderer.root
+      .findAllByType('p')
+      .find((p) => p.props.role === 'alert')
+    if (!alert) {
+      throw new Error('Expected upload error message')
+    }
+    expect(alert.props.children).toBe('Image too large')
+  })
+
+  test('clears the upload error when the paste modal is cancelled', async () => {
+    globalAny.navigator = {
+      vibrate: () => true,
+      clipboard: clipboardWithImage(),
+    } as unknown as Navigator
+
+    globalAny.fetch = (async () =>
+      new Response(JSON.stringify({ error: 'Unsupported image type' }), {
+        status: 415,
+        headers: { 'content-type': 'application/json' },
+      })) as unknown as typeof fetch
+
+    const renderer = TestRenderer.create(
+      <TerminalControls
+        onSendKey={() => {}}
+        sessions={[{ id: 'session-1', name: 'alpha', status: 'working' }]}
+        currentSessionId="session-1"
+        onSelectSession={() => {}}
+      />
+    )
+
+    const pasteButton = findPasteButton(renderer)
+    if (!pasteButton) {
+      throw new Error('Expected paste button')
+    }
+
+    await act(async () => {
+      await pasteButton.props.onClick()
+    })
+
+    const cancelButton = renderer.root
+      .findAllByType('button')
+      .find((button) => button.props.children === 'Cancel')
+    if (!cancelButton) {
+      throw new Error('Expected cancel button')
+    }
+
+    act(() => {
+      cancelButton.props.onClick()
+    })
+
+    expect(
+      renderer.root.findAllByType('p').some((p) => p.props.role === 'alert')
+    ).toBe(false)
   })
 })

--- a/src/client/components/TerminalControls.tsx
+++ b/src/client/components/TerminalControls.tsx
@@ -114,6 +114,36 @@ const statusDot: Record<Session['status'], string> = {
   unknown: 'bg-muted',
 }
 
+/**
+ * Uploads a clipboard image to the server. Returns the stored file path, or
+ * the failure message (e.g. the server's "Image too large" / "Unsupported
+ * image type") so callers can show it instead of dropping the paste silently.
+ */
+async function uploadPasteImage(
+  blob: Blob,
+  filename: string
+): Promise<{ path: string } | { error: string }> {
+  try {
+    const formData = new FormData()
+    formData.append('image', blob, filename)
+    const res = await fetch('/api/paste-image', { method: 'POST', body: formData })
+    if (res.ok) {
+      const { path } = (await res.json()) as { path: string }
+      return { path }
+    }
+    let error = 'Image upload failed'
+    try {
+      const body = (await res.json()) as { error?: unknown }
+      if (typeof body.error === 'string') error = body.error
+    } catch {
+      // non-JSON error response; keep the generic message
+    }
+    return { error }
+  } catch {
+    return { error: 'Image upload failed' }
+  }
+}
+
 export default function TerminalControls({
   onSendKey,
   disabled = false,
@@ -127,6 +157,7 @@ export default function TerminalControls({
 }: TerminalControlsProps) {
   const [showPasteInput, setShowPasteInput] = useState(false)
   const [pasteValue, setPasteValue] = useState('')
+  const [pasteError, setPasteError] = useState<string | null>(null)
   const [isUploading, setIsUploading] = useState(false)
   const [ctrlActive, setCtrlActive] = useState(false)
   const pasteInputRef = useRef<HTMLInputElement>(null)
@@ -203,16 +234,19 @@ export default function TerminalControls({
           if (!blob) continue
 
           setIsUploading(true)
+          setPasteError(null)
           try {
-            const formData = new FormData()
-            formData.append('image', blob, `paste.${item.type.split('/')[1] || 'png'}`)
-            const res = await fetch('/api/paste-image', { method: 'POST', body: formData })
-            if (res.ok) {
-              const { path } = await res.json()
-              onSendKey(path)
+            const result = await uploadPasteImage(
+              blob,
+              `paste.${item.type.split('/')[1] || 'png'}`
+            )
+            if ('path' in result) {
+              onSendKey(result.path)
               setShowPasteInput(false)
               setPasteValue('')
               onRefocus?.()
+            } else {
+              setPasteError(result.error)
             }
           } finally {
             setIsUploading(false)
@@ -264,6 +298,7 @@ export default function TerminalControls({
     // Check if keyboard was visible before we do anything
     const wasKeyboardVisible = isKeyboardVisible?.() ?? false
     triggerHaptic()
+    setPasteError(null)
 
     // Try Clipboard API with image support
     try {
@@ -273,19 +308,23 @@ export default function TerminalControls({
         const imageType = item.types.find((t) => t.startsWith('image/'))
         if (imageType) {
           const blob = await item.getType(imageType)
-          // Upload image to server
-          const formData = new FormData()
-          formData.append('image', blob, `paste.${imageType.split('/')[1] || 'png'}`)
-          const res = await fetch('/api/paste-image', { method: 'POST', body: formData })
-          if (res.ok) {
-            const { path } = await res.json()
+          const result = await uploadPasteImage(
+            blob,
+            `paste.${imageType.split('/')[1] || 'png'}`
+          )
+          if ('path' in result) {
             // Send file path - Claude Code can reference images by path
-            onSendKey(path)
+            onSendKey(result.path)
             if (wasKeyboardVisible) {
               onRefocus?.()
             }
             return
           }
+          // Surface the failure in the paste modal instead of dropping the paste
+          setPasteError(result.error)
+          setShowPasteInput(true)
+          setPasteValue('')
+          return
         }
 
         // Check for text
@@ -329,12 +368,14 @@ export default function TerminalControls({
     }
     setShowPasteInput(false)
     setPasteValue('')
+    setPasteError(null)
     onRefocus?.()
   }
 
   const handlePasteCancel = () => {
     setShowPasteInput(false)
     setPasteValue('')
+    setPasteError(null)
     onRefocus?.()
   }
 
@@ -593,6 +634,11 @@ export default function TerminalControls({
                 className="w-full h-11 px-3 text-[16px] bg-surface border border-border rounded-md text-primary placeholder:text-muted outline-none focus:border-accent"
                 style={{ fontSize: '16px' }}
               />
+            )}
+            {pasteError && (
+              <p className="mt-2 text-xs text-danger" role="alert">
+                {pasteError}
+              </p>
             )}
             <div className="flex justify-end gap-2 mt-4">
               <button

--- a/src/server/__tests__/config.test.ts
+++ b/src/server/__tests__/config.test.ts
@@ -125,7 +125,7 @@ describe('config', () => {
     expect(config.remoteAllowControl).toBe(false)
     expect(config.tmuxTimeoutMs).toBe(3000)
     expect(config.tmuxMutationTimeoutMs).toBe(15000)
-    expect(config.pasteImageMaxBytes).toBe(10 * 1024 * 1024)
+    expect(config.pasteImageMaxBytes).toBe(40 * 1024 * 1024)
   })
 
   test('parses env overrides and trims discover prefixes', async () => {
@@ -204,13 +204,13 @@ describe('config', () => {
 
   test('falls back to default paste image cap for invalid values', async () => {
     process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES = '0'
-    expect((await loadConfig('paste-zero')).pasteImageMaxBytes).toBe(10 * 1024 * 1024)
+    expect((await loadConfig('paste-zero')).pasteImageMaxBytes).toBe(40 * 1024 * 1024)
 
     process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES = '-1'
-    expect((await loadConfig('paste-negative')).pasteImageMaxBytes).toBe(10 * 1024 * 1024)
+    expect((await loadConfig('paste-negative')).pasteImageMaxBytes).toBe(40 * 1024 * 1024)
 
     process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES = 'lots'
-    expect((await loadConfig('paste-nan')).pasteImageMaxBytes).toBe(10 * 1024 * 1024)
+    expect((await loadConfig('paste-nan')).pasteImageMaxBytes).toBe(40 * 1024 * 1024)
 
     process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES = '1024.9'
     expect((await loadConfig('paste-fractional')).pasteImageMaxBytes).toBe(1024)

--- a/src/server/__tests__/config.test.ts
+++ b/src/server/__tests__/config.test.ts
@@ -32,6 +32,7 @@ const ORIGINAL_ENV = {
   AGENTBOARD_REMOTE_ALLOW_CONTROL: process.env.AGENTBOARD_REMOTE_ALLOW_CONTROL,
   AGENTBOARD_TMUX_TIMEOUT_MS: process.env.AGENTBOARD_TMUX_TIMEOUT_MS,
   AGENTBOARD_TMUX_MUTATION_TIMEOUT_MS: process.env.AGENTBOARD_TMUX_MUTATION_TIMEOUT_MS,
+  AGENTBOARD_PASTE_IMAGE_MAX_BYTES: process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES,
 }
 
 const ENV_KEYS = Object.keys(ORIGINAL_ENV) as Array<keyof typeof ORIGINAL_ENV>
@@ -81,6 +82,7 @@ async function loadConfig(tag: string) {
     remoteAllowControl: boolean
     tmuxTimeoutMs: number
     tmuxMutationTimeoutMs: number
+    pasteImageMaxBytes: number
   }
 }
 
@@ -123,6 +125,7 @@ describe('config', () => {
     expect(config.remoteAllowControl).toBe(false)
     expect(config.tmuxTimeoutMs).toBe(3000)
     expect(config.tmuxMutationTimeoutMs).toBe(15000)
+    expect(config.pasteImageMaxBytes).toBe(10 * 1024 * 1024)
   })
 
   test('parses env overrides and trims discover prefixes', async () => {
@@ -156,6 +159,7 @@ describe('config', () => {
     process.env.AGENTBOARD_REMOTE_ALLOW_CONTROL = 'true'
     process.env.AGENTBOARD_TMUX_TIMEOUT_MS = '4500'
     process.env.AGENTBOARD_TMUX_MUTATION_TIMEOUT_MS = '12000'
+    process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES = '4096'
 
     const config = await loadConfig('overrides')
     expect(config.port).toBe(9090)
@@ -188,6 +192,7 @@ describe('config', () => {
     expect(config.remoteAllowControl).toBe(true)
     expect(config.tmuxTimeoutMs).toBe(4500)
     expect(config.tmuxMutationTimeoutMs).toBe(12000)
+    expect(config.pasteImageMaxBytes).toBe(4096)
   })
 
   test('defaults to watch mode for invalid AGENTBOARD_LOG_WATCH_MODE', async () => {
@@ -195,5 +200,19 @@ describe('config', () => {
 
     const config = await loadConfig('invalid-watch-mode')
     expect(config.logWatchMode).toBe('watch')
+  })
+
+  test('falls back to default paste image cap for invalid values', async () => {
+    process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES = '0'
+    expect((await loadConfig('paste-zero')).pasteImageMaxBytes).toBe(10 * 1024 * 1024)
+
+    process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES = '-1'
+    expect((await loadConfig('paste-negative')).pasteImageMaxBytes).toBe(10 * 1024 * 1024)
+
+    process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES = 'lots'
+    expect((await loadConfig('paste-nan')).pasteImageMaxBytes).toBe(10 * 1024 * 1024)
+
+    process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES = '1024.9'
+    expect((await loadConfig('paste-fractional')).pasteImageMaxBytes).toBe(1024)
   })
 })

--- a/src/server/__tests__/integration.test.ts
+++ b/src/server/__tests__/integration.test.ts
@@ -40,6 +40,7 @@ if (!tmuxAvailable || !localhostBindable) {
           DISCOVER_PREFIXES: '',
           AGENTBOARD_LOG_POLL_MS: '0',
           AGENTBOARD_DB_PATH: dbPath,
+          AGENTBOARD_PASTE_IMAGE_MAX_BYTES: '1024',
         },
         stdout: 'pipe',
         stderr: 'pipe',
@@ -130,6 +131,39 @@ if (!tmuxAvailable || !localhostBindable) {
       })
 
       expect(response.status).toBe(400)
+    })
+
+    test('paste-image endpoint rejects unsupported types', async () => {
+      const formData = new FormData()
+      const blob = new Blob([new Uint8Array([0, 1, 2, 3])], {
+        type: 'text/plain',
+      })
+      formData.append('image', blob, 'paste.txt')
+
+      const response = await fetch(`http://${testHost}:${port}/api/paste-image`, {
+        method: 'POST',
+        body: formData,
+      })
+
+      expect(response.status).toBe(415)
+      const payload = (await response.json()) as { error: string }
+      expect(payload.error).toBe('Unsupported image type')
+    })
+
+    test('paste-image endpoint rejects oversized uploads', async () => {
+      // Server is started with AGENTBOARD_PASTE_IMAGE_MAX_BYTES=1024
+      const formData = new FormData()
+      const blob = new Blob([new Uint8Array(2048)], { type: 'image/png' })
+      formData.append('image', blob, 'paste.png')
+
+      const response = await fetch(`http://${testHost}:${port}/api/paste-image`, {
+        method: 'POST',
+        body: formData,
+      })
+
+      expect(response.status).toBe(413)
+      const payload = (await response.json()) as { error: string }
+      expect(payload.error).toBe('Image too large')
     })
   })
 }

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -81,7 +81,7 @@ const defaultConfig = {
   remoteAllowAttach: false,
   tmuxTimeoutMs: 3000,
   tmuxMutationTimeoutMs: 15000,
-  pasteImageMaxBytes: 10 * 1024 * 1024,
+  pasteImageMaxBytes: 40 * 1024 * 1024,
 }
 
 const configState = { ...defaultConfig }
@@ -4656,7 +4656,7 @@ describe('server fetch handlers', () => {
       server,
       new Request('http://localhost/api/paste-image', {
         method: 'POST',
-        headers: { 'content-length': String(20 * 1024 * 1024) },
+        headers: { 'content-length': String(64 * 1024 * 1024) },
         body: 'x',
       }),
       server

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -81,6 +81,7 @@ const defaultConfig = {
   remoteAllowAttach: false,
   tmuxTimeoutMs: 3000,
   tmuxMutationTimeoutMs: 15000,
+  pasteImageMaxBytes: 10 * 1024 * 1024,
 }
 
 const configState = { ...defaultConfig }
@@ -4501,6 +4502,171 @@ describe('server fetch handlers', () => {
     expect(response.status).toBe(500)
     const payload = (await response.json()) as { error: string }
     expect(payload.error).toBe('write-failed')
+  })
+
+  test('maps each allowed paste-image type to its extension', async () => {
+    const { serveOptions } = await loadIndex()
+    const fetchHandler = serveOptions.fetch
+    if (!fetchHandler) {
+      throw new Error('Fetch handler not configured')
+    }
+    const server = {} as Bun.Server<unknown>
+
+    // Bun's multipart parser derives File.type from the part filename's
+    // extension, ignoring the declared blob type — so each upload's filename
+    // must carry the extension for the type under test.
+    const cases = [
+      ['paste.png', 'image/png', '.png'],
+      ['paste.jpeg', 'image/jpeg', '.jpg'],
+      ['paste.gif', 'image/gif', '.gif'],
+      ['paste.webp', 'image/webp', '.webp'],
+    ] as const
+
+    for (const [uploadName, mime, extension] of cases) {
+      const formData = new FormData()
+      formData.append(
+        'image',
+        new File([new Uint8Array([1, 2, 3])], uploadName, { type: mime })
+      )
+
+      const response = await fetchHandler.call(
+        server,
+        new Request('http://localhost/api/paste-image', {
+          method: 'POST',
+          body: formData,
+        }),
+        server
+      )
+
+      if (!response) {
+        throw new Error(`Expected response for ${mime} upload`)
+      }
+
+      expect(response.status).toBe(200)
+      const payload = (await response.json()) as { path: string }
+      expect(payload.path.startsWith('/tmp/paste-')).toBe(true)
+      expect(payload.path.endsWith(extension)).toBe(true)
+    }
+  })
+
+  test('rejects paste-image uploads with unsupported types', async () => {
+    const { serveOptions } = await loadIndex()
+    const fetchHandler = serveOptions.fetch
+    if (!fetchHandler) {
+      throw new Error('Fetch handler not configured')
+    }
+    const server = {} as Bun.Server<unknown>
+
+    const unsupported = [
+      ['paste.txt', 'text/plain'],
+      ['paste.svg', 'image/svg+xml'],
+      ['paste.pdf', 'application/pdf'],
+      ['paste.heic', 'image/heic'],
+    ] as const
+
+    for (const [uploadName, mime] of unsupported) {
+      const formData = new FormData()
+      formData.append(
+        'image',
+        new File([new Uint8Array([1, 2, 3])], uploadName, { type: mime })
+      )
+
+      const response = await fetchHandler.call(
+        server,
+        new Request('http://localhost/api/paste-image', {
+          method: 'POST',
+          body: formData,
+        }),
+        server
+      )
+
+      if (!response) {
+        throw new Error(`Expected response for ${mime} upload`)
+      }
+
+      expect(response.status).toBe(415)
+      const payload = (await response.json()) as { error: string }
+      expect(payload.error).toBe('Unsupported image type')
+    }
+
+    // A plain string field named 'image' is not a file upload
+    const stringForm = new FormData()
+    stringForm.append('image', 'not-a-file')
+
+    const stringResponse = await fetchHandler.call(
+      server,
+      new Request('http://localhost/api/paste-image', {
+        method: 'POST',
+        body: stringForm,
+      }),
+      server
+    )
+
+    if (!stringResponse) {
+      throw new Error('Expected response for string image field')
+    }
+
+    expect(stringResponse.status).toBe(400)
+  })
+
+  test('rejects oversized paste-image uploads', async () => {
+    configState.pasteImageMaxBytes = 2
+    const { serveOptions } = await loadIndex()
+    const fetchHandler = serveOptions.fetch
+    if (!fetchHandler) {
+      throw new Error('Fetch handler not configured')
+    }
+    const server = {} as Bun.Server<unknown>
+
+    const formData = new FormData()
+    formData.append(
+      'image',
+      new File([new Uint8Array([1, 2, 3])], 'paste.png', { type: 'image/png' })
+    )
+
+    const oversizedResponse = await fetchHandler.call(
+      server,
+      new Request('http://localhost/api/paste-image', {
+        method: 'POST',
+        body: formData,
+      }),
+      server
+    )
+
+    if (!oversizedResponse) {
+      throw new Error('Expected response for oversized upload')
+    }
+
+    expect(oversizedResponse.status).toBe(413)
+    const payload = (await oversizedResponse.json()) as { error: string }
+    expect(payload.error).toBe('Image too large')
+  })
+
+  test('rejects paste-image requests by content-length before parsing the body', async () => {
+    const { serveOptions } = await loadIndex()
+    const fetchHandler = serveOptions.fetch
+    if (!fetchHandler) {
+      throw new Error('Fetch handler not configured')
+    }
+    const server = {} as Bun.Server<unknown>
+
+    // The body is not valid multipart, so a 413 (rather than the 500 a
+    // formData() parse failure produces) proves the header check ran first.
+    const response = await fetchHandler.call(
+      server,
+      new Request('http://localhost/api/paste-image', {
+        method: 'POST',
+        headers: { 'content-length': String(20 * 1024 * 1024) },
+        body: 'x',
+      }),
+      server
+    )
+
+    if (!response) {
+      throw new Error('Expected response for oversized content-length')
+    }
+
+    expect(response.status).toBe(413)
   })
 
   test('returns session preview for existing logs', async () => {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -141,6 +141,11 @@ const tmuxMutationTimeoutMs = Number.isFinite(tmuxMutationTimeoutMsRaw) && tmuxM
   ? Math.max(Math.floor(tmuxMutationTimeoutMsRaw), tmuxTimeoutMs)
   : Math.max(tmuxTimeoutMs * 5, 15000)
 
+const pasteImageMaxBytesRaw = Number(process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES)
+const pasteImageMaxBytes = Number.isFinite(pasteImageMaxBytesRaw) && pasteImageMaxBytesRaw > 0
+  ? Math.floor(pasteImageMaxBytesRaw)
+  : 10 * 1024 * 1024
+
 export const config = {
   port: Number(process.env.PORT) || 4040,
   hostname: process.env.HOSTNAME || '127.0.0.1',
@@ -191,4 +196,5 @@ export const config = {
   remoteAllowAttach,
   tmuxTimeoutMs,
   tmuxMutationTimeoutMs,
+  pasteImageMaxBytes,
 }

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -144,7 +144,7 @@ const tmuxMutationTimeoutMs = Number.isFinite(tmuxMutationTimeoutMsRaw) && tmuxM
 const pasteImageMaxBytesRaw = Number(process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES)
 const pasteImageMaxBytes = Number.isFinite(pasteImageMaxBytesRaw) && pasteImageMaxBytesRaw > 0
   ? Math.floor(pasteImageMaxBytesRaw)
-  : 10 * 1024 * 1024
+  : 40 * 1024 * 1024
 
 export const config = {
   port: Number(process.env.PORT) || 4040,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1364,23 +1364,43 @@ app.put('/api/settings/history-max-age-hours', putHistoryMaxAgeHours)
 app.get('/api/settings/inactive-max-age-hours', getHistoryMaxAgeHours)
 app.put('/api/settings/inactive-max-age-hours', putHistoryMaxAgeHours)
 
+// Allowed paste-image types; the extension written to /tmp comes from this map,
+// never from client-supplied values. Note Bun's multipart parser derives
+// File.type from the part filename's extension, not the declared blob type.
+const pasteImageExtensionByMime = new Map([
+  ['image/gif', 'gif'],
+  ['image/jpeg', 'jpg'],
+  ['image/png', 'png'],
+  ['image/webp', 'webp'],
+])
+
 // Image upload endpoint for iOS clipboard paste
 app.post('/api/paste-image', async (c) => {
+  // Early reject before buffering the multipart body. The header is
+  // client-controlled, so image.size below remains the authoritative check.
+  const contentLength = Number(c.req.header('content-length'))
+  if (Number.isFinite(contentLength) && contentLength > config.pasteImageMaxBytes) {
+    return c.json({ error: 'Image too large' }, 413)
+  }
+
   try {
     const formData = await c.req.formData()
-    const file = formData.get('image') as File | null
-    if (!file) {
+    const image = formData.get('image')
+    if (!(image instanceof File)) {
       return c.json({ error: 'No image provided' }, 400)
+    }
+    if (image.size > config.pasteImageMaxBytes) {
+      return c.json({ error: 'Image too large' }, 413)
+    }
+    const ext = pasteImageExtensionByMime.get(image.type)
+    if (!ext) {
+      return c.json({ error: 'Unsupported image type' }, 415)
     }
 
     // Generate unique filename in temp directory
-    const ext = file.type.split('/')[1] || 'png'
     const filename = `paste-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext}`
     const filepath = `/tmp/${filename}`
-
-    // Write file
-    const buffer = await file.arrayBuffer()
-    await Bun.write(filepath, buffer)
+    await Bun.write(filepath, image)
 
     return c.json({ path: filepath })
   } catch (error) {


### PR DESCRIPTION
Hardens `/api/paste-image` (the iOS clipboard-paste endpoint). Adapted from the worth-keeping part of #142 — thanks @dsfaccini for the idea.

## Server
- MIME allowlist: only PNG, JPEG, GIF, and WebP are accepted (415 otherwise). The `/tmp` file extension now always comes from the allowlist map — previously `file.type.split('/')[1] || 'png'` wrote arbitrary client-controlled extensions.
- Size cap via `AGENTBOARD_PASTE_IMAGE_MAX_BYTES` (default 40 MB — sized for full-resolution photos pasted as PNG; 413 over), with an early content-length rejection before the multipart body is buffered. `image.size` (parser-derived, can't be spoofed) remains the authoritative check.
- Writes the `File` directly via `Bun.write` instead of copying through `arrayBuffer()`, halving peak memory on large pastes.

## Client
- Both paste paths previously checked `res.ok` and silently dropped failed pastes. Failed uploads now show the server's error message in the paste modal.

## Notes
- Bun's multipart parser derives `File.type` from the part filename's extension, ignoring the declared blob type (verified against raw wire bytes) — documented in code comments; tests name fixtures accordingly.
- Reviewed at xhigh effort (9 finder angles + adversarial verification): no blocking findings. Known conservative edge: images within ~225 bytes of the exact cap are rejected by the content-length pre-check.

## Validation
- `bun run lint && bun run typecheck && bun run test` — 868 tests pass
- New coverage: config defaults/overrides/invalid values, all four allowed types → mapped extensions, four unsupported types → 415, oversized → 413, content-length early rejection, integration tests over a real server, client success/error/clear paths
