### PR TITLE
fix: handle clipboard image paste by agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/__tests__/useTerminal.test.tsx
+++ b/src/client/__tests__/useTerminal.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, jest, test, mock } from 'bun:test'
 import TestRenderer, { act } from 'react-test-renderer'
-import type { ServerMessage } from '@shared/types'
+import type { AgentType, ServerMessage } from '@shared/types'
 import type { ITheme } from '@xterm/xterm'
 import type { ConnectionStatus } from '../stores/sessionStore'
 
@@ -262,6 +262,7 @@ function createContainerMock() {
 function TerminalHarness(props: {
   sessionId: string | null
   tmuxTarget?: string | null
+  agentType?: AgentType
   connectionStatus?: ConnectionStatus
   connectionEpoch?: number
   sendMessage: (message: any) => void
@@ -1224,6 +1225,63 @@ describe('useTerminal', () => {
     })
   })
 
+  test('Ctrl+V on macOS sends literal Ctrl+V for Codex image paste', async () => {
+    globalAny.navigator = {
+      userAgent: 'Chrome',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      clipboard: {
+        writeText: () => Promise.resolve(),
+        readText: () => Promise.resolve(''),
+      },
+    } as unknown as Navigator
+
+    const sendCalls: Array<Record<string, unknown>> = []
+    const { container } = createContainerMock()
+
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          agentType="codex"
+          sendMessage={(message) => sendCalls.push(message)}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+        {
+          createNodeMock: () => container,
+        },
+      )
+      await Promise.resolve()
+    })
+
+    const terminal = TerminalMock.instances[0]
+    if (!terminal) throw new Error('Expected terminal instance')
+
+    const result = terminal.emitKey({
+      key: 'v',
+      type: 'keydown',
+      ctrlKey: true,
+      metaKey: false,
+    })
+
+    expect(result).toBe(false)
+    expect(sendCalls).toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-1',
+      data: '\x16',
+    })
+    expect(terminal.pasteCalls).toEqual([])
+
+    act(() => {
+      renderer.unmount()
+    })
+  })
+
   test('Ctrl+V while in tmux copy-mode exits copy-mode first', async () => {
     globalAny.navigator = {
       userAgent: 'Chrome',
@@ -1427,6 +1485,595 @@ describe('useTerminal', () => {
 
     act(() => { renderer.unmount() })
     globalThis.fetch = originalFetch
+  })
+
+  test('Cmd+V with non-image file metadata still sends Finder path on macOS', async () => {
+    jest.useFakeTimers()
+    globalAny.navigator = {
+      userAgent: 'Chrome',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      clipboard: {
+        writeText: () => Promise.resolve(),
+        readText: () => Promise.resolve(''),
+      },
+    } as unknown as Navigator
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      if (String(input) === '/api/clipboard-file-path') {
+        return { ok: true, json: async () => ({ path: '/Users/test/report.pdf', isImage: false }) } as Response
+      }
+      return originalFetch(input)
+    }) as typeof fetch
+
+    const sendCalls: Array<Record<string, unknown>> = []
+    const { container, dispatchEvent } = createContainerMock()
+
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          sendMessage={(message) => sendCalls.push(message)}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+        { createNodeMock: () => container },
+      )
+      await Promise.resolve()
+    })
+
+    const terminal = TerminalMock.instances[0]
+    if (!terminal) throw new Error('Expected terminal instance')
+
+    terminal.emitKey({ key: 'v', type: 'keydown', metaKey: true, ctrlKey: false })
+
+    dispatchEvent('paste', {
+      type: 'paste',
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      clipboardData: {
+        files: [{ type: 'application/pdf' }],
+        items: [{ kind: 'file', type: 'application/pdf' }],
+        getData: () => '',
+      },
+    })
+
+    await act(async () => {
+      jest.advanceTimersByTime(100)
+    })
+
+    expect(sendCalls).toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-1',
+      data: '/Users/test/report.pdf',
+    })
+    expect(sendCalls).not.toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-1',
+      data: '\x1b[200~\x1b[201~',
+    })
+    expect(terminal.pasteCalls).toEqual([])
+
+    act(() => { renderer.unmount() })
+    globalThis.fetch = originalFetch
+  })
+
+  test('Cmd+V with macOS clipboard image path sends empty bracket paste', async () => {
+    jest.useFakeTimers()
+    globalAny.navigator = {
+      userAgent: 'Chrome',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      clipboard: {
+        writeText: () => Promise.resolve(),
+        readText: () => Promise.resolve(''),
+      },
+    } as unknown as Navigator
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      if (String(input) === '/api/clipboard-file-path') {
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/Users/test/Documents/Screenshots/CleanShot 2026-06-13 at 10.41.52@2x.png',
+            isImage: true,
+          }),
+        } as Response
+      }
+      return originalFetch(input)
+    }) as typeof fetch
+
+    const sendCalls: Array<Record<string, unknown>> = []
+    const { container, dispatchEvent } = createContainerMock()
+
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          sendMessage={(message) => sendCalls.push(message)}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+        { createNodeMock: () => container },
+      )
+      await Promise.resolve()
+    })
+
+    const terminal = TerminalMock.instances[0]
+    if (!terminal) throw new Error('Expected terminal instance')
+
+    terminal.emitKey({ key: 'v', type: 'keydown', metaKey: true, ctrlKey: false })
+
+    dispatchEvent('paste', {
+      type: 'paste',
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      clipboardData: { getData: () => '' },
+    })
+
+    await act(async () => {
+      jest.advanceTimersByTime(100)
+    })
+
+    expect(sendCalls).toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-1',
+      data: '\x1b[200~\x1b[201~',
+    })
+    expect(terminal.pasteCalls).toEqual([])
+
+    act(() => { renderer.unmount() })
+    globalThis.fetch = originalFetch
+  })
+
+  test('Cmd+V with macOS clipboard image path sends literal Ctrl+V for Codex', async () => {
+    jest.useFakeTimers()
+    globalAny.navigator = {
+      userAgent: 'Chrome',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      clipboard: {
+        writeText: () => Promise.resolve(),
+        readText: () => Promise.resolve(''),
+      },
+    } as unknown as Navigator
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      if (String(input) === '/api/clipboard-file-path') {
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/Users/test/Documents/Screenshots/CleanShot 2026-06-13 at 10.41.52@2x.png',
+            isImage: true,
+          }),
+        } as Response
+      }
+      return originalFetch(input)
+    }) as typeof fetch
+
+    const sendCalls: Array<Record<string, unknown>> = []
+    const { container, dispatchEvent } = createContainerMock()
+
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          agentType="codex"
+          sendMessage={(message) => sendCalls.push(message)}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+        { createNodeMock: () => container },
+      )
+      await Promise.resolve()
+    })
+
+    const terminal = TerminalMock.instances[0]
+    if (!terminal) throw new Error('Expected terminal instance')
+
+    terminal.emitKey({ key: 'v', type: 'keydown', metaKey: true, ctrlKey: false })
+
+    dispatchEvent('paste', {
+      type: 'paste',
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      clipboardData: { getData: () => '' },
+    })
+
+    await act(async () => {
+      jest.advanceTimersByTime(100)
+    })
+
+    expect(sendCalls).toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-1',
+      data: '\x16',
+    })
+    expect(terminal.pasteCalls).toEqual([])
+
+    act(() => { renderer.unmount() })
+    globalThis.fetch = originalFetch
+  })
+
+  test('Cmd+V image paste uses latest agent type after session switch', async () => {
+    jest.useFakeTimers()
+    globalAny.navigator = {
+      userAgent: 'Chrome',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      clipboard: {
+        writeText: () => Promise.resolve(),
+        readText: () => Promise.resolve(''),
+      },
+    } as unknown as Navigator
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      if (String(input) === '/api/clipboard-file-path') {
+        return {
+          ok: true,
+          json: async () => ({
+            path: '/Users/test/Documents/Screenshots/paste.png',
+            isImage: true,
+          }),
+        } as Response
+      }
+      return originalFetch(input)
+    }) as typeof fetch
+
+    const sendCalls: Array<Record<string, unknown>> = []
+    const { container, dispatchEvent } = createContainerMock()
+
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          agentType="claude"
+          sendMessage={(message) => sendCalls.push(message)}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+        { createNodeMock: () => container },
+      )
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      renderer.update(
+        <TerminalHarness
+          sessionId="session-2"
+          tmuxTarget="agentboard:@2"
+          agentType="codex"
+          sendMessage={(message) => sendCalls.push(message)}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+      )
+      await Promise.resolve()
+    })
+
+    const terminal = TerminalMock.instances[0]
+    if (!terminal) throw new Error('Expected terminal instance')
+
+    terminal.emitKey({ key: 'v', type: 'keydown', metaKey: true, ctrlKey: false })
+
+    dispatchEvent('paste', {
+      type: 'paste',
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      clipboardData: { getData: () => '' },
+    })
+
+    await act(async () => {
+      jest.advanceTimersByTime(100)
+    })
+
+    expect(sendCalls).toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-2',
+      data: '\x16',
+    })
+    expect(sendCalls).not.toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-2',
+      data: '\x1b[200~\x1b[201~',
+    })
+
+    act(() => { renderer.unmount() })
+    globalThis.fetch = originalFetch
+  })
+
+  test('Cmd+V with empty macOS clipboard and no Finder path sends empty bracket paste', async () => {
+    jest.useFakeTimers()
+    globalAny.navigator = {
+      userAgent: 'Chrome',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      clipboard: {
+        writeText: () => Promise.resolve(),
+        readText: () => Promise.resolve(''),
+      },
+    } as unknown as Navigator
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      if (String(input) === '/api/clipboard-file-path') {
+        return { ok: true, json: async () => ({ path: null }) } as Response
+      }
+      return originalFetch(input)
+    }) as typeof fetch
+
+    const sendCalls: Array<Record<string, unknown>> = []
+    const { container, dispatchEvent } = createContainerMock()
+
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          sendMessage={(message) => sendCalls.push(message)}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+        { createNodeMock: () => container },
+      )
+      await Promise.resolve()
+    })
+
+    const terminal = TerminalMock.instances[0]
+    if (!terminal) throw new Error('Expected terminal instance')
+
+    terminal.emitKey({ key: 'v', type: 'keydown', metaKey: true, ctrlKey: false })
+
+    dispatchEvent('paste', {
+      type: 'paste',
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      clipboardData: { getData: () => '' },
+    })
+
+    await act(async () => {
+      jest.advanceTimersByTime(100)
+    })
+
+    expect(sendCalls).toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-1',
+      data: '\x1b[200~\x1b[201~',
+    })
+    expect(terminal.pasteCalls).toEqual([])
+
+    act(() => { renderer.unmount() })
+    globalThis.fetch = originalFetch
+  })
+
+  test('Cmd+V with image clipboard metadata sends empty bracket paste', async () => {
+    jest.useFakeTimers()
+    globalAny.navigator = {
+      userAgent: 'Chrome',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      clipboard: {
+        writeText: () => Promise.resolve(),
+        readText: () => Promise.resolve(''),
+      },
+    } as unknown as Navigator
+
+    const originalFetch = globalThis.fetch
+    const fetchCalls: string[] = []
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      fetchCalls.push(String(input))
+      if (String(input) === '/api/clipboard-file-path') {
+        return { ok: true, json: async () => ({ path: '/Users/test/file.txt' }) } as Response
+      }
+      return originalFetch(input)
+    }) as typeof fetch
+
+    const sendCalls: Array<Record<string, unknown>> = []
+    const { container, dispatchEvent } = createContainerMock()
+
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          sendMessage={(message) => sendCalls.push(message)}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+        { createNodeMock: () => container },
+      )
+      await Promise.resolve()
+    })
+
+    const terminal = TerminalMock.instances[0]
+    if (!terminal) throw new Error('Expected terminal instance')
+
+    terminal.emitKey({ key: 'v', type: 'keydown', metaKey: true, ctrlKey: false })
+
+    dispatchEvent('paste', {
+      type: 'paste',
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      clipboardData: {
+        files: { length: 1 },
+        items: [{ kind: 'file', type: 'image/png' }],
+        getData: () => '',
+      },
+    })
+
+    await act(async () => {
+      jest.advanceTimersByTime(100)
+    })
+
+    expect(sendCalls).toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-1',
+      data: '\x1b[200~\x1b[201~',
+    })
+    expect(fetchCalls).not.toContain('/api/clipboard-file-path')
+    expect(terminal.pasteCalls).toEqual([])
+
+    act(() => { renderer.unmount() })
+    globalThis.fetch = originalFetch
+  })
+
+  test('Cmd+V with image clipboard metadata sends literal Ctrl+V for Codex', async () => {
+    jest.useFakeTimers()
+    globalAny.navigator = {
+      userAgent: 'Chrome',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      clipboard: {
+        writeText: () => Promise.resolve(),
+        readText: () => Promise.resolve(''),
+      },
+    } as unknown as Navigator
+
+    const originalFetch = globalThis.fetch
+    const fetchCalls: string[] = []
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      fetchCalls.push(String(input))
+      return originalFetch(input)
+    }) as typeof fetch
+
+    const sendCalls: Array<Record<string, unknown>> = []
+    const { container, dispatchEvent } = createContainerMock()
+
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          agentType="codex"
+          sendMessage={(message) => sendCalls.push(message)}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+        { createNodeMock: () => container },
+      )
+      await Promise.resolve()
+    })
+
+    const terminal = TerminalMock.instances[0]
+    if (!terminal) throw new Error('Expected terminal instance')
+
+    terminal.emitKey({ key: 'v', type: 'keydown', metaKey: true, ctrlKey: false })
+
+    dispatchEvent('paste', {
+      type: 'paste',
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      clipboardData: {
+        files: { length: 1 },
+        items: [{ kind: 'file', type: 'image/png' }],
+        getData: () => '',
+      },
+    })
+
+    await act(async () => {
+      jest.advanceTimersByTime(100)
+    })
+
+    expect(sendCalls).toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-1',
+      data: '\x16',
+    })
+    expect(fetchCalls).not.toContain('/api/clipboard-file-path')
+    expect(terminal.pasteCalls).toEqual([])
+
+    act(() => { renderer.unmount() })
+    globalThis.fetch = originalFetch
+  })
+
+  test('Cmd+V with macOS shared-pasteboard path sends empty bracket paste', async () => {
+    jest.useFakeTimers()
+    globalAny.navigator = {
+      userAgent: 'Chrome',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      clipboard: {
+        writeText: () => Promise.resolve(),
+        readText: () => Promise.resolve(''),
+      },
+    } as unknown as Navigator
+
+    const sendCalls: Array<Record<string, unknown>> = []
+    const { container, dispatchEvent } = createContainerMock()
+
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          sendMessage={(message) => sendCalls.push(message)}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+        { createNodeMock: () => container },
+      )
+      await Promise.resolve()
+    })
+
+    const terminal = TerminalMock.instances[0]
+    if (!terminal) throw new Error('Expected terminal instance')
+
+    terminal.emitKey({ key: 'v', type: 'keydown', metaKey: true, ctrlKey: false })
+
+    dispatchEvent('paste', {
+      type: 'paste',
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      clipboardData: {
+        getData: () => '/Users/garybasin/Library/Group Containers/group.com.apple.coreservices.useractivityd/shared-pasteboard/items/88E743D0-B583-40F8-90DC-C25DF63BBFDF/CleanShot 2026-06-13 at 09.55.20.png',
+      },
+    })
+
+    await act(async () => {
+      jest.advanceTimersByTime(100)
+    })
+
+    expect(sendCalls).toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-1',
+      data: '\x1b[200~\x1b[201~',
+    })
+    expect(terminal.pasteCalls).toEqual([])
+
+    act(() => { renderer.unmount() })
   })
 
   test('Cmd+V does nothing when no session is attached', async () => {

--- a/src/client/components/Terminal.tsx
+++ b/src/client/components/Terminal.tsx
@@ -159,6 +159,7 @@ export default function Terminal({
   const { containerRef, terminalRef, inTmuxCopyModeRef, setTmuxCopyMode, isSwitching } = useTerminal({
     sessionId: session?.id ?? null,
     tmuxTarget: session?.tmuxWindow ?? null,
+    agentType: session?.agentType,
     allowAttach: !isReadOnly,
     connectionStatus,
     connectionEpoch,

--- a/src/client/hooks/useTerminal.ts
+++ b/src/client/hooks/useTerminal.ts
@@ -7,7 +7,7 @@ import { ClipboardAddon, type ClipboardSelectionType, type IClipboardProvider } 
 import { SearchAddon } from '@xterm/addon-search'
 import { SerializeAddon } from '@xterm/addon-serialize'
 import { ProgressAddon } from '@xterm/addon-progress'
-import type { SendClientMessage, ServerMessageWithDiagnostics, SubscribeServerMessage } from '@shared/types'
+import type { AgentType, SendClientMessage, ServerMessageWithDiagnostics, SubscribeServerMessage } from '@shared/types'
 import { clientLog } from '../utils/clientLog'
 import type { ConnectionStatus } from '../stores/sessionStore'
 
@@ -69,6 +69,36 @@ const getIsMac = () => typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod
 
 /** Empty bracket paste sequence — signals a paste event without text content. */
 const BRACKET_PASTE_EMPTY = '\x1b[200~\x1b[201~'
+const CTRL_V = '\x16'
+
+function getImagePasteSignal(agentType: AgentType | undefined): string {
+  return agentType === 'codex' ? CTRL_V : BRACKET_PASTE_EMPTY
+}
+
+const MAC_SHARED_PASTEBOARD_PATH_PATTERN =
+  /\/Users\/[^/\n]+\/Library\/Group Containers\/group\.com\.apple\.coreservices\.useractivityd\/shared-pasteboard\/items\//
+
+function isMacSharedPasteboardPathText(text: string): boolean {
+  return MAC_SHARED_PASTEBOARD_PATH_PATTERN.test(text)
+}
+
+interface PastePayload {
+  text: string
+  hasImage: boolean
+}
+
+function clipboardHasImage(clipboardData: DataTransfer | null | undefined): boolean {
+  if (!clipboardData) return false
+
+  for (const file of Array.from(clipboardData.files ?? [])) {
+    if (file?.type?.startsWith('image/')) return true
+  }
+
+  for (const item of Array.from(clipboardData.items ?? [])) {
+    if (item?.type?.startsWith('image/')) return true
+  }
+  return false
+}
 
 /**
  * Custom clipboard provider that prevents empty writes (matching Ghostty's behavior).
@@ -133,6 +163,7 @@ export function forceTextPresentation(data: string): string {
 interface UseTerminalOptions {
   sessionId: string | null
   tmuxTarget: string | null
+  agentType?: AgentType
   allowAttach?: boolean
   connectionStatus?: ConnectionStatus
   connectionEpoch?: number
@@ -150,6 +181,7 @@ interface UseTerminalOptions {
 export function useTerminal({
   sessionId,
   tmuxTarget,
+  agentType,
   allowAttach = true,
   connectionStatus = 'connected',
   connectionEpoch = 0,
@@ -190,6 +222,7 @@ export function useTerminal({
   const focusAfterAttachSessionRef = useRef<string | null>(null)
   const switchStartRef = useRef<number | null>(null)
   const sendMessageRef = useRef(sendMessage)
+  const agentTypeRef = useRef(agentType)
   const onScrollChangeRef = useRef(onScrollChange)
   const useWebGLRef = useRef(useWebGL)
 
@@ -271,6 +304,10 @@ export function useTerminal({
   useEffect(() => {
     sendMessageRef.current = sendMessage
   }, [sendMessage])
+
+  useEffect(() => {
+    agentTypeRef.current = agentType
+  }, [agentType])
 
   useEffect(() => {
     onScrollChangeRef.current = onScrollChange
@@ -555,10 +592,10 @@ export function useTerminal({
     webLinksAddonRef.current = webLinksAddon
 
     // Paste interception state: each keydown creates a resolver that the
-    // capture-phase paste listener fulfills with clipboardData text.
+    // capture-phase paste listener fulfills with clipboardData text/metadata.
     // This per-request model prevents race conditions with rapid pastes
     // and avoids double-paste without depending on the async Clipboard API.
-    let pasteResolver: ((text: string) => void) | null = null
+    let pasteResolver: ((payload: PastePayload) => void) | null = null
     let pasteTimeoutId: ReturnType<typeof setTimeout> | null = null
 
     const pasteModifier = getIsMac() ? 'metaKey' : 'ctrlKey' as const
@@ -575,22 +612,23 @@ export function useTerminal({
         }
       }
 
-      // Ctrl+V on macOS desktop: send bracket paste signal for Claude Code image paste.
-      // Claude Code detects bracket paste and reads the macOS system clipboard
-      // for image data. Ctrl+V doesn't trigger a browser paste event, so there's
-      // no double-paste risk — we just need to convert it to a bracket paste signal.
+      // Ctrl+V on macOS desktop: route image paste through the agent-specific
+      // signal. Claude Code reads the macOS clipboard after an empty bracket
+      // paste; Codex handles a literal Ctrl+V byte.
+      // Ctrl+V doesn't trigger a browser paste event, so there's no double-paste risk.
       // Excluded on iOS: no Finder/osascript, and Ctrl+V with hardware keyboard
-      // should not trigger bracket paste.
-      // Send bracket paste markers directly as raw terminal input because xterm.js's
-      // bracketedPasteMode is off (tmux intercepts DECSET 2004), so terminal.paste('')
-      // would send an empty string instead of the bracket paste sequence.
+      // should not trigger desktop image paste behavior.
       if (getIsMac() && !isiOS && event.ctrlKey && !event.metaKey && event.key.toLowerCase() === 'v' && event.type === 'keydown') {
         if (attachedSessionRef.current) {
           if (inTmuxCopyModeRef.current) {
             sendMessageRef.current({ type: 'tmux-cancel-copy-mode', sessionId: attachedSessionRef.current })
             setTmuxCopyMode(false)
           }
-          sendMessageRef.current({ type: 'terminal-input', sessionId: attachedSessionRef.current, data: BRACKET_PASTE_EMPTY })
+          sendMessageRef.current({
+            type: 'terminal-input',
+            sessionId: attachedSessionRef.current,
+            data: getImagePasteSignal(agentTypeRef.current),
+          })
         }
         return !attachedSessionRef.current // Only swallow when attached
       }
@@ -610,18 +648,18 @@ export function useTerminal({
           pasteTimeoutId = null
         }
         pasteResolver = null
-        const pastePromise = new Promise<string | null>((resolve) => {
+        const pastePromise = new Promise<PastePayload | null>((resolve) => {
           pasteTimeoutId = setTimeout(() => {
             pasteTimeoutId = null
             pasteResolver = null
             resolve(null)
           }, 100)
-          pasteResolver = (text: string) => {
+          pasteResolver = (payload: PastePayload) => {
             if (pasteTimeoutId !== null) {
               clearTimeout(pasteTimeoutId)
               pasteTimeoutId = null
             }
-            resolve(text)
+            resolve(payload)
           }
         })
         void (async () => {
@@ -631,9 +669,15 @@ export function useTerminal({
 
             // Wait for the paste event to deliver text (up to 100ms timeout).
             // Falls back to clipboard API if paste event didn't fire.
-            let text = await pastePromise
-            if (text == null) {
+            const payload = await pastePromise
+            let text = payload?.text ?? null
+            if (text === null) {
               try { text = await navigator.clipboard.readText() } catch { text = '' }
+            }
+
+            if (payload?.hasImage && getIsMac() && !isiOS) {
+              sendMessageRef.current({ type: 'terminal-input', sessionId: attached, data: getImagePasteSignal(agentTypeRef.current) })
+              return
             }
 
             // If paste text is empty and on macOS desktop, check for Finder file copy.
@@ -642,8 +686,12 @@ export function useTerminal({
               try {
                 const res = await fetch('/api/clipboard-file-path')
                 if (res.ok) {
-                  const { path } = (await res.json()) as { path: string | null }
+                  const { path, isImage } = (await res.json()) as { path: string | null; isImage?: boolean }
                   if (path) {
+                    if (isImage) {
+                      sendMessageRef.current({ type: 'terminal-input', sessionId: attached, data: getImagePasteSignal(agentTypeRef.current) })
+                      return
+                    }
                     // Send as raw input (no bracket paste) so Claude Code
                     // doesn't detect a paste and read the system clipboard
                     sendMessageRef.current({ type: 'terminal-input', sessionId: attached, data: path })
@@ -653,7 +701,17 @@ export function useTerminal({
               } catch { /* not on macOS or endpoint unavailable */ }
             }
 
-            if (text) terminal.paste(text)
+            if (text && !isMacSharedPasteboardPathText(text)) {
+              terminal.paste(text)
+              return
+            }
+
+            // Shared Mac clipboard image pastes can expose only a protected
+            // useractivityd path to the browser. Sending that path to an agent
+            // is useless; ask the attached CLI to run its native image-paste path.
+            if (getIsMac() && !isiOS) {
+              sendMessageRef.current({ type: 'terminal-input', sessionId: attached, data: getImagePasteSignal(agentTypeRef.current) })
+            }
           } finally {
             pasteResolver = null
           }
@@ -682,9 +740,10 @@ export function useTerminal({
       e.preventDefault()
       e.stopPropagation()
       const text = e.clipboardData?.getData('text/plain') ?? ''
+      const hasImage = clipboardHasImage(e.clipboardData)
       const resolver = pasteResolver
       pasteResolver = null
-      resolver(text)
+      resolver({ text, hasImage })
     }
     container.addEventListener('paste', handlePaste, { capture: true })
 

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -4397,6 +4397,164 @@ describe('server fetch handlers', () => {
     expect(await response.text()).toBe('WebSocket upgrade failed')
   })
 
+  test('returns macOS clipboard image file paths from AppKit pasteboard reader', async () => {
+    if (process.platform !== 'darwin') {
+      return
+    }
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-clipboard-'))
+    try {
+      const imagePath = path.join(tempDir, 'screenshot.png')
+      await fs.writeFile(imagePath, new Uint8Array([1, 2, 3]))
+
+      let capturedCommandPrefix: string[] = []
+      let capturedTimeout: number | undefined
+      let capturedEnv: Record<string, string | undefined> | undefined
+      spawnSyncImpl = ((...args: Parameters<typeof Bun.spawnSync>) => {
+        const command = Array.isArray(args[0]) ? args[0].map(String) : [String(args[0])]
+        if (command[0] !== 'swift') {
+          return {
+            exitCode: 0,
+            stdout: Buffer.from(''),
+            stderr: Buffer.from(''),
+          } as ReturnType<typeof Bun.spawnSync>
+        }
+        capturedCommandPrefix = command.slice(0, 2)
+        capturedTimeout = args[1]?.timeout
+        capturedEnv = args[1]?.env as Record<string, string | undefined> | undefined
+        return {
+          exitCode: 0,
+          stdout: Buffer.from(JSON.stringify({ path: imagePath, isImage: true })),
+          stderr: Buffer.from(''),
+        } as ReturnType<typeof Bun.spawnSync>
+      }) as typeof Bun.spawnSync
+
+      const { serveOptions } = await loadIndex()
+      const fetchHandler = serveOptions.fetch
+      if (!fetchHandler) {
+        throw new Error('Fetch handler not configured')
+      }
+
+      const response = await fetchHandler.call(
+        {} as Bun.Server<unknown>,
+        new Request('http://localhost/api/clipboard-file-path'),
+        {} as Bun.Server<unknown>
+      )
+
+      if (!response) {
+        throw new Error('Expected response for clipboard file path')
+      }
+
+      expect(capturedCommandPrefix).toEqual(['swift', '-e'])
+      expect(capturedTimeout).toBe(10000)
+      expect(capturedEnv?.AGENTBOARD_PASTE_IMAGE_MAX_BYTES).toBe(String(defaultConfig.pasteImageMaxBytes))
+      expect(response.status).toBe(200)
+      expect(response.headers.get('cache-control')).toBe('no-store')
+      expect(await response.json()).toEqual({ path: imagePath, isImage: true })
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  test('returns null when macOS clipboard path does not exist', async () => {
+    if (process.platform !== 'darwin') {
+      return
+    }
+
+    spawnSyncImpl = ((...args: Parameters<typeof Bun.spawnSync>) => {
+      const command = Array.isArray(args[0]) ? args[0].map(String) : [String(args[0])]
+      if (command[0] !== 'swift') {
+        return {
+          exitCode: 0,
+          stdout: Buffer.from(''),
+          stderr: Buffer.from(''),
+        } as ReturnType<typeof Bun.spawnSync>
+      }
+      return {
+        exitCode: 0,
+        stdout: Buffer.from(JSON.stringify({ path: '/tmp/agentboard-missing.png', isImage: true })),
+        stderr: Buffer.from(''),
+      } as ReturnType<typeof Bun.spawnSync>
+    }) as typeof Bun.spawnSync
+
+    const { serveOptions } = await loadIndex()
+    const fetchHandler = serveOptions.fetch
+    if (!fetchHandler) {
+      throw new Error('Fetch handler not configured')
+    }
+
+    const response = await fetchHandler.call(
+      {} as Bun.Server<unknown>,
+      new Request('http://localhost/api/clipboard-file-path'),
+      {} as Bun.Server<unknown>
+    )
+
+    if (!response) {
+      throw new Error('Expected response for clipboard file path')
+    }
+
+    expect(await response.json()).toEqual({ path: null, isImage: false })
+  })
+
+  test('falls back to osascript when AppKit pasteboard reader fails', async () => {
+    if (process.platform !== 'darwin') {
+      return
+    }
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-clipboard-'))
+    try {
+      const filePath = path.join(tempDir, 'report.pdf')
+      await fs.writeFile(filePath, new Uint8Array([1, 2, 3]))
+
+      const commands: string[][] = []
+      spawnSyncImpl = ((...args: Parameters<typeof Bun.spawnSync>) => {
+        const command = Array.isArray(args[0]) ? args[0].map(String) : [String(args[0])]
+        commands.push(command.slice(0, 2))
+        if (command[0] === 'swift') {
+          return {
+            exitCode: 1,
+            stdout: Buffer.from(''),
+            stderr: Buffer.from('swift-missing'),
+          } as ReturnType<typeof Bun.spawnSync>
+        }
+        if (command[0] === 'osascript') {
+          return {
+            exitCode: 0,
+            stdout: Buffer.from(`${filePath}\n`),
+            stderr: Buffer.from(''),
+          } as ReturnType<typeof Bun.spawnSync>
+        }
+        return {
+          exitCode: 0,
+          stdout: Buffer.from(''),
+          stderr: Buffer.from(''),
+        } as ReturnType<typeof Bun.spawnSync>
+      }) as typeof Bun.spawnSync
+
+      const { serveOptions } = await loadIndex()
+      const fetchHandler = serveOptions.fetch
+      if (!fetchHandler) {
+        throw new Error('Fetch handler not configured')
+      }
+
+      const response = await fetchHandler.call(
+        {} as Bun.Server<unknown>,
+        new Request('http://localhost/api/clipboard-file-path'),
+        {} as Bun.Server<unknown>
+      )
+
+      if (!response) {
+        throw new Error('Expected response for clipboard file path')
+      }
+
+      expect(commands).toContainEqual(['swift', '-e'])
+      expect(commands).toContainEqual(['osascript', '-e'])
+      expect(await response.json()).toEqual({ path: filePath, isImage: false })
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
   test('handles paste-image requests with and without files', async () => {
     const { serveOptions, registryInstance } = await loadIndex()
     const fetchHandler = serveOptions.fetch

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1374,6 +1374,52 @@ const pasteImageExtensionByMime = new Map([
   ['image/webp', 'webp'],
 ])
 
+const macPasteboardSwiftScript = `
+import AppKit
+import Foundation
+
+let maxBytes = Int(ProcessInfo.processInfo.environment["AGENTBOARD_PASTE_IMAGE_MAX_BYTES"] ?? "") ?? 0
+let imageExtensions: Set<String> = ["png", "jpg", "jpeg", "gif", "webp", "heic", "tif", "tiff"]
+
+func emit(path: String?, isImage: Bool) {
+  let payload: [String: Any?] = ["path": path, "isImage": isImage]
+  let data = try! JSONSerialization.data(withJSONObject: payload.compactMapValues { $0 })
+  print(String(data: data, encoding: .utf8)!)
+}
+
+let pasteboard = NSPasteboard.general
+let items = pasteboard.pasteboardItems ?? []
+
+for item in items {
+  if let fileURLString = item.string(forType: .fileURL),
+     let url = URL(string: fileURLString),
+     url.isFileURL {
+    let path = url.path
+    let lowerExt = url.pathExtension.lowercased()
+    let hasImageType = item.types.contains(.png) || item.types.contains(.tiff)
+    emit(path: path, isImage: hasImageType || imageExtensions.contains(lowerExt))
+    exit(0)
+  }
+}
+
+for item in items {
+  if let data = item.data(forType: .png), data.count > 0, (maxBytes <= 0 || data.count <= maxBytes) {
+    let path = NSTemporaryDirectory() + "agentboard-paste-" + UUID().uuidString + ".png"
+    try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+    emit(path: path, isImage: true)
+    exit(0)
+  }
+}
+
+emit(path: nil, isImage: false)
+`
+
+const MAC_PASTEBOARD_TIMEOUT_MS = 10000
+
+function isImageFilePath(filePath: string): boolean {
+  return /\.(png|jpe?g|gif|webp|heic|tiff?)$/i.test(filePath)
+}
+
 // Image upload endpoint for iOS clipboard paste
 app.post('/api/paste-image', async (c) => {
   // Early reject before buffering the multipart body. The header is
@@ -1411,33 +1457,59 @@ app.post('/api/paste-image', async (c) => {
   }
 })
 
-// Get file path from macOS clipboard (for Finder file copies).
-// When a user copies a file in Finder, the browser clipboard only exposes the
-// file icon, not the actual contents. This endpoint extracts the real file path
-// via AppleScript so the client can send it to the terminal.
+// Get file path from macOS clipboard (for Finder file copies and screenshot apps).
+// Browser paste events can hide AppKit pasteboard types such as public.file-url
+// and public.png, so this endpoint reads NSPasteboard directly.
 app.get('/api/clipboard-file-path', async (c) => {
   if (process.platform !== 'darwin') {
-    return c.json({ path: null })
+    return c.json({ path: null, isImage: false })
   }
   try {
     const proc = Bun.spawn(
-      ['osascript', '-e', 'POSIX path of (the clipboard as «class furl»)'],
-      { stdout: 'pipe', stderr: 'pipe' }
+      ['swift', '-e', macPasteboardSwiftScript],
+      {
+        stdout: 'pipe',
+        stderr: 'pipe',
+        timeout: MAC_PASTEBOARD_TIMEOUT_MS,
+        env: {
+          ...process.env,
+          AGENTBOARD_PASTE_IMAGE_MAX_BYTES: String(config.pasteImageMaxBytes),
+        },
+      }
     )
     const text = await new Response(proc.stdout).text()
     const exitCode = await proc.exited
-    const filePath = text.trim()
-    if (exitCode === 0 && filePath.startsWith('/')) {
+    if (exitCode === 0) {
+      const payload = JSON.parse(text) as { path?: unknown; isImage?: unknown }
+      const filePath = typeof payload.path === 'string' ? payload.path : null
       // Verify the file actually exists
-      const file = Bun.file(filePath)
-      if (await file.exists()) {
-        c.header('Cache-Control', 'no-store')
-        return c.json({ path: filePath })
+      if (filePath?.startsWith('/')) {
+        const file = Bun.file(filePath)
+        if (await file.exists()) {
+          c.header('Cache-Control', 'no-store')
+          return c.json({ path: filePath, isImage: payload.isImage === true })
+        }
       }
     }
-    return c.json({ path: null })
+
+    const fallbackProc = Bun.spawn(
+      ['osascript', '-e', 'POSIX path of (the clipboard as «class furl»)'],
+      { stdout: 'pipe', stderr: 'pipe', timeout: MAC_PASTEBOARD_TIMEOUT_MS }
+    )
+    const fallbackText = await new Response(fallbackProc.stdout).text()
+    const fallbackExitCode = await fallbackProc.exited
+    const fallbackPath = fallbackText.trim()
+    if (fallbackExitCode === 0 && fallbackPath.startsWith('/')) {
+      const file = Bun.file(fallbackPath)
+      if (await file.exists()) {
+        c.header('Cache-Control', 'no-store')
+        return c.json({ path: fallbackPath, isImage: isImageFilePath(fallbackPath) })
+      }
+    }
+
+    return c.json({ path: null, isImage: false })
   } catch {
-    return c.json({ path: null })
+    return c.json({ path: null, isImage: false })
   }
 })
 


### PR DESCRIPTION
## Summary

- route pasted clipboard images to the right agent-specific signal for Claude and Codex
- read macOS pasteboard file/image data server-side instead of relying on CleanShot-specific filename matching
- preserve normal file-path paste behavior for non-image files and shared clipboard paths

## Root Cause

Cmd+V handling only treated a narrow clipboard path shape as an image paste, and the terminal paste handler captured agent type at attach time. That made Codex receive the wrong image-paste signal after session changes and made cross-device/shared clipboard image paths brittle.

## Validation

- bun run lint && bun run typecheck && bun run test
