### PR TITLE
feat: improve hibernated transcript reader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.2.53",
+  "version": "0.3.0",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/__tests__/SessionPreviewModal.test.tsx
+++ b/src/client/__tests__/SessionPreviewModal.test.tsx
@@ -41,8 +41,9 @@ function renderedText(value: unknown): string {
   if (typeof value === 'string' || typeof value === 'number') return String(value)
   if (Array.isArray(value)) return value.map(renderedText).join('')
   if (typeof value === 'object' && 'props' in value) {
-    const props = (value as { props?: { children?: unknown } }).props
-    return renderedText(props?.children)
+    const props = (value as { props?: { children?: unknown }, children?: unknown }).props
+    const children = (value as { children?: unknown }).children
+    return renderedText(props?.children) || renderedText(children)
   }
   return ''
 }
@@ -65,6 +66,20 @@ async function resolveAndFlush(controller: { resolveNext: () => void }) {
   await act(async () => {
     controller.resolveNext()
     await flushUpdates()
+  })
+}
+
+function clickButton(renderer: TestRenderer.ReactTestRenderer, label: string) {
+  const button = renderer.root
+    .findAllByType('button')
+    .find((candidate) => renderedText(candidate.props.children).includes(label))
+
+  if (!button) {
+    throw new Error(`Expected ${label} button`)
+  }
+
+  act(() => {
+    button.props.onClick()
   })
 }
 
@@ -136,22 +151,32 @@ afterEach(() => {
 })
 
 describe('SessionPreviewModal', () => {
-  test('loads preview, shows parsed entries, toggles raw, and resumes', async () => {
+  test('loads preview, shows parsed entries, pages earlier history, toggles events, and resumes', async () => {
+    const longToolResult = `Done ${'tool-output '.repeat(30)}`
     const previewData = {
       sessionId: baseSession.sessionId,
       displayName: 'Alpha',
       projectPath: baseSession.projectPath,
       agentType: 'claude',
       lastActivityAt: baseSession.lastActivityAt,
-      totalLines: 11,
-      startLine: 1,
-      endLine: 11,
+      totalLines: 13,
+      startLine: 2,
+      endLine: 13,
       hasMoreBefore: true,
       lines: [
-        JSON.stringify({ type: 'user', message: { content: 'Hello' } }),
-        JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'World' }] } }),
+        JSON.stringify({
+          type: 'user',
+          timestamp: '2026-06-15T14:01:00.000Z',
+          message: { content: 'Hello' },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          timestamp: '2026-06-15T14:02:00.000Z',
+          message: { content: [{ type: 'text', text: 'World' }] },
+        }),
         JSON.stringify({
           type: 'response_item',
+          timestamp: '2026-06-15T14:03:00.000Z',
           payload: {
             type: 'message',
             role: 'assistant',
@@ -160,12 +185,17 @@ describe('SessionPreviewModal', () => {
         }),
         JSON.stringify({
           type: 'event_msg',
-          payload: { type: 'user_message', message: 'From event msg' },
+          payload: {
+            type: 'user_message',
+            timestamp: '2026-06-15T14:04:00.000Z',
+            message: 'From event msg',
+          },
         }),
         JSON.stringify({
           type: 'event_msg',
           payload: {
             type: 'user_message',
+            timestamp: '2026-06-15T14:05:00.000Z',
             message: {
               role: 'user',
               content: [{ type: 'input_text', text: 'From structured event msg' }],
@@ -186,25 +216,44 @@ describe('SessionPreviewModal', () => {
           payload: { type: 'assistant_message', message: 'Assistant from event msg' },
         }),
         JSON.stringify({ type: 'tool_use', name: 'search' }),
-        JSON.stringify({ type: 'result', result: 'Done' }),
+        JSON.stringify({ type: 'result', result: longToolResult }),
         JSON.stringify({ type: 'assistant', message: { content: 'x'.repeat(650) } }),
         'plain text line',
       ],
     }
-    const earlierData = {
+    const middleData = {
       ...previewData,
-      totalLines: 11,
+      totalLines: 13,
+      startLine: 1,
+      endLine: 2,
+      hasMoreBefore: true,
+      lines: [
+        JSON.stringify({
+          type: 'assistant',
+          timestamp: '2026-06-15T14:00:30.000Z',
+          message: { content: 'Middle message' },
+        }),
+      ],
+    }
+    const earliestData = {
+      ...previewData,
+      totalLines: 13,
       startLine: 0,
       endLine: 1,
       hasMoreBefore: false,
       lines: [
-        JSON.stringify({ type: 'user', message: { content: 'Earlier message' } }),
+        JSON.stringify({
+          type: 'user',
+          timestamp: '2026-06-15T14:00:00.000Z',
+          message: { content: 'Earlier message' },
+        }),
       ],
     }
 
     const controller = createFetchController([
       createJsonResponse(previewData),
-      createJsonResponse(earlierData),
+      createJsonResponse(middleData),
+      createJsonResponse(earliestData),
     ])
     let resumed: string[] = []
 
@@ -235,76 +284,57 @@ describe('SessionPreviewModal', () => {
     expect(html).not.toContain('Done')
     expect(html).toContain('x'.repeat(650))
     expect(html).toContain('plain text line')
-    expect(html).toContain('Lines 2-11 of 11')
+    expect(html).toContain('Showing 11 of 13 log entries')
+    expect(html).toContain('2026-06-15T14:01:00.000Z')
+    expect(renderedText(renderer.toJSON())).not.toContain('Line 3Hello')
 
-    const resultButton = renderer.root
-      .findAllByType('button')
-      .find((button) => renderedText(button.props.children).includes('Result'))
-
-    if (!resultButton) {
-      throw new Error('Expected result disclosure button')
-    }
-
-    act(() => {
-      resultButton.props.onClick()
-    })
+    clickButton(renderer, 'Result')
 
     html = JSON.stringify(renderer.toJSON())
     expect(html).toContain('Done')
+    expect(html).toContain('tool-output')
 
-    const loadEarlierButton = renderer.root
-      .findAllByType('button')
-      .find((button) => button.props.children === 'Load earlier')
+    clickButton(renderer, 'Load earlier')
+    await resolveAndFlush(controller)
 
-    if (!loadEarlierButton) {
-      throw new Error('Expected load earlier button')
-    }
+    html = JSON.stringify(renderer.toJSON())
+    expect(html).toContain('Middle message')
+    expect(html).toContain('Showing 12 of 13 log entries')
+    expect(controller.calls[1]).toBe('/api/session-preview/session-12345678?limit=200&beforeLine=2')
 
-    act(() => {
-      loadEarlierButton.props.onClick()
-    })
-
+    clickButton(renderer, 'Load earlier')
     await resolveAndFlush(controller)
 
     html = JSON.stringify(renderer.toJSON())
     expect(html).toContain('Earlier message')
-    expect(html).toContain('Lines 1-11 of 11')
-    expect(controller.calls[1]).toBe('/api/session-preview/session-12345678?limit=200&beforeLine=1')
+    expect(html).toContain('Showing 13 of 13 log entries')
+    expect(controller.calls[2]).toBe('/api/session-preview/session-12345678?limit=200&beforeLine=1')
 
-    const toggleButton = renderer.root
-      .findAllByType('button')
-      .find((button) => button.props.children === 'Events')
+    const text = renderedText(renderer.toJSON())
+    expect(text.indexOf('Earlier message')).toBeLessThan(text.indexOf('Middle message'))
+    expect(text.indexOf('Middle message')).toBeLessThan(text.indexOf('Hello'))
 
-    if (!toggleButton) {
-      throw new Error('Expected toggle button')
-    }
-
-    act(() => {
-      toggleButton.props.onClick()
-    })
+    clickButton(renderer, 'Events')
 
     html = JSON.stringify(renderer.toJSON())
-    expect(html).toContain('CLAUDE')
-    expect(html).toContain('CODEX')
+    expect(html).toContain('claude')
+    expect(html).toContain('codex')
     expect(html).toContain('event_msg')
     expect(html).toContain('From structured event msg')
     expect(html).toContain('Visible assistant text')
     expect(html).not.toContain('Hidden thinking block')
     expect(html).toContain('Plain text')
     expect(html).toContain('payload')
+    expect(html).toContain('Output')
+    expect(html).not.toContain('tool-output')
     expect(html).toContain('Messages')
 
-    const resumeButton = renderer.root
-      .findAllByType('button')
-      .find((button) => button.props.children === 'Wake')
+    clickButton(renderer, 'Output')
 
-    if (!resumeButton) {
-      throw new Error('Expected resume button')
-    }
+    html = JSON.stringify(renderer.toJSON())
+    expect(html).toContain('tool-output')
 
-    act(() => {
-      resumeButton.props.onClick()
-    })
+    clickButton(renderer, 'Wake')
 
     expect(resumed).toEqual([baseSession.sessionId])
 
@@ -350,8 +380,8 @@ describe('SessionPreviewModal', () => {
     await resolveAndFlush(controller)
 
     const html = JSON.stringify(renderer.toJSON())
-    expect(html).toContain('No transcript lines')
-    expect(html).not.toContain('Lines 1-0 of 0')
+    expect(html).toContain('No transcript entries')
+    expect(html).not.toContain('Showing 0 of 0 log entries')
 
     await cleanup(renderer)
   })

--- a/src/client/__tests__/SessionPreviewModal.test.tsx
+++ b/src/client/__tests__/SessionPreviewModal.test.tsx
@@ -36,6 +36,17 @@ function flushPromises() {
   return new Promise((resolve) => setTimeout(resolve, 0))
 }
 
+function renderedText(value: unknown): string {
+  if (value === null || value === undefined || typeof value === 'boolean') return ''
+  if (typeof value === 'string' || typeof value === 'number') return String(value)
+  if (Array.isArray(value)) return value.map(renderedText).join('')
+  if (typeof value === 'object' && 'props' in value) {
+    const props = (value as { props?: { children?: unknown } }).props
+    return renderedText(props?.children)
+  }
+  return ''
+}
+
 async function flushUpdates() {
   await flushPromises()
   await flushPromises()
@@ -228,10 +239,7 @@ describe('SessionPreviewModal', () => {
 
     const resultButton = renderer.root
       .findAllByType('button')
-      .find((button) => {
-        const children = button.props.children
-        return Array.isArray(children) && children[0]?.props?.children === 'Result'
-      })
+      .find((button) => renderedText(button.props.children).includes('Result'))
 
     if (!resultButton) {
       throw new Error('Expected result disclosure button')
@@ -265,7 +273,7 @@ describe('SessionPreviewModal', () => {
 
     const toggleButton = renderer.root
       .findAllByType('button')
-      .find((button) => button.props.children === 'Log lines')
+      .find((button) => button.props.children === 'Events')
 
     if (!toggleButton) {
       throw new Error('Expected toggle button')

--- a/src/client/__tests__/SessionPreviewModal.test.tsx
+++ b/src/client/__tests__/SessionPreviewModal.test.tsx
@@ -132,6 +132,10 @@ describe('SessionPreviewModal', () => {
       projectPath: baseSession.projectPath,
       agentType: 'claude',
       lastActivityAt: baseSession.lastActivityAt,
+      totalLines: 11,
+      startLine: 1,
+      endLine: 11,
+      hasMoreBefore: true,
       lines: [
         JSON.stringify({ type: 'user', message: { content: 'Hello' } }),
         JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'World' }] } }),
@@ -158,16 +162,39 @@ describe('SessionPreviewModal', () => {
           },
         }),
         JSON.stringify({
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'thinking', thinking: 'Hidden thinking block' },
+              { type: 'text', text: 'Visible assistant text' },
+            ],
+          },
+        }),
+        JSON.stringify({
           type: 'event_msg',
           payload: { type: 'assistant_message', message: 'Assistant from event msg' },
         }),
         JSON.stringify({ type: 'tool_use', name: 'search' }),
         JSON.stringify({ type: 'result', result: 'Done' }),
+        JSON.stringify({ type: 'assistant', message: { content: 'x'.repeat(650) } }),
         'plain text line',
       ],
     }
+    const earlierData = {
+      ...previewData,
+      totalLines: 11,
+      startLine: 0,
+      endLine: 1,
+      hasMoreBefore: false,
+      lines: [
+        JSON.stringify({ type: 'user', message: { content: 'Earlier message' } }),
+      ],
+    }
 
-    const controller = createFetchController([createJsonResponse(previewData)])
+    const controller = createFetchController([
+      createJsonResponse(previewData),
+      createJsonResponse(earlierData),
+    ])
     let resumed: string[] = []
 
     const renderer = await createModal(
@@ -193,12 +220,52 @@ describe('SessionPreviewModal', () => {
     expect(html).toContain('From structured event msg')
     expect(html).toContain('Assistant from event msg')
     expect(html).toContain('[Tool: search]')
-    expect(html).toContain('Done')
+    expect(html).toContain('Result')
+    expect(html).not.toContain('Done')
+    expect(html).toContain('x'.repeat(650))
     expect(html).toContain('plain text line')
+    expect(html).toContain('Lines 2-11 of 11')
+
+    const resultButton = renderer.root
+      .findAllByType('button')
+      .find((button) => {
+        const children = button.props.children
+        return Array.isArray(children) && children[0]?.props?.children === 'Result'
+      })
+
+    if (!resultButton) {
+      throw new Error('Expected result disclosure button')
+    }
+
+    act(() => {
+      resultButton.props.onClick()
+    })
+
+    html = JSON.stringify(renderer.toJSON())
+    expect(html).toContain('Done')
+
+    const loadEarlierButton = renderer.root
+      .findAllByType('button')
+      .find((button) => button.props.children === 'Load earlier')
+
+    if (!loadEarlierButton) {
+      throw new Error('Expected load earlier button')
+    }
+
+    act(() => {
+      loadEarlierButton.props.onClick()
+    })
+
+    await resolveAndFlush(controller)
+
+    html = JSON.stringify(renderer.toJSON())
+    expect(html).toContain('Earlier message')
+    expect(html).toContain('Lines 1-11 of 11')
+    expect(controller.calls[1]).toBe('/api/session-preview/session-12345678?limit=200&beforeLine=1')
 
     const toggleButton = renderer.root
       .findAllByType('button')
-      .find((button) => button.props.children === 'Raw')
+      .find((button) => button.props.children === 'Log lines')
 
     if (!toggleButton) {
       throw new Error('Expected toggle button')
@@ -209,7 +276,15 @@ describe('SessionPreviewModal', () => {
     })
 
     html = JSON.stringify(renderer.toJSON())
-    expect(html).toContain('\\\"type\\\":\\\"user\\\"')
+    expect(html).toContain('CLAUDE')
+    expect(html).toContain('CODEX')
+    expect(html).toContain('event_msg')
+    expect(html).toContain('From structured event msg')
+    expect(html).toContain('Visible assistant text')
+    expect(html).not.toContain('Hidden thinking block')
+    expect(html).toContain('Plain text')
+    expect(html).toContain('payload')
+    expect(html).toContain('Messages')
 
     const resumeButton = renderer.root
       .findAllByType('button')
@@ -236,6 +311,39 @@ describe('SessionPreviewModal', () => {
     })
 
     expect(resumed).toEqual([baseSession.sessionId, baseSession.sessionId])
+
+    await cleanup(renderer)
+  })
+
+  test('shows a stable label for empty transcripts', async () => {
+    const controller = createFetchController([
+      createJsonResponse({
+        sessionId: baseSession.sessionId,
+        displayName: 'Alpha',
+        projectPath: baseSession.projectPath,
+        agentType: 'claude',
+        lastActivityAt: baseSession.lastActivityAt,
+        totalLines: 0,
+        startLine: 0,
+        endLine: 0,
+        hasMoreBefore: false,
+        lines: [],
+      }),
+    ])
+
+    const renderer = await createModal(
+      <SessionPreviewModal
+        session={baseSession}
+        onClose={() => {}}
+        onResume={() => {}}
+      />
+    )
+
+    await resolveAndFlush(controller)
+
+    const html = JSON.stringify(renderer.toJSON())
+    expect(html).toContain('No transcript lines')
+    expect(html).not.toContain('Lines 1-0 of 0')
 
     await cleanup(renderer)
   })

--- a/src/client/__tests__/app.test.tsx
+++ b/src/client/__tests__/app.test.tsx
@@ -559,7 +559,7 @@ describe('App', () => {
     expect(
       renderer.root
         .findAllByType('button')
-        .some((button) => button.props.children === 'Wake Session')
+        .some((button) => button.props.children === 'Wake')
     ).toBe(true)
   })
 

--- a/src/client/__tests__/terminal.test.tsx
+++ b/src/client/__tests__/terminal.test.tsx
@@ -819,6 +819,10 @@ describe('Terminal', () => {
           projectPath: hibernatingSession.projectPath,
           agentType: hibernatingSession.agentType,
           lastActivityAt: hibernatingSession.lastActivityAt,
+          totalLines: 1,
+          startLine: 0,
+          endLine: 1,
+          hasMoreBefore: false,
           lines: [
             JSON.stringify({
               type: 'user',
@@ -862,7 +866,7 @@ describe('Terminal', () => {
 
     const html = JSON.stringify(renderer.toJSON())
     expect(html).toContain('Hibernating')
-    expect(html).toContain('Wake Session')
+    expect(html).toContain('Wake')
     expect(
       sentMessages.some(
         (message) =>
@@ -873,7 +877,7 @@ describe('Terminal', () => {
     ).toBe(false)
 
     const wakeButton = renderer.root.findAllByType('button').find(
-      (button) => button.props.children === 'Wake Session'
+      (button) => button.props.children === 'Wake'
     )
     if (!wakeButton) {
       throw new Error('Expected wake button')

--- a/src/client/components/SessionPreviewContent.tsx
+++ b/src/client/components/SessionPreviewContent.tsx
@@ -1,5 +1,10 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { parseAndNormalizeAgentLogLine, type NormalizedEventKind } from '@shared/eventTaxonomy'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import {
+  parseAndNormalizeAgentLogLine,
+  inferSourceFamily,
+  type NormalizedEventKind,
+} from '@shared/eventTaxonomy'
+import { asRecord, asString } from '@shared/json'
 import type { AgentSession } from '@shared/types'
 
 const PREVIEW_FETCH_TIMEOUT_MS = 10_000
@@ -45,15 +50,6 @@ interface StructuredLogLine {
   details: Array<{ label: string; value: string }>
 }
 
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
-  return value as Record<string, unknown>
-}
-
-function asString(value: unknown): string | null {
-  return typeof value === 'string' ? value : null
-}
-
 function extractLogTimestampFromRecord(record: Record<string, unknown>): string | null {
   const payload = asRecord(record.payload)
   const message = asRecord(record.message)
@@ -67,15 +63,6 @@ function extractLogTimestampFromRecord(record: Record<string, unknown>): string 
     asString(payload?.createdAt)
 
   return timestamp && !Number.isNaN(Date.parse(timestamp)) ? timestamp : null
-}
-
-function extractLogTimestamp(line: string): string | null {
-  try {
-    const record = asRecord(JSON.parse(line) as unknown)
-    return record ? extractLogTimestampFromRecord(record) : null
-  } catch {
-    return null
-  }
 }
 
 function formatLogTimestamp(timestamp?: string): string | null {
@@ -140,24 +127,16 @@ function extractReadableText(value: unknown): string {
   )
 }
 
-function inferLogSource(record: Record<string, unknown>) {
+function inferLogSource(record: Record<string, unknown>): string {
+  // Reuse the shared family detection for pi/claude, then layer the transcript
+  // badge's display heuristics on top (any payload.type reads as a Codex signal,
+  // ahead of Claude type detection — matching the original ordering).
+  const family = inferSourceFamily(record)
+  if (family === 'pi') return 'pi'
   const type = asString(record.type) ?? ''
-  const payload = asRecord(record.payload)
-  const payloadType = asString(payload?.type) ?? ''
-  const source = asString(record.source) ?? asString(payload?.source) ?? ''
-  const agent = asString(record.agent) ?? ''
-  if (source.toLowerCase() === 'pi' || agent.toLowerCase() === 'pi') return 'pi'
+  const payloadType = asString(asRecord(record.payload)?.type) ?? ''
   if (type === 'event_msg' || type === 'response_item' || payloadType) return 'codex'
-  if (
-    type === 'user' ||
-    type === 'assistant' ||
-    type === 'system' ||
-    type === 'tool_use' ||
-    type === 'tool_result' ||
-    type === 'result'
-  ) {
-    return 'claude'
-  }
+  if (family === 'claude' || type === 'tool_result') return 'claude'
   return 'log'
 }
 
@@ -290,7 +269,10 @@ function mapNormalizedRoleToEntryType(role: string): ParsedEntry['type'] {
 function parseLogEntry(line: string, lineNumber: number): ParsedEntry[] {
   const parsed = parseAndNormalizeAgentLogLine(line)
   if (!parsed) return []
-  const timestamp = extractLogTimestamp(line)
+  // Reuse the object parseAndNormalizeAgentLogLine already parsed instead of
+  // re-running JSON.parse on the same line.
+  const record = parsed.parsed ? asRecord(parsed.raw) : null
+  const timestamp = record ? extractLogTimestampFromRecord(record) : null
 
   const entries = parsed.events
     .map((event, seq) => ({
@@ -338,13 +320,7 @@ function ToolEntry({ entry }: { entry: ParsedEntry }) {
   const [expanded, setExpanded] = useState(false)
   const timestamp = formatLogTimestamp(entry.timestamp)
   const marker = timestamp ?? `Line ${entry.lineNumber + 1}`
-  const label = entry.kind === 'tool_call'
-    ? entry.content
-    : entry.kind === 'result'
-      ? 'Result'
-      : entry.kind === 'tool_result'
-        ? 'Tool result'
-        : entryLabel(entry)
+  const label = entry.kind === 'tool_call' ? entry.content : 'Result'
 
   return (
     <div className="rounded-md border border-border bg-surface/40">
@@ -375,7 +351,9 @@ function ToolEntry({ entry }: { entry: ParsedEntry }) {
 }
 
 function TranscriptEntry({ entry }: { entry: ParsedEntry }) {
-  if (entry.kind === 'tool_call' || entry.kind === 'tool_result' || entry.kind === 'result' || entry.type === 'tool') {
+  // tool_result events normalize to empty text and are dropped by parseLogEntry,
+  // so only tool_call and result entries reach the collapsible ToolEntry.
+  if (entry.kind === 'tool_call' || entry.kind === 'result') {
     return <ToolEntry entry={entry} />
   }
   const timestamp = formatLogTimestamp(entry.timestamp)
@@ -480,6 +458,23 @@ function StructuredLogEntry({ entry }: { entry: StructuredLogLine }) {
   )
 }
 
+async function fetchPreviewWindow(url: string, signal: AbortSignal): Promise<PreviewData> {
+  const response = await fetch(url, { signal })
+  if (!response.ok) {
+    // Defensive: tolerate non-JSON error bodies (e.g., proxy-injected HTML) so we
+    // surface the HTTP status instead of swallowing it in a parse throw.
+    let message = `Failed to load preview (HTTP ${response.status})`
+    try {
+      const data = (await response.json()) as { error?: string }
+      if (data?.error) message = data.error
+    } catch {
+      // Non-JSON — keep default message.
+    }
+    throw new Error(message)
+  }
+  return (await response.json()) as PreviewData
+}
+
 interface SessionPreviewContentProps {
   session: AgentSession
   className?: string
@@ -498,6 +493,10 @@ export default function SessionPreviewContent({
   const [viewMode, setViewMode] = useState<'messages' | 'events'>('messages')
   const contentRef = useRef<HTMLDivElement>(null)
   const preserveScrollRef = useRef<{ scrollHeight: number; scrollTop: number } | null>(null)
+  // Atomic in-flight guard: a state flag is read from a stale render closure, so a
+  // fast double-click could fire two identical "Load earlier" fetches and prepend
+  // the same lines twice. A ref is updated synchronously and can't be stale.
+  const loadingEarlierRef = useRef(false)
 
   useEffect(() => {
     let cancelled = false
@@ -511,23 +510,10 @@ export default function SessionPreviewContent({
       setPreviewData(null)
 
       try {
-        const response = await fetch(
+        const data = await fetchPreviewWindow(
           `/api/session-preview/${session.sessionId}?limit=${PREVIEW_LINE_LIMIT}`,
-          { signal: controller.signal }
+          controller.signal
         )
-        if (!response.ok) {
-          // Defensive: tolerate non-JSON error bodies (e.g., proxy-injected HTML)
-          // so we surface the HTTP status instead of swallowing it in a parse throw.
-          let message = `Failed to load preview (HTTP ${response.status})`
-          try {
-            const data = (await response.json()) as { error?: string }
-            if (data?.error) message = data.error
-          } catch {
-            // Non-JSON — keep default message.
-          }
-          throw new Error(message)
-        }
-        const data = (await response.json()) as PreviewData
         if (!cancelled) {
           setPreviewData(data)
         }
@@ -554,7 +540,8 @@ export default function SessionPreviewContent({
   }, [session.sessionId])
 
   const loadEarlier = async () => {
-    if (!previewData || loadingEarlier || !previewData.hasMoreBefore) return
+    if (!previewData || loadingEarlierRef.current || !previewData.hasMoreBefore) return
+    loadingEarlierRef.current = true
     const scroller = contentRef.current
     if (scroller) {
       preserveScrollRef.current = {
@@ -573,21 +560,10 @@ export default function SessionPreviewContent({
         limit: String(PREVIEW_LINE_LIMIT),
         beforeLine: String(previewData.startLine),
       })
-      const response = await fetch(
+      const data = await fetchPreviewWindow(
         `/api/session-preview/${session.sessionId}?${params.toString()}`,
-        { signal: controller.signal }
+        controller.signal
       )
-      if (!response.ok) {
-        let message = `Failed to load preview (HTTP ${response.status})`
-        try {
-          const data = (await response.json()) as { error?: string }
-          if (data?.error) message = data.error
-        } catch {
-          // Non-JSON — keep default message.
-        }
-        throw new Error(message)
-      }
-      const data = (await response.json()) as PreviewData
       setPreviewData((current) => {
         if (!current) return data
         return {
@@ -606,6 +582,7 @@ export default function SessionPreviewContent({
       }
     } finally {
       clearTimeout(timeoutId)
+      loadingEarlierRef.current = false
       setLoadingEarlier(false)
     }
   }
@@ -627,12 +604,22 @@ export default function SessionPreviewContent({
     }
   }, [previewData, viewMode])
 
-  const parsedEntries = previewData?.lines.flatMap((line, index) =>
-    parseLogEntry(line, previewData.startLine + index)
-  ) ?? []
-  const structuredLines = previewData?.lines.map((line, index) =>
-    parseStructuredLogLine(line, previewData.startLine + index)
-  ) ?? []
+  // Parse once per data change instead of on every render (view-mode toggle,
+  // load-earlier spinner, etc.). previewData is replaced wholesale when it changes.
+  const parsedEntries = useMemo(
+    () =>
+      previewData?.lines.flatMap((line, index) =>
+        parseLogEntry(line, previewData.startLine + index)
+      ) ?? [],
+    [previewData]
+  )
+  const structuredLines = useMemo(
+    () =>
+      previewData?.lines.map((line, index) =>
+        parseStructuredLogLine(line, previewData.startLine + index)
+      ) ?? [],
+    [previewData]
+  )
   const lineRangeLabel = previewData
     ? previewData.totalLines === 0
       ? 'No transcript entries'

--- a/src/client/components/SessionPreviewContent.tsx
+++ b/src/client/components/SessionPreviewContent.tsx
@@ -24,6 +24,7 @@ interface ParsedEntry {
   content: string
   raw: string
   lineNumber: number
+  timestamp?: string
 }
 
 interface StructuredLogLine {
@@ -47,6 +48,48 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 
 function asString(value: unknown): string | null {
   return typeof value === 'string' ? value : null
+}
+
+function extractLogTimestampFromRecord(record: Record<string, unknown>): string | null {
+  const payload = asRecord(record.payload)
+  const message = asRecord(record.message)
+  const timestamp =
+    asString(record.timestamp) ??
+    asString(payload?.timestamp) ??
+    asString(message?.timestamp) ??
+    asString(record.created_at) ??
+    asString(payload?.created_at) ??
+    asString(record.createdAt) ??
+    asString(payload?.createdAt)
+
+  return timestamp && !Number.isNaN(Date.parse(timestamp)) ? timestamp : null
+}
+
+function extractLogTimestamp(line: string): string | null {
+  try {
+    const record = asRecord(JSON.parse(line) as unknown)
+    return record ? extractLogTimestampFromRecord(record) : null
+  } catch {
+    return null
+  }
+}
+
+function formatLogTimestamp(timestamp?: string): string | null {
+  if (!timestamp) return null
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return null
+
+  const now = new Date()
+  const sameDay = date.toDateString() === now.toDateString()
+  const sameYear = date.getFullYear() === now.getFullYear()
+
+  const options: Intl.DateTimeFormatOptions = sameDay
+    ? { hour: 'numeric', minute: '2-digit' }
+    : sameYear
+      ? { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }
+      : { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' }
+
+  return new Intl.DateTimeFormat(undefined, options).format(date)
 }
 
 function compactJson(value: unknown) {
@@ -101,7 +144,16 @@ function inferLogSource(record: Record<string, unknown>) {
   const agent = asString(record.agent) ?? ''
   if (source.toLowerCase() === 'pi' || agent.toLowerCase() === 'pi') return 'pi'
   if (type === 'event_msg' || type === 'response_item' || payloadType) return 'codex'
-  if (type === 'user' || type === 'assistant' || type === 'system' || type === 'tool_use' || type === 'result') return 'claude'
+  if (
+    type === 'user' ||
+    type === 'assistant' ||
+    type === 'system' ||
+    type === 'tool_use' ||
+    type === 'tool_result' ||
+    type === 'result'
+  ) {
+    return 'claude'
+  }
   return 'log'
 }
 
@@ -128,7 +180,7 @@ function parseStructuredLogLine(line: string, lineNumber: number): StructuredLog
     const type = asString(record.type) ?? 'unknown'
     const payloadType = asString(payload?.type)
     const role = asString(record.role) ?? asString(message?.role) ?? asString(payload?.role)
-    const timestamp = asString(record.timestamp) ?? asString(payload?.timestamp)
+    const timestamp = extractLogTimestampFromRecord(record)
     const source = inferLogSource(record)
     const prominence = getStructuredProminence(
       type,
@@ -136,7 +188,6 @@ function parseStructuredLogLine(line: string, lineNumber: number): StructuredLog
       role ?? undefined
     )
     const titleParts = [
-      source.toUpperCase(),
       payloadType ? `${type} / ${payloadType}` : type,
       role,
     ].filter(Boolean)
@@ -210,10 +261,13 @@ function getStructuredProminence(
   }
   if (
     type === 'tool_use' ||
+    type === 'tool_result' ||
     type === 'result' ||
+    type.includes('tool') ||
     payloadType?.includes('tool') ||
     payloadType === 'function_call' ||
-    payloadType === 'function_call_output'
+    payloadType === 'function_call_output' ||
+    payloadType === 'custom_tool_call_output'
   ) {
     return 'tool'
   }
@@ -232,6 +286,7 @@ function mapNormalizedRoleToEntryType(role: string): ParsedEntry['type'] {
 function parseLogEntry(line: string, lineNumber: number): ParsedEntry[] {
   const parsed = parseAndNormalizeAgentLogLine(line)
   if (!parsed) return []
+  const timestamp = extractLogTimestamp(line)
 
   const entries = parsed.events
     .map((event) => ({
@@ -240,6 +295,7 @@ function parseLogEntry(line: string, lineNumber: number): ParsedEntry[] {
       content: event.text.trim(),
       raw: line,
       lineNumber,
+      ...(timestamp ? { timestamp } : {}),
     }))
     .filter((entry) => entry.content.length > 0)
 
@@ -275,6 +331,8 @@ function entryToneClass(entry: ParsedEntry) {
 
 function ToolEntry({ entry }: { entry: ParsedEntry }) {
   const [expanded, setExpanded] = useState(false)
+  const timestamp = formatLogTimestamp(entry.timestamp)
+  const marker = timestamp ?? `Line ${entry.lineNumber + 1}`
   const label = entry.kind === 'tool_call'
     ? entry.content
     : entry.kind === 'result'
@@ -292,7 +350,12 @@ function ToolEntry({ entry }: { entry: ParsedEntry }) {
         aria-expanded={expanded}
       >
         <span className="min-w-0 truncate">
-          <span className="mr-2 text-[10px] uppercase tracking-wide text-muted">L{entry.lineNumber + 1}</span>
+          <span
+            className="mr-2 text-[10px] uppercase tracking-wide text-muted"
+            title={timestamp ? `Line ${entry.lineNumber + 1} · ${entry.timestamp}` : undefined}
+          >
+            {marker}
+          </span>
           {label}
         </span>
         <span className="shrink-0 text-[11px]">{expanded ? 'Hide' : 'Show'}</span>
@@ -310,15 +373,20 @@ function TranscriptEntry({ entry }: { entry: ParsedEntry }) {
   if (entry.kind === 'tool_call' || entry.kind === 'tool_result' || entry.kind === 'result' || entry.type === 'tool') {
     return <ToolEntry entry={entry} />
   }
+  const timestamp = formatLogTimestamp(entry.timestamp)
+  const marker = timestamp ?? `Line ${entry.lineNumber + 1}`
 
   return (
-    <article className="grid grid-cols-[4.25rem_minmax(0,1fr)] gap-3 border-b border-border/60 py-4 last:border-b-0">
+    <article className="grid grid-cols-[5.75rem_minmax(0,1fr)] gap-3 border-b border-border/60 py-4 last:border-b-0 sm:grid-cols-[6.75rem_minmax(0,1fr)]">
       <div className="select-none pt-0.5 text-right">
         <div className={`text-[11px] font-semibold uppercase tracking-wide ${entryToneClass(entry)}`}>
           {entryLabel(entry)}
         </div>
-        <div className="mt-1 text-[10px] tabular-nums text-muted">
-          L{entry.lineNumber + 1}
+        <div
+          className="mt-1 text-[10px] tabular-nums text-muted"
+          title={timestamp ? `Line ${entry.lineNumber + 1} · ${entry.timestamp}` : undefined}
+        >
+          {marker}
         </div>
       </div>
       <div className="min-w-0 whitespace-pre-wrap break-words text-sm leading-6 text-primary">
@@ -329,8 +397,10 @@ function TranscriptEntry({ entry }: { entry: ParsedEntry }) {
 }
 
 function StructuredLogEntry({ entry }: { entry: StructuredLogLine }) {
+  const [bodyExpanded, setBodyExpanded] = useState(false)
   const isLowProminence = entry.prominence === 'system' || entry.prominence === 'plain'
   const collapseBody = entry.prominence === 'tool' && Boolean(entry.body && entry.body.length > 160)
+  const timestamp = formatLogTimestamp(entry.timestamp)
   const rowClass = isLowProminence
     ? 'border-border/70 bg-surface/20 opacity-80'
     : entry.prominence === 'tool'
@@ -342,9 +412,12 @@ function StructuredLogEntry({ entry }: { entry: StructuredLogLine }) {
 
   return (
     <article className={`rounded-md border ${rowClass}`}>
-      <div className="grid grid-cols-[3.5rem_minmax(0,1fr)] gap-3 px-3 py-2">
-        <div className="select-none text-right text-[11px] tabular-nums text-muted">
-          L{entry.lineNumber + 1}
+      <div className="grid grid-cols-[5.75rem_minmax(0,1fr)] gap-3 px-3 py-2 sm:grid-cols-[6.75rem_minmax(0,1fr)]">
+        <div
+          className="select-none text-right text-[11px] tabular-nums text-muted"
+          title={entry.timestamp ? `Line ${entry.lineNumber + 1} · ${entry.timestamp}` : undefined}
+        >
+          {timestamp ?? `Line ${entry.lineNumber + 1}`}
         </div>
         <div className="min-w-0 space-y-2">
           <div className="flex flex-wrap items-center gap-2">
@@ -354,11 +427,6 @@ function StructuredLogEntry({ entry }: { entry: StructuredLogLine }) {
             <span className="min-w-0 break-words text-xs font-semibold text-primary">
               {entry.title}
             </span>
-            {entry.timestamp && (
-              <span className="text-[11px] text-muted">
-                {entry.timestamp}
-              </span>
-            )}
           </div>
           {entry.body && !collapseBody && (
             <pre className="whitespace-pre-wrap break-words rounded bg-base px-3 py-2 text-xs leading-relaxed text-secondary">
@@ -366,14 +434,21 @@ function StructuredLogEntry({ entry }: { entry: StructuredLogLine }) {
             </pre>
           )}
           {entry.body && collapseBody && (
-            <details className="group rounded bg-base px-3 py-2">
-              <summary className="cursor-pointer select-none text-[11px] text-muted hover:text-primary">
+            <div className="rounded bg-base px-3 py-2">
+              <button
+                type="button"
+                className="select-none text-[11px] text-muted hover:text-primary"
+                aria-expanded={bodyExpanded}
+                onClick={() => setBodyExpanded((value) => !value)}
+              >
                 Output
-              </summary>
-              <pre className="mt-2 max-h-80 overflow-auto whitespace-pre-wrap break-words text-xs leading-relaxed text-secondary">
-                {entry.body}
-              </pre>
-            </details>
+              </button>
+              {bodyExpanded && (
+                <pre className="mt-2 max-h-80 overflow-auto whitespace-pre-wrap break-words text-xs leading-relaxed text-secondary">
+                  {entry.body}
+                </pre>
+              )}
+            </div>
           )}
           {entry.details.length > 0 && (
             <details className="group">
@@ -555,8 +630,8 @@ export default function SessionPreviewContent({
   ) ?? []
   const lineRangeLabel = previewData
     ? previewData.totalLines === 0
-      ? 'No transcript lines'
-      : `Lines ${previewData.startLine + 1}-${previewData.endLine} of ${previewData.totalLines}`
+      ? 'No transcript entries'
+      : `Showing ${previewData.lines.length} of ${previewData.totalLines} log entries`
     : 'Derived from the saved session log.'
 
   return (

--- a/src/client/components/SessionPreviewContent.tsx
+++ b/src/client/components/SessionPreviewContent.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from 'react'
-import { parseAndNormalizeAgentLogLine } from '@shared/eventTaxonomy'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { parseAndNormalizeAgentLogLine, type NormalizedEventKind } from '@shared/eventTaxonomy'
 import type { AgentSession } from '@shared/types'
 
 const PREVIEW_FETCH_TIMEOUT_MS = 10_000
+const PREVIEW_LINE_LIMIT = 200
 
 interface PreviewData {
   sessionId: string
@@ -10,31 +11,198 @@ interface PreviewData {
   projectPath: string
   agentType: string
   lastActivityAt: string
+  totalLines: number
+  startLine: number
+  endLine: number
+  hasMoreBefore: boolean
   lines: string[]
 }
 
 interface ParsedEntry {
-  type: 'user' | 'assistant' | 'system' | 'other'
+  type: 'user' | 'assistant' | 'system' | 'tool' | 'other'
+  kind: NormalizedEventKind
   content: string
   raw: string
+  lineNumber: number
+}
+
+interface StructuredLogLine {
+  lineNumber: number
+  parsed: boolean
+  raw: string
+  source: string
+  type: string
+  role?: string
+  timestamp?: string
+  title: string
+  body?: string
+  details: Array<{ label: string; value: string }>
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}
+
+function compactJson(value: unknown) {
+  if (value === undefined || value === null) return ''
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+function extractReadableText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        if (typeof item === 'string') return item
+        const record = asRecord(item)
+        if (!record) return ''
+        const type = asString(record.type)
+        if (type === 'thinking') return ''
+        if (type === 'tool_use') return `[Tool: ${asString(record.name) ?? 'tool'}]`
+        const text = asString(record.text) ?? asString(record.content) ?? asString(record.output)
+        if (text) return text
+        return ''
+      })
+      .filter(Boolean)
+      .join('\n\n')
+  }
+  const record = asRecord(value)
+  if (!record) return compactJson(value)
+  const type = asString(record.type)
+  if (type === 'thinking') return ''
+  if (type === 'tool_use') return `[Tool: ${asString(record.name) ?? 'tool'}]`
+  const nestedContent = extractReadableText(record.content)
+  if (nestedContent) return nestedContent
+  const nestedMessage = extractReadableText(record.message)
+  if (nestedMessage) return nestedMessage
+  return (
+    asString(record.text) ??
+    asString(record.output) ??
+    ''
+  )
+}
+
+function inferLogSource(record: Record<string, unknown>) {
+  const type = asString(record.type) ?? ''
+  const payload = asRecord(record.payload)
+  const payloadType = asString(payload?.type) ?? ''
+  const source = asString(record.source) ?? asString(payload?.source) ?? ''
+  const agent = asString(record.agent) ?? ''
+  if (source.toLowerCase() === 'pi' || agent.toLowerCase() === 'pi') return 'pi'
+  if (type === 'event_msg' || type === 'response_item' || payloadType) return 'codex'
+  if (type === 'user' || type === 'assistant' || type === 'system' || type === 'tool_use' || type === 'result') return 'claude'
+  return 'log'
+}
+
+function parseStructuredLogLine(line: string, lineNumber: number): StructuredLogLine {
+  try {
+    const parsed = JSON.parse(line) as unknown
+    const record = asRecord(parsed)
+    if (!record) {
+      return {
+        lineNumber,
+        parsed: true,
+        raw: line,
+        source: 'json',
+        type: Array.isArray(parsed) ? 'array' : typeof parsed,
+        title: Array.isArray(parsed) ? 'JSON array' : 'JSON value',
+        body: compactJson(parsed),
+        details: [],
+      }
+    }
+
+    const payload = asRecord(record.payload)
+    const message = asRecord(record.message)
+    const type = asString(record.type) ?? 'unknown'
+    const payloadType = asString(payload?.type)
+    const role = asString(record.role) ?? asString(message?.role) ?? asString(payload?.role)
+    const timestamp = asString(record.timestamp) ?? asString(payload?.timestamp)
+    const source = inferLogSource(record)
+    const titleParts = [
+      source.toUpperCase(),
+      payloadType ? `${type} / ${payloadType}` : type,
+      role,
+    ].filter(Boolean)
+
+    let body =
+      extractReadableText(message?.content) ||
+      extractReadableText(message?.message) ||
+      extractReadableText(payload?.message) ||
+      extractReadableText(payload?.content) ||
+      extractReadableText(payload?.text) ||
+      asString(record.result) ||
+      asString(record.name) ||
+      extractReadableText(record.content) ||
+      extractReadableText(record.text)
+
+    if (type === 'tool_use' && asString(record.name)) {
+      body = `[Tool: ${asString(record.name)}]`
+    }
+
+    const details = [
+      { label: 'uuid', value: asString(record.uuid) ?? '' },
+      { label: 'parent', value: asString(record.parentUuid) ?? '' },
+      { label: 'session', value: asString(record.sessionId) ?? asString(payload?.session_id) ?? '' },
+      { label: 'cwd', value: asString(record.cwd) ?? '' },
+      { label: 'metadata', value: compactJson(record.metadata ?? payload?.metadata) },
+      { label: 'payload', value: payload ? compactJson(payload) : '' },
+    ].filter((detail) => detail.value)
+
+    return {
+      lineNumber,
+      parsed: true,
+      raw: line,
+      source,
+      type: payloadType ? `${type}:${payloadType}` : type,
+      ...(role ? { role } : {}),
+      ...(timestamp ? { timestamp } : {}),
+      title: titleParts.join(' · '),
+      ...(body ? { body } : {}),
+      details,
+    }
+  } catch {
+    return {
+      lineNumber,
+      parsed: false,
+      raw: line,
+      source: 'text',
+      type: 'plain',
+      title: 'Plain text',
+      body: line,
+      details: [],
+    }
+  }
 }
 
 function mapNormalizedRoleToEntryType(role: string): ParsedEntry['type'] {
   if (role === 'user') return 'user'
   if (role === 'assistant') return 'assistant'
   if (role === 'system') return 'system'
+  if (role === 'tool') return 'tool'
   return 'other'
 }
 
-function parseLogEntry(line: string): ParsedEntry[] {
+function parseLogEntry(line: string, lineNumber: number): ParsedEntry[] {
   const parsed = parseAndNormalizeAgentLogLine(line)
   if (!parsed) return []
 
   const entries = parsed.events
     .map((event) => ({
       type: mapNormalizedRoleToEntryType(event.role),
+      kind: event.kind,
       content: event.text.trim(),
       raw: line,
+      lineNumber,
     }))
     .filter((entry) => entry.content.length > 0)
 
@@ -43,10 +211,130 @@ function parseLogEntry(line: string): ParsedEntry[] {
   }
 
   if (!parsed.parsed && line.trim()) {
-    return [{ type: 'other', content: line.trim(), raw: line }]
+    return [{ type: 'other', kind: 'unknown', content: line.trim(), raw: line, lineNumber }]
   }
 
   return []
+}
+
+function lineKey(entry: ParsedEntry, index: number) {
+  return `${entry.lineNumber}:${entry.kind}:${entry.type}:${index}`
+}
+
+function entryLabel(entry: ParsedEntry) {
+  if (entry.type === 'user') return 'User'
+  if (entry.type === 'assistant') return 'Assistant'
+  if (entry.type === 'system') return 'System'
+  if (entry.type === 'tool') return 'Tool'
+  return 'Log'
+}
+
+function ToolEntry({ entry }: { entry: ParsedEntry }) {
+  const [expanded, setExpanded] = useState(false)
+  const label = entry.kind === 'tool_call'
+    ? entry.content
+    : entry.kind === 'result'
+      ? 'Result'
+      : entry.kind === 'tool_result'
+        ? 'Tool result'
+        : entryLabel(entry)
+
+  return (
+    <div className="rounded border border-border bg-surface/60">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-xs text-muted hover:text-primary"
+        onClick={() => setExpanded((value) => !value)}
+        aria-expanded={expanded}
+      >
+        <span className="min-w-0 truncate">{label}</span>
+        <span className="shrink-0 text-[11px]">{expanded ? 'Hide' : 'Show'}</span>
+      </button>
+      {expanded && (
+        <pre className="max-h-80 overflow-auto border-t border-border px-3 py-2 whitespace-pre-wrap break-words text-xs leading-relaxed text-secondary">
+          {entry.content}
+        </pre>
+      )}
+    </div>
+  )
+}
+
+function TranscriptEntry({ entry }: { entry: ParsedEntry }) {
+  if (entry.kind === 'tool_call' || entry.kind === 'tool_result' || entry.kind === 'result' || entry.type === 'tool') {
+    return <ToolEntry entry={entry} />
+  }
+
+  const classes =
+    entry.type === 'user'
+      ? 'border-blue-500/20 bg-blue-500/10'
+      : entry.type === 'assistant'
+        ? 'border-emerald-500/20 bg-emerald-500/10'
+        : entry.type === 'system'
+          ? 'border-yellow-500/20 bg-yellow-500/10'
+          : 'border-border bg-surface/60'
+
+  return (
+    <article className={`rounded-lg border px-3 py-3 ${classes}`}>
+      <div className="mb-2 flex items-center justify-between gap-3 text-[11px] font-semibold uppercase tracking-wide text-muted">
+        <span>{entryLabel(entry)}</span>
+        <span className="font-normal normal-case tabular-nums">Line {entry.lineNumber + 1}</span>
+      </div>
+      <div className="whitespace-pre-wrap break-words text-sm leading-6 text-primary">
+        {entry.content}
+      </div>
+    </article>
+  )
+}
+
+function StructuredLogEntry({ entry }: { entry: StructuredLogLine }) {
+  return (
+    <article className="rounded border border-border bg-surface/40">
+      <div className="grid grid-cols-[3.5rem_minmax(0,1fr)] gap-3 px-3 py-2">
+        <div className="select-none text-right text-[11px] tabular-nums text-muted">
+          {entry.lineNumber + 1}
+        </div>
+        <div className="min-w-0 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded bg-accent/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent">
+              {entry.source}
+            </span>
+            <span className="min-w-0 break-words text-xs font-semibold text-primary">
+              {entry.title}
+            </span>
+            {entry.timestamp && (
+              <span className="text-[11px] text-muted">
+                {entry.timestamp}
+              </span>
+            )}
+          </div>
+          {entry.body && (
+            <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded bg-base px-3 py-2 text-xs leading-relaxed text-secondary">
+              {entry.body}
+            </pre>
+          )}
+          {entry.details.length > 0 && (
+            <details className="group">
+              <summary className="cursor-pointer select-none text-[11px] text-muted hover:text-primary">
+                Details
+              </summary>
+              <div className="mt-2 space-y-2">
+                {entry.details.map((detail) => (
+                  <div key={detail.label}>
+                    <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-muted">
+                      {detail.label}
+                    </div>
+                    <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded bg-base px-3 py-2 text-[11px] leading-relaxed text-muted">
+                      {detail.value}
+                    </pre>
+                  </div>
+                ))}
+              </div>
+            </details>
+          )}
+        </div>
+      </div>
+    </article>
+  )
 }
 
 interface SessionPreviewContentProps {
@@ -61,10 +349,12 @@ export default function SessionPreviewContent({
   onStateChange,
 }: SessionPreviewContentProps) {
   const [loading, setLoading] = useState(true)
+  const [loadingEarlier, setLoadingEarlier] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [previewData, setPreviewData] = useState<PreviewData | null>(null)
   const [showRaw, setShowRaw] = useState(false)
   const contentRef = useRef<HTMLDivElement>(null)
+  const preserveScrollRef = useRef<{ scrollHeight: number; scrollTop: number } | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -79,7 +369,7 @@ export default function SessionPreviewContent({
 
       try {
         const response = await fetch(
-          `/api/session-preview/${session.sessionId}`,
+          `/api/session-preview/${session.sessionId}?limit=${PREVIEW_LINE_LIMIT}`,
           { signal: controller.signal }
         )
         if (!response.ok) {
@@ -120,31 +410,107 @@ export default function SessionPreviewContent({
     }
   }, [session.sessionId])
 
+  const loadEarlier = async () => {
+    if (!previewData || loadingEarlier || !previewData.hasMoreBefore) return
+    const scroller = contentRef.current
+    if (scroller) {
+      preserveScrollRef.current = {
+        scrollHeight: scroller.scrollHeight,
+        scrollTop: scroller.scrollTop,
+      }
+    }
+
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), PREVIEW_FETCH_TIMEOUT_MS)
+    setLoadingEarlier(true)
+    setError(null)
+
+    try {
+      const params = new URLSearchParams({
+        limit: String(PREVIEW_LINE_LIMIT),
+        beforeLine: String(previewData.startLine),
+      })
+      const response = await fetch(
+        `/api/session-preview/${session.sessionId}?${params.toString()}`,
+        { signal: controller.signal }
+      )
+      if (!response.ok) {
+        let message = `Failed to load preview (HTTP ${response.status})`
+        try {
+          const data = (await response.json()) as { error?: string }
+          if (data?.error) message = data.error
+        } catch {
+          // Non-JSON — keep default message.
+        }
+        throw new Error(message)
+      }
+      const data = (await response.json()) as PreviewData
+      setPreviewData((current) => {
+        if (!current) return data
+        return {
+          ...current,
+          startLine: data.startLine,
+          hasMoreBefore: data.hasMoreBefore,
+          lines: [...data.lines, ...current.lines],
+        }
+      })
+    } catch (err) {
+      preserveScrollRef.current = null
+      if (controller.signal.aborted) {
+        setError('Preview timed out')
+      } else {
+        setError(err instanceof Error ? err.message : 'Failed to load preview')
+      }
+    } finally {
+      clearTimeout(timeoutId)
+      setLoadingEarlier(false)
+    }
+  }
+
   useEffect(() => {
     onStateChange?.({ loading, error })
   }, [error, loading, onStateChange])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    const preserve = preserveScrollRef.current
+    if (contentRef.current && preserve) {
+      contentRef.current.scrollTop =
+        contentRef.current.scrollHeight - preserve.scrollHeight + preserve.scrollTop
+      preserveScrollRef.current = null
+      return
+    }
     if (contentRef.current && previewData) {
       contentRef.current.scrollTop = contentRef.current.scrollHeight
     }
   }, [previewData, showRaw])
 
-  const parsedEntries = previewData?.lines.flatMap(parseLogEntry).slice(-30) ?? []
+  const parsedEntries = previewData?.lines.flatMap((line, index) =>
+    parseLogEntry(line, previewData.startLine + index)
+  ) ?? []
+  const structuredLines = previewData?.lines.map((line, index) =>
+    parseStructuredLogLine(line, previewData.startLine + index)
+  ) ?? []
+  const lineRangeLabel = previewData
+    ? previewData.totalLines === 0
+      ? 'No transcript lines'
+      : `Lines ${previewData.startLine + 1}-${previewData.endLine} of ${previewData.totalLines}`
+    : 'Derived from the saved session log.'
 
   return (
     <div className={`flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-elevated ${className}`.trim()}>
       <div className="flex items-center justify-between border-b border-border px-4 py-3">
         <div>
-          <h3 className="text-sm font-semibold text-primary">Recent Preview</h3>
-          <p className="text-xs text-muted">Derived from the saved session log.</p>
+          <h3 className="text-sm font-semibold text-primary">Transcript</h3>
+          <p className="text-xs text-muted">
+            {lineRangeLabel}
+          </p>
         </div>
         <button
           type="button"
           onClick={() => setShowRaw((value) => !value)}
           className={`btn text-xs ${showRaw ? 'btn-primary' : ''}`}
         >
-          {showRaw ? 'Parsed' : 'Raw'}
+          {showRaw ? 'Messages' : 'Log lines'}
         </button>
       </div>
 
@@ -163,42 +529,48 @@ export default function SessionPreviewContent({
           </div>
         )}
         {previewData && !showRaw && (
-          <div className="space-y-2">
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
+            {previewData.hasMoreBefore && (
+              <button
+                type="button"
+                className="btn mx-auto"
+                onClick={loadEarlier}
+                disabled={loadingEarlier}
+              >
+                {loadingEarlier ? 'Loading...' : 'Load earlier'}
+              </button>
+            )}
             {parsedEntries.length === 0 ? (
               <div className="py-8 text-center text-muted">
                 No readable content found. Try raw view.
               </div>
             ) : (
               parsedEntries.map((entry, i) => (
-                <div
-                  key={i}
-                  className={`rounded px-2 py-1 ${
-                    entry.type === 'user'
-                      ? 'bg-blue-500/10 text-blue-400'
-                      : entry.type === 'assistant'
-                        ? 'bg-emerald-500/10 text-emerald-400'
-                        : entry.type === 'system'
-                          ? 'bg-yellow-500/10 text-yellow-400'
-                          : 'text-muted'
-                  }`}
-                >
-                  <span className="whitespace-pre-wrap break-words">
-                    {entry.content.length > 500
-                      ? `${entry.content.slice(0, 500)}...`
-                      : entry.content}
-                  </span>
-                </div>
+                <TranscriptEntry key={lineKey(entry, i)} entry={entry} />
               ))
             )}
           </div>
         )}
         {previewData && showRaw && (
-          <div className="space-y-1">
-            {previewData.lines.slice(-50).map((line, i) => (
-              <div key={i} className="whitespace-pre-wrap break-all text-muted">
-                {line || ' '}
-              </div>
-            ))}
+          <div className="mx-auto flex w-full max-w-5xl flex-col gap-2">
+            {previewData.hasMoreBefore && (
+              <button
+                type="button"
+                className="btn mx-auto"
+                onClick={loadEarlier}
+                disabled={loadingEarlier}
+              >
+                {loadingEarlier ? 'Loading...' : 'Load earlier'}
+              </button>
+            )}
+            <div className="space-y-2">
+              {structuredLines.map((entry) => (
+                <StructuredLogEntry
+                  key={`${entry.lineNumber}:${entry.type}:${entry.raw.slice(0, 24)}`}
+                  entry={entry}
+                />
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/src/client/components/SessionPreviewContent.tsx
+++ b/src/client/components/SessionPreviewContent.tsx
@@ -32,6 +32,7 @@ interface StructuredLogLine {
   raw: string
   source: string
   type: string
+  prominence: 'message' | 'tool' | 'system' | 'plain'
   role?: string
   timestamp?: string
   title: string
@@ -115,6 +116,7 @@ function parseStructuredLogLine(line: string, lineNumber: number): StructuredLog
         raw: line,
         source: 'json',
         type: Array.isArray(parsed) ? 'array' : typeof parsed,
+        prominence: 'plain',
         title: Array.isArray(parsed) ? 'JSON array' : 'JSON value',
         body: compactJson(parsed),
         details: [],
@@ -128,6 +130,11 @@ function parseStructuredLogLine(line: string, lineNumber: number): StructuredLog
     const role = asString(record.role) ?? asString(message?.role) ?? asString(payload?.role)
     const timestamp = asString(record.timestamp) ?? asString(payload?.timestamp)
     const source = inferLogSource(record)
+    const prominence = getStructuredProminence(
+      type,
+      payloadType ?? undefined,
+      role ?? undefined
+    )
     const titleParts = [
       source.toUpperCase(),
       payloadType ? `${type} / ${payloadType}` : type,
@@ -164,6 +171,7 @@ function parseStructuredLogLine(line: string, lineNumber: number): StructuredLog
       raw: line,
       source,
       type: payloadType ? `${type}:${payloadType}` : type,
+      prominence,
       ...(role ? { role } : {}),
       ...(timestamp ? { timestamp } : {}),
       title: titleParts.join(' · '),
@@ -177,11 +185,40 @@ function parseStructuredLogLine(line: string, lineNumber: number): StructuredLog
       raw: line,
       source: 'text',
       type: 'plain',
+      prominence: 'plain',
       title: 'Plain text',
       body: line,
       details: [],
     }
   }
+}
+
+function getStructuredProminence(
+  type: string,
+  payloadType?: string,
+  role?: string
+): StructuredLogLine['prominence'] {
+  if (role === 'user' || role === 'assistant') return 'message'
+  if (
+    type === 'user' ||
+    type === 'assistant' ||
+    payloadType === 'user_message' ||
+    payloadType === 'assistant_message' ||
+    payloadType === 'message'
+  ) {
+    return 'message'
+  }
+  if (
+    type === 'tool_use' ||
+    type === 'result' ||
+    payloadType?.includes('tool') ||
+    payloadType === 'function_call' ||
+    payloadType === 'function_call_output'
+  ) {
+    return 'tool'
+  }
+  if (type === 'plain') return 'plain'
+  return 'system'
 }
 
 function mapNormalizedRoleToEntryType(role: string): ParsedEntry['type'] {
@@ -229,6 +266,13 @@ function entryLabel(entry: ParsedEntry) {
   return 'Log'
 }
 
+function entryToneClass(entry: ParsedEntry) {
+  if (entry.type === 'user') return 'text-blue-400'
+  if (entry.type === 'assistant') return 'text-emerald-400'
+  if (entry.type === 'system') return 'text-yellow-400'
+  return 'text-muted'
+}
+
 function ToolEntry({ entry }: { entry: ParsedEntry }) {
   const [expanded, setExpanded] = useState(false)
   const label = entry.kind === 'tool_call'
@@ -240,14 +284,17 @@ function ToolEntry({ entry }: { entry: ParsedEntry }) {
         : entryLabel(entry)
 
   return (
-    <div className="rounded border border-border bg-surface/60">
+    <div className="rounded-md border border-border bg-surface/40">
       <button
         type="button"
         className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-xs text-muted hover:text-primary"
         onClick={() => setExpanded((value) => !value)}
         aria-expanded={expanded}
       >
-        <span className="min-w-0 truncate">{label}</span>
+        <span className="min-w-0 truncate">
+          <span className="mr-2 text-[10px] uppercase tracking-wide text-muted">L{entry.lineNumber + 1}</span>
+          {label}
+        </span>
         <span className="shrink-0 text-[11px]">{expanded ? 'Hide' : 'Show'}</span>
       </button>
       {expanded && (
@@ -264,22 +311,17 @@ function TranscriptEntry({ entry }: { entry: ParsedEntry }) {
     return <ToolEntry entry={entry} />
   }
 
-  const classes =
-    entry.type === 'user'
-      ? 'border-blue-500/20 bg-blue-500/10'
-      : entry.type === 'assistant'
-        ? 'border-emerald-500/20 bg-emerald-500/10'
-        : entry.type === 'system'
-          ? 'border-yellow-500/20 bg-yellow-500/10'
-          : 'border-border bg-surface/60'
-
   return (
-    <article className={`rounded-lg border px-3 py-3 ${classes}`}>
-      <div className="mb-2 flex items-center justify-between gap-3 text-[11px] font-semibold uppercase tracking-wide text-muted">
-        <span>{entryLabel(entry)}</span>
-        <span className="font-normal normal-case tabular-nums">Line {entry.lineNumber + 1}</span>
+    <article className="grid grid-cols-[4.25rem_minmax(0,1fr)] gap-3 border-b border-border/60 py-4 last:border-b-0">
+      <div className="select-none pt-0.5 text-right">
+        <div className={`text-[11px] font-semibold uppercase tracking-wide ${entryToneClass(entry)}`}>
+          {entryLabel(entry)}
+        </div>
+        <div className="mt-1 text-[10px] tabular-nums text-muted">
+          L{entry.lineNumber + 1}
+        </div>
       </div>
-      <div className="whitespace-pre-wrap break-words text-sm leading-6 text-primary">
+      <div className="min-w-0 whitespace-pre-wrap break-words text-sm leading-6 text-primary">
         {entry.content}
       </div>
     </article>
@@ -287,15 +329,26 @@ function TranscriptEntry({ entry }: { entry: ParsedEntry }) {
 }
 
 function StructuredLogEntry({ entry }: { entry: StructuredLogLine }) {
+  const isLowProminence = entry.prominence === 'system' || entry.prominence === 'plain'
+  const collapseBody = entry.prominence === 'tool' && Boolean(entry.body && entry.body.length > 160)
+  const rowClass = isLowProminence
+    ? 'border-border/70 bg-surface/20 opacity-80'
+    : entry.prominence === 'tool'
+      ? 'border-border bg-surface/35'
+      : 'border-border bg-surface/50'
+  const sourceClass = entry.prominence === 'message'
+    ? 'bg-accent/15 text-accent'
+    : 'bg-surface text-muted'
+
   return (
-    <article className="rounded border border-border bg-surface/40">
+    <article className={`rounded-md border ${rowClass}`}>
       <div className="grid grid-cols-[3.5rem_minmax(0,1fr)] gap-3 px-3 py-2">
         <div className="select-none text-right text-[11px] tabular-nums text-muted">
-          {entry.lineNumber + 1}
+          L{entry.lineNumber + 1}
         </div>
         <div className="min-w-0 space-y-2">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="rounded bg-accent/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent">
+            <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${sourceClass}`}>
               {entry.source}
             </span>
             <span className="min-w-0 break-words text-xs font-semibold text-primary">
@@ -307,10 +360,20 @@ function StructuredLogEntry({ entry }: { entry: StructuredLogLine }) {
               </span>
             )}
           </div>
-          {entry.body && (
-            <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded bg-base px-3 py-2 text-xs leading-relaxed text-secondary">
+          {entry.body && !collapseBody && (
+            <pre className="whitespace-pre-wrap break-words rounded bg-base px-3 py-2 text-xs leading-relaxed text-secondary">
               {entry.body}
             </pre>
+          )}
+          {entry.body && collapseBody && (
+            <details className="group rounded bg-base px-3 py-2">
+              <summary className="cursor-pointer select-none text-[11px] text-muted hover:text-primary">
+                Output
+              </summary>
+              <pre className="mt-2 max-h-80 overflow-auto whitespace-pre-wrap break-words text-xs leading-relaxed text-secondary">
+                {entry.body}
+              </pre>
+            </details>
           )}
           {entry.details.length > 0 && (
             <details className="group">
@@ -352,7 +415,7 @@ export default function SessionPreviewContent({
   const [loadingEarlier, setLoadingEarlier] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [previewData, setPreviewData] = useState<PreviewData | null>(null)
-  const [showRaw, setShowRaw] = useState(false)
+  const [viewMode, setViewMode] = useState<'messages' | 'events'>('messages')
   const contentRef = useRef<HTMLDivElement>(null)
   const preserveScrollRef = useRef<{ scrollHeight: number; scrollTop: number } | null>(null)
 
@@ -482,7 +545,7 @@ export default function SessionPreviewContent({
     if (contentRef.current && previewData) {
       contentRef.current.scrollTop = contentRef.current.scrollHeight
     }
-  }, [previewData, showRaw])
+  }, [previewData, viewMode])
 
   const parsedEntries = previewData?.lines.flatMap((line, index) =>
     parseLogEntry(line, previewData.startLine + index)
@@ -498,20 +561,39 @@ export default function SessionPreviewContent({
 
   return (
     <div className={`flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-elevated ${className}`.trim()}>
-      <div className="flex items-center justify-between border-b border-border px-4 py-3">
+      <div className="flex flex-col gap-3 border-b border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h3 className="text-sm font-semibold text-primary">Transcript</h3>
           <p className="text-xs text-muted">
             {lineRangeLabel}
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => setShowRaw((value) => !value)}
-          className={`btn text-xs ${showRaw ? 'btn-primary' : ''}`}
-        >
-          {showRaw ? 'Messages' : 'Log lines'}
-        </button>
+        <div className="inline-flex w-fit rounded-md border border-border bg-base p-0.5">
+          <button
+            type="button"
+            onClick={() => setViewMode('messages')}
+            className={`rounded px-2.5 py-1 text-xs transition-colors ${
+              viewMode === 'messages'
+                ? 'bg-accent text-white'
+                : 'text-muted hover:text-primary'
+            }`}
+            aria-pressed={viewMode === 'messages'}
+          >
+            Messages
+          </button>
+          <button
+            type="button"
+            onClick={() => setViewMode('events')}
+            className={`rounded px-2.5 py-1 text-xs transition-colors ${
+              viewMode === 'events'
+                ? 'bg-accent text-white'
+                : 'text-muted hover:text-primary'
+            }`}
+            aria-pressed={viewMode === 'events'}
+          >
+            Events
+          </button>
+        </div>
       </div>
 
       <div
@@ -528,12 +610,12 @@ export default function SessionPreviewContent({
             {error}
           </div>
         )}
-        {previewData && !showRaw && (
-          <div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
+        {previewData && viewMode === 'messages' && (
+          <div className="mx-auto flex w-full max-w-4xl flex-col">
             {previewData.hasMoreBefore && (
               <button
                 type="button"
-                className="btn mx-auto"
+                className="btn mx-auto mb-3"
                 onClick={loadEarlier}
                 disabled={loadingEarlier}
               >
@@ -542,7 +624,7 @@ export default function SessionPreviewContent({
             )}
             {parsedEntries.length === 0 ? (
               <div className="py-8 text-center text-muted">
-                No readable content found. Try raw view.
+                No readable messages found. Try Events.
               </div>
             ) : (
               parsedEntries.map((entry, i) => (
@@ -551,7 +633,7 @@ export default function SessionPreviewContent({
             )}
           </div>
         )}
-        {previewData && showRaw && (
+        {previewData && viewMode === 'events' && (
           <div className="mx-auto flex w-full max-w-5xl flex-col gap-2">
             {previewData.hasMoreBefore && (
               <button

--- a/src/client/components/SessionPreviewContent.tsx
+++ b/src/client/components/SessionPreviewContent.tsx
@@ -24,6 +24,10 @@ interface ParsedEntry {
   content: string
   raw: string
   lineNumber: number
+  // Index of this entry within its source line. Combined with lineNumber it forms
+  // a stable React key that survives prepending earlier history (positional keys
+  // would shift and force a full remount, collapsing expanded tool entries).
+  seq: number
   timestamp?: string
 }
 
@@ -289,12 +293,13 @@ function parseLogEntry(line: string, lineNumber: number): ParsedEntry[] {
   const timestamp = extractLogTimestamp(line)
 
   const entries = parsed.events
-    .map((event) => ({
+    .map((event, seq) => ({
       type: mapNormalizedRoleToEntryType(event.role),
       kind: event.kind,
       content: event.text.trim(),
       raw: line,
       lineNumber,
+      seq,
       ...(timestamp ? { timestamp } : {}),
     }))
     .filter((entry) => entry.content.length > 0)
@@ -304,14 +309,14 @@ function parseLogEntry(line: string, lineNumber: number): ParsedEntry[] {
   }
 
   if (!parsed.parsed && line.trim()) {
-    return [{ type: 'other', kind: 'unknown', content: line.trim(), raw: line, lineNumber }]
+    return [{ type: 'other', kind: 'unknown', content: line.trim(), raw: line, lineNumber, seq: 0 }]
   }
 
   return []
 }
 
-function lineKey(entry: ParsedEntry, index: number) {
-  return `${entry.lineNumber}:${entry.kind}:${entry.type}:${index}`
+function lineKey(entry: ParsedEntry) {
+  return `${entry.lineNumber}:${entry.seq}`
 }
 
 function entryLabel(entry: ParsedEntry) {
@@ -702,8 +707,8 @@ export default function SessionPreviewContent({
                 No readable messages found. Try Events.
               </div>
             ) : (
-              parsedEntries.map((entry, i) => (
-                <TranscriptEntry key={lineKey(entry, i)} entry={entry} />
+              parsedEntries.map((entry) => (
+                <TranscriptEntry key={lineKey(entry)} entry={entry} />
               ))
             )}
           </div>

--- a/src/client/components/Terminal.tsx
+++ b/src/client/components/Terminal.tsx
@@ -1051,7 +1051,7 @@ export default function Terminal({
           {hibernatingSession && (
             <button
               onClick={() => onResumeSession(hibernatingSession.sessionId)}
-              className="btn btn-primary h-7 px-2 text-xs"
+              className="btn btn-primary h-7 px-2 text-xs md:hidden"
             >
               Wake
             </button>
@@ -1177,45 +1177,38 @@ export default function Terminal({
         )}
         {hibernatingSession && (
           <div className="absolute inset-0 z-10 overflow-y-auto bg-base">
-            <div className="mx-auto flex h-full w-full max-w-4xl flex-col gap-6 p-6">
-              <div className="rounded-2xl border border-border bg-elevated p-6">
-                <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-                  <div className="space-y-3">
-                    <div className="flex items-center gap-2">
-                      <span className="rounded-full bg-blue-500/15 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-blue-400">
-                        Hibernating
-                      </span>
-                      {hibernatingSession.lastResumeError && (
-                        <span
-                          className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-1 text-[11px] text-amber-400"
-                          title={`Last wake failed: ${hibernatingSession.lastResumeError}`}
-                        >
-                          <AlertTriangleIcon width={12} height={12} />
-                          Wake failed
-                        </span>
-                      )}
-                    </div>
-                    <div>
-                      <h2 className="text-xl font-semibold text-primary">
+            <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col gap-4 p-4 md:p-6">
+              <div className="border-b border-border pb-4">
+                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                  <div className="min-w-0 space-y-2">
+                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+                      <h2 className="min-w-0 truncate text-lg font-semibold text-primary">
                         {hibernatingDisplayName}
                       </h2>
-                      <p className="mt-1 text-sm text-secondary">
-                        Wake this session to reopen its underlying app and terminal.
-                      </p>
-                    </div>
-                    <div className="flex flex-wrap gap-2 text-xs text-muted">
+                      <span className="rounded-full bg-blue-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-400">
+                        Hibernating
+                      </span>
                       {hibernatingProjectName && (
-                        <span className="rounded-full bg-surface px-2.5 py-1">
+                        <span className="text-muted">
                           {hibernatingProjectName}
                         </span>
                       )}
-                      <span className="rounded-full bg-surface px-2.5 py-1">
+                      <span className="text-muted">
                         Last active {hibernatingLastActivity}
                       </span>
                     </div>
+                    {hibernatingSession.lastResumeError && (
+                      <div
+                        className="inline-flex items-center gap-1 rounded bg-amber-500/15 px-2 py-1 text-xs text-amber-400"
+                        title={`Last wake failed: ${hibernatingSession.lastResumeError}`}
+                      >
+                        <AlertTriangleIcon width={12} height={12} />
+                        Last wake failed
+                      </div>
+                    )}
                     {hibernatingSession.lastUserMessage && (
-                      <p className="max-w-2xl text-sm italic text-muted">
-                        "{hibernatingSession.lastUserMessage}"
+                      <p className="max-w-3xl whitespace-pre-wrap break-words text-sm leading-6 text-secondary">
+                        {hibernatingSession.lastUserMessage}
                       </p>
                     )}
                   </div>
@@ -1223,9 +1216,9 @@ export default function Terminal({
                     <button
                       type="button"
                       onClick={() => onResumeSession(hibernatingSession.sessionId)}
-                      className="btn btn-primary"
+                      className="btn btn-primary hidden md:inline-flex"
                     >
-                      Wake Session
+                      Wake
                     </button>
                     {onMoveToHistory && (
                       <button

--- a/src/client/components/Terminal.tsx
+++ b/src/client/components/Terminal.tsx
@@ -1207,7 +1207,7 @@ export default function Terminal({
                       </div>
                     )}
                     {hibernatingSession.lastUserMessage && (
-                      <p className="max-w-3xl whitespace-pre-wrap break-words text-sm leading-6 text-secondary">
+                      <p className="max-h-28 max-w-3xl overflow-y-auto whitespace-pre-wrap break-words pr-2 text-sm leading-6 text-secondary">
                         {hibernatingSession.lastUserMessage}
                       </p>
                     )}

--- a/src/client/components/Terminal.tsx
+++ b/src/client/components/Terminal.tsx
@@ -927,6 +927,16 @@ export default function Terminal({
     }
   }, [containerRef, isiOS, isSelectingText])
 
+  // While the hibernation overlay is up, mark the terminal underneath as `inert`
+  // rather than just `aria-hidden`: inert also drops its xterm helper textarea out
+  // of the tab order, so focus can't land on a hidden, unreachable element.
+  useEffect(() => {
+    const container = containerRef.current
+    if (container) {
+      container.inert = !!hibernatingSession
+    }
+  }, [containerRef, hibernatingSession])
+
   // Use session names as mobile tab labels only when AGENTBOARD_PREFER_WINDOW_NAME is
   // enabled AND every session has a distinct, non-empty name. Otherwise tabs would
   // repeat the same label and numeric indices remain the better signal.
@@ -1151,11 +1161,7 @@ export default function Terminal({
 
       {/* Terminal content - always rendered so ref is attached */}
       <div className="relative flex-1">
-        <div
-          ref={containerRef}
-          className={`absolute inset-0 ${hibernatingSession ? 'pointer-events-none' : ''}`}
-          aria-hidden={hibernatingSession ? 'true' : undefined}
-        />
+        <div ref={containerRef} className="absolute inset-0" />
         {isSwitching && session && (
           <div className="absolute top-2 left-2 z-50 flex items-center gap-1.5 rounded-lg bg-black/60 px-2.5 py-1.5 text-xs text-white/90 shadow-lg backdrop-blur-md">
             <svg className="h-3 w-3 animate-spin" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/client/components/Terminal.tsx
+++ b/src/client/components/Terminal.tsx
@@ -1151,7 +1151,11 @@ export default function Terminal({
 
       {/* Terminal content - always rendered so ref is attached */}
       <div className="relative flex-1">
-        <div ref={containerRef} className="absolute inset-0" />
+        <div
+          ref={containerRef}
+          className={`absolute inset-0 ${hibernatingSession ? 'pointer-events-none' : ''}`}
+          aria-hidden={hibernatingSession ? 'true' : undefined}
+        />
         {isSwitching && session && (
           <div className="absolute top-2 left-2 z-50 flex items-center gap-1.5 rounded-lg bg-black/60 px-2.5 py-1.5 text-xs text-white/90 shadow-lg backdrop-blur-md">
             <svg className="h-3 w-3 animate-spin" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -1172,7 +1176,7 @@ export default function Terminal({
           </div>
         )}
         {hibernatingSession && (
-          <div className="absolute inset-0 overflow-y-auto bg-base">
+          <div className="absolute inset-0 z-10 overflow-y-auto bg-base">
             <div className="mx-auto flex h-full w-full max-w-4xl flex-col gap-6 p-6">
               <div className="rounded-2xl border border-border bg-elevated p-6">
                 <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -4913,6 +4913,55 @@ describe('server fetch handlers', () => {
     }
   })
 
+  test('serves fresh content after the preview log is rewritten', async () => {
+    const { serveOptions } = await loadIndex()
+    const fetchHandler = serveOptions.fetch
+    if (!fetchHandler) {
+      throw new Error('Fetch handler not configured')
+    }
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-preview-refresh-'))
+    const logPath = path.join(tempDir, 'session.jsonl')
+    await fs.writeFile(logPath, ['line-a', 'line-b'].join('\n'))
+
+    seedRecord(
+      makeRecord({
+        sessionId: 'session-preview-refresh',
+        logFilePath: logPath,
+        displayName: 'Preview',
+        projectPath: '/tmp/preview',
+        agentType: 'codex',
+      })
+    )
+
+    const request = () =>
+      fetchHandler.call(
+        {} as Bun.Server<unknown>,
+        new Request('http://localhost/api/session-preview/session-preview-refresh'),
+        {} as Bun.Server<unknown>
+      )
+
+    try {
+      const first = await request()
+      if (!first) throw new Error('Expected first preview response')
+      const firstPayload = (await first.json()) as { totalLines: number; lines: string[] }
+      expect(firstPayload.totalLines).toBe(2)
+      expect(firstPayload.lines).toEqual(['line-a', 'line-b'])
+
+      // Rewrite with different content (and different size) so size+mtime keying
+      // invalidates the cached line array instead of serving stale data.
+      await fs.writeFile(logPath, ['line-c', 'line-d', 'line-e'].join('\n'))
+
+      const second = await request()
+      if (!second) throw new Error('Expected second preview response')
+      const secondPayload = (await second.json()) as { totalLines: number; lines: string[] }
+      expect(secondPayload.totalLines).toBe(3)
+      expect(secondPayload.lines).toEqual(['line-c', 'line-d', 'line-e'])
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
   test('returns 404 when session preview log is missing', async () => {
     const { serveOptions } = await loadIndex()
     const fetchHandler = serveOptions.fetch

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -4962,6 +4962,59 @@ describe('server fetch handlers', () => {
     }
   })
 
+  test('treats empty limit/beforeLine query params as absent', async () => {
+    const { serveOptions } = await loadIndex()
+    const fetchHandler = serveOptions.fetch
+    if (!fetchHandler) {
+      throw new Error('Fetch handler not configured')
+    }
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-preview-empty-'))
+    const logPath = path.join(tempDir, 'session.jsonl')
+    await fs.writeFile(logPath, ['line-0', 'line-1', 'line-2', 'line-3', 'line-4'].join('\n'))
+
+    seedRecord(
+      makeRecord({
+        sessionId: 'session-preview-empty',
+        logFilePath: logPath,
+        displayName: 'Preview',
+        projectPath: '/tmp/preview',
+        agentType: 'codex',
+      })
+    )
+
+    try {
+      const response = await fetchHandler.call(
+        {} as Bun.Server<unknown>,
+        new Request('http://localhost/api/session-preview/session-preview-empty?limit=&beforeLine='),
+        {} as Bun.Server<unknown>
+      )
+
+      if (!response) {
+        throw new Error('Expected response for session preview')
+      }
+
+      expect(response.ok).toBe(true)
+      const payload = (await response.json()) as {
+        totalLines: number
+        startLine: number
+        endLine: number
+        hasMoreBefore: boolean
+        lines: string[]
+      }
+      // Empty limit must fall back to the default window, not collapse to 1 line
+      // (Number('') === 0 -> Math.max(1, 0) === 1), and empty beforeLine must mean
+      // "latest" rather than "before line 0".
+      expect(payload.totalLines).toBe(5)
+      expect(payload.startLine).toBe(0)
+      expect(payload.endLine).toBe(5)
+      expect(payload.hasMoreBefore).toBe(false)
+      expect(payload.lines).toHaveLength(5)
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
   test('returns 404 when session preview log is missing', async () => {
     const { serveOptions } = await loadIndex()
     const fetchHandler = serveOptions.fetch

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -4836,7 +4836,7 @@ describe('server fetch handlers', () => {
 
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-preview-'))
     const logPath = path.join(tempDir, 'session.jsonl')
-    const lines = Array.from({ length: 120 }, (_, index) => `line-${index}`)
+    const lines = Array.from({ length: 250 }, (_, index) => `line-${index}`)
     await fs.writeFile(logPath, lines.join('\n'))
 
     seedRecord(
@@ -4866,14 +4866,48 @@ describe('server fetch handlers', () => {
         displayName: string
         projectPath: string
         agentType: string
+        totalLines: number
+        startLine: number
+        endLine: number
+        hasMoreBefore: boolean
         lines: string[]
       }
       expect(payload.sessionId).toBe('session-preview')
       expect(payload.displayName).toBe('Preview')
       expect(payload.projectPath).toBe('/tmp/preview')
       expect(payload.agentType).toBe('codex')
-      expect(payload.lines).toHaveLength(100)
-      expect(payload.lines[0]).toBe('line-20')
+      expect(payload.totalLines).toBe(250)
+      expect(payload.startLine).toBe(50)
+      expect(payload.endLine).toBe(250)
+      expect(payload.hasMoreBefore).toBe(true)
+      expect(payload.lines).toHaveLength(200)
+      expect(payload.lines[0]).toBe('line-50')
+
+      const earlierResponse = await fetchHandler.call(
+        {} as Bun.Server<unknown>,
+        new Request('http://localhost/api/session-preview/session-preview?beforeLine=50&limit=30'),
+        {} as Bun.Server<unknown>
+      )
+
+      if (!earlierResponse) {
+        throw new Error('Expected earlier response for session preview')
+      }
+
+      expect(earlierResponse.ok).toBe(true)
+      const earlierPayload = (await earlierResponse.json()) as {
+        totalLines: number
+        startLine: number
+        endLine: number
+        hasMoreBefore: boolean
+        lines: string[]
+      }
+      expect(earlierPayload.totalLines).toBe(250)
+      expect(earlierPayload.startLine).toBe(20)
+      expect(earlierPayload.endLine).toBe(50)
+      expect(earlierPayload.hasMoreBefore).toBe(true)
+      expect(earlierPayload.lines).toHaveLength(30)
+      expect(earlierPayload.lines[0]).toBe('line-20')
+      expect(earlierPayload.lines[29]).toBe('line-49')
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true })
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -113,7 +113,75 @@ interface LogLineWindow {
   lines: string[]
 }
 
-async function readLogLineWindow(
+// Hibernated session logs are static (the session is no longer writing to them),
+// so the parsed line array is cached and re-sliced for pagination instead of
+// re-scanning the whole file on every "Load earlier" request. Entries are keyed
+// by size+mtime so a rewritten log self-invalidates, and the cache is byte-bounded
+// so it can't grow without limit.
+interface CachedLogLines {
+  size: number
+  mtimeMs: number
+  lines: string[]
+}
+const LOG_LINE_CACHE = new Map<string, CachedLogLines>()
+// Logs larger than this are streamed with a bounded window instead of cached, so
+// a pathologically large file never lands in memory whole.
+const MAX_CACHEABLE_LOG_BYTES = 4 * 1024 * 1024
+// Total budget across all cached logs; oldest entries are evicted past this.
+const MAX_LOG_CACHE_BYTES = 16 * 1024 * 1024
+let logLineCacheBytes = 0
+
+function evictStaleLogLineCacheEntries(): void {
+  // Map preserves insertion order, so the first key is the least-recently-used.
+  while (logLineCacheBytes > MAX_LOG_CACHE_BYTES) {
+    const oldestKey = LOG_LINE_CACHE.keys().next().value
+    if (oldestKey === undefined) break
+    const evicted = LOG_LINE_CACHE.get(oldestKey)
+    LOG_LINE_CACHE.delete(oldestKey)
+    if (evicted) logLineCacheBytes -= evicted.size
+  }
+}
+
+function selectLineWindow(
+  lines: string[],
+  limit: number,
+  beforeLine: number
+): LogLineWindow {
+  const totalLines = lines.length
+  const requestedEndLine = Number.isFinite(beforeLine)
+    ? Math.max(0, Math.trunc(beforeLine))
+    : totalLines
+  const endLine = Math.min(totalLines, requestedEndLine)
+  const startLine = Math.max(0, endLine - limit)
+  return {
+    totalLines,
+    startLine,
+    endLine,
+    hasMoreBefore: startLine > 0,
+    lines: lines.slice(startLine, endLine),
+  }
+}
+
+async function readAllLogLines(logPath: string): Promise<string[]> {
+  const lines: string[] = []
+  const fileStream = createReadStream(logPath, { encoding: 'utf8' })
+  const reader = createInterface({ input: fileStream, crlfDelay: Infinity })
+  try {
+    for await (const line of reader) {
+      lines.push(line)
+    }
+  } finally {
+    // close() ends the readline interface; destroy() releases the fd even when
+    // iteration aborts early (e.g. EIO mid-read), which close() alone won't do.
+    reader.close()
+    fileStream.destroy()
+  }
+  return lines
+}
+
+// Streaming fallback for logs too large to cache: holds only the requested window
+// in memory while counting total lines.
+async function streamLogLineWindow(
   logPath: string,
   limit: number,
   beforeLine: number
@@ -125,10 +193,7 @@ async function readLogLineWindow(
   let totalLines = 0
 
   const fileStream = createReadStream(logPath, { encoding: 'utf8' })
-  const reader = createInterface({
-    input: fileStream,
-    crlfDelay: Infinity,
-  })
+  const reader = createInterface({ input: fileStream, crlfDelay: Infinity })
 
   try {
     for await (const line of reader) {
@@ -142,6 +207,7 @@ async function readLogLineWindow(
     }
   } finally {
     reader.close()
+    fileStream.destroy()
   }
 
   const endLine = Math.min(totalLines, requestedEndLine)
@@ -153,6 +219,34 @@ async function readLogLineWindow(
     hasMoreBefore: startLine > 0,
     lines: selectedLines,
   }
+}
+
+async function readLogLineWindow(
+  logPath: string,
+  stats: { size: number; mtimeMs: number },
+  limit: number,
+  beforeLine: number
+): Promise<LogLineWindow> {
+  // Don't cache oversized logs; stream a bounded window so memory stays in check.
+  if (stats.size > MAX_CACHEABLE_LOG_BYTES) {
+    return streamLogLineWindow(logPath, limit, beforeLine)
+  }
+
+  const cached = LOG_LINE_CACHE.get(logPath)
+  if (cached && cached.size === stats.size && cached.mtimeMs === stats.mtimeMs) {
+    // Refresh recency: re-inserting moves the key to the end of the Map.
+    LOG_LINE_CACHE.delete(logPath)
+    LOG_LINE_CACHE.set(logPath, cached)
+    return selectLineWindow(cached.lines, limit, beforeLine)
+  }
+
+  if (cached) logLineCacheBytes -= cached.size
+  const lines = await readAllLogLines(logPath)
+  LOG_LINE_CACHE.delete(logPath)
+  LOG_LINE_CACHE.set(logPath, { size: stats.size, mtimeMs: stats.mtimeMs, lines })
+  logLineCacheBytes += stats.size
+  evictStaleLogLineCacheEntries()
+  return selectLineWindow(lines, limit, beforeLine)
 }
 
 function getTailscaleIp(): string | null {
@@ -1166,7 +1260,7 @@ app.get('/api/session-preview/:sessionId', async (c) => {
     const rawBeforeLine = beforeLineQuery === undefined
       ? Number.POSITIVE_INFINITY
       : Number(beforeLineQuery)
-    const lineWindow = await readLogLineWindow(logPath, limit, rawBeforeLine)
+    const lineWindow = await readLogLineWindow(logPath, stats, limit, rawBeforeLine)
 
     return c.json({
       sessionId,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1241,7 +1241,12 @@ app.get('/api/session-preview/:sessionId', async (c) => {
 
   const DEFAULT_LIMIT = 200
   const MAX_LIMIT = 500
-  const rawLimit = Number(c.req.query('limit') ?? DEFAULT_LIMIT)
+  // Treat a missing OR empty `?limit=` as absent — `'' ?? DEFAULT` keeps '', and
+  // Number('') is 0, which would otherwise collapse the window to a single line.
+  const limitQuery = c.req.query('limit')
+  const rawLimit = limitQuery === undefined || limitQuery === ''
+    ? DEFAULT_LIMIT
+    : Number(limitQuery)
   const limit = Number.isFinite(rawLimit)
     ? Math.min(MAX_LIMIT, Math.max(1, Math.trunc(rawLimit)))
     : DEFAULT_LIMIT
@@ -1263,7 +1268,9 @@ app.get('/api/session-preview/:sessionId', async (c) => {
     }
 
     const beforeLineQuery = c.req.query('beforeLine')
-    const rawBeforeLine = beforeLineQuery === undefined
+    // Missing or empty means "latest window"; a non-numeric value falls back to
+    // the same (selectLineWindow treats a non-finite cursor as the end).
+    const rawBeforeLine = beforeLineQuery === undefined || beforeLineQuery === ''
       ? Number.POSITIVE_INFINITY
       : Number(beforeLineQuery)
     const lineWindow = await readLogLineWindow(logPath, stats, limit, rawBeforeLine)

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -131,7 +131,7 @@ const MAX_CACHEABLE_LOG_BYTES = 4 * 1024 * 1024
 const MAX_LOG_CACHE_BYTES = 16 * 1024 * 1024
 let logLineCacheBytes = 0
 
-function evictStaleLogLineCacheEntries(): void {
+function enforceLogCacheBudget(): void {
   // Map preserves insertion order, so the first key is the least-recently-used.
   while (logLineCacheBytes > MAX_LOG_CACHE_BYTES) {
     const oldestKey = LOG_LINE_CACHE.keys().next().value
@@ -240,12 +240,18 @@ async function readLogLineWindow(
     return selectLineWindow(cached.lines, limit, beforeLine)
   }
 
-  if (cached) logLineCacheBytes -= cached.size
   const lines = await readAllLogLines(logPath)
-  LOG_LINE_CACHE.delete(logPath)
+  // Reconcile byte accounting against the CURRENT entry (re-read after the await,
+  // not the pre-await `cached`) so two concurrent misses for the same path can't
+  // double-count and skew the cache budget.
+  const prior = LOG_LINE_CACHE.get(logPath)
+  if (prior) {
+    LOG_LINE_CACHE.delete(logPath)
+    logLineCacheBytes -= prior.size
+  }
   LOG_LINE_CACHE.set(logPath, { size: stats.size, mtimeMs: stats.mtimeMs, lines })
   logLineCacheBytes += stats.size
-  evictStaleLogLineCacheEntries()
+  enforceLogCacheBudget()
   return selectLineWindow(lines, limit, beforeLine)
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,7 +1,9 @@
 import type { Server, ServerWebSocket } from 'bun'
+import { createReadStream } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import fs from 'node:fs/promises'
+import { createInterface } from 'node:readline'
 import { Hono, type Context } from 'hono'
 import { serveStatic } from 'hono/bun'
 import { config, isValidHostname } from './config'
@@ -100,6 +102,56 @@ function checkPortAvailable(port: number): void {
     }
     logger.error('port_in_use', { port, pid, processName })
     process.exit(1)
+  }
+}
+
+interface LogLineWindow {
+  totalLines: number
+  startLine: number
+  endLine: number
+  hasMoreBefore: boolean
+  lines: string[]
+}
+
+async function readLogLineWindow(
+  logPath: string,
+  limit: number,
+  beforeLine: number
+): Promise<LogLineWindow> {
+  const requestedEndLine = Number.isFinite(beforeLine)
+    ? Math.max(0, Math.trunc(beforeLine))
+    : Number.POSITIVE_INFINITY
+  const selectedLines: string[] = []
+  let totalLines = 0
+
+  const fileStream = createReadStream(logPath, { encoding: 'utf8' })
+  const reader = createInterface({
+    input: fileStream,
+    crlfDelay: Infinity,
+  })
+
+  try {
+    for await (const line of reader) {
+      if (totalLines < requestedEndLine) {
+        selectedLines.push(line)
+        if (selectedLines.length > limit) {
+          selectedLines.shift()
+        }
+      }
+      totalLines += 1
+    }
+  } finally {
+    reader.close()
+  }
+
+  const endLine = Math.min(totalLines, requestedEndLine)
+  const startLine = Math.max(0, endLine - selectedLines.length)
+  return {
+    totalLines,
+    startLine,
+    endLine,
+    hasMoreBefore: startLine > 0,
+    lines: selectedLines,
   }
 }
 
@@ -1087,6 +1139,13 @@ app.get('/api/session-preview/:sessionId', async (c) => {
     return c.json({ error: 'Invalid session id' }, 400)
   }
 
+  const DEFAULT_LIMIT = 200
+  const MAX_LIMIT = 500
+  const rawLimit = Number(c.req.query('limit') ?? DEFAULT_LIMIT)
+  const limit = Number.isFinite(rawLimit)
+    ? Math.min(MAX_LIMIT, Math.max(1, Math.trunc(rawLimit)))
+    : DEFAULT_LIMIT
+
   const record = db.getSessionById(sessionId)
   if (!record) {
     return c.json({ error: 'Session not found' }, 404)
@@ -1103,22 +1162,11 @@ app.get('/api/session-preview/:sessionId', async (c) => {
       return c.json({ error: 'Log file not found' }, 404)
     }
 
-    // Read last 64KB of the file. try/finally guarantees the fd is released
-    // if fd.read() throws (e.g., EIO, file unlinked mid-read, permission drop).
-    const TAIL_BYTES = 64 * 1024
-    const fileSize = stats.size
-    const offset = Math.max(0, fileSize - TAIL_BYTES)
-    const fd = await fs.open(logPath, 'r')
-    let content: string
-    try {
-      const buffer = Buffer.alloc(Math.min(TAIL_BYTES, fileSize))
-      const { bytesRead } = await fd.read(buffer, 0, buffer.length, offset)
-      content = buffer.subarray(0, bytesRead).toString('utf8')
-    } finally {
-      await fd.close()
-    }
-    // Take last 100 lines
-    const lines = content.split('\n').slice(-100)
+    const beforeLineQuery = c.req.query('beforeLine')
+    const rawBeforeLine = beforeLineQuery === undefined
+      ? Number.POSITIVE_INFINITY
+      : Number(beforeLineQuery)
+    const lineWindow = await readLogLineWindow(logPath, limit, rawBeforeLine)
 
     return c.json({
       sessionId,
@@ -1126,7 +1174,7 @@ app.get('/api/session-preview/:sessionId', async (c) => {
       projectPath: record.projectPath,
       agentType: record.agentType,
       lastActivityAt: record.lastActivityAt,
-      lines,
+      ...lineWindow,
     })
   } catch (error) {
     const err = error as NodeJS.ErrnoException

--- a/src/shared/eventTaxonomy.ts
+++ b/src/shared/eventTaxonomy.ts
@@ -1,3 +1,5 @@
+import { asRecord, asString } from './json'
+
 export type NormalizedEventKind =
   | 'message'
   | 'tool_call'
@@ -36,15 +38,6 @@ export interface NormalizedLineParseResult {
 const TOOL_RESULT_TYPES = new Set(['tool_result', 'custom_tool_call_output'])
 const TEXT_CONTENT_TYPES = new Set(['text', 'input_text', 'output_text'])
 
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== 'object') return null
-  return value as Record<string, unknown>
-}
-
-function asString(value: unknown): string | null {
-  return typeof value === 'string' ? value : null
-}
-
 function normalizeRole(value: unknown): NormalizedEventRole {
   if (value === 'user') return 'user'
   if (value === 'assistant') return 'assistant'
@@ -53,7 +46,7 @@ function normalizeRole(value: unknown): NormalizedEventRole {
   return 'other'
 }
 
-function inferSourceFamily(record: Record<string, unknown>): NormalizedSourceFamily {
+export function inferSourceFamily(record: Record<string, unknown>): NormalizedSourceFamily {
   const typeValue = asString(record.type) ?? ''
   const payload = asRecord(record.payload)
   const payloadType = asString(payload?.type) ?? ''

--- a/src/shared/json.ts
+++ b/src/shared/json.ts
@@ -1,0 +1,12 @@
+// Small structural type-guards shared by the log parsers (eventTaxonomy and the
+// client transcript reader). Kept in one place so the two parsers agree on what
+// counts as a plain object record vs. a string.
+
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+export function asString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}


### PR DESCRIPTION
## Summary

- Redesign the hibernated session transcript preview into a usable reader with full messages, timestamp-first markers, and paged earlier history.
- Parse Claude and Codex JSONL shapes into readable Messages and structured Events views.
- Keep tool calls/results compact by default while allowing full expansion when needed.
- Cap the hibernated header prompt preview so the transcript remains the main surface.

## Validation

- `bun run lint && bun run typecheck && bun run test`
- `bun run build`
- Browser visual pass against a 203-line hibernated fixture: timestamps, load earlier, chronological order, full messages, Events mode, tool expansion, and mobile overflow.
