### PR TITLE
Fix hibernated transcript previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/__tests__/SessionPreviewModal.test.tsx
+++ b/src/client/__tests__/SessionPreviewModal.test.tsx
@@ -353,6 +353,70 @@ describe('SessionPreviewModal', () => {
     await cleanup(renderer)
   })
 
+  test('pages large transcript previews with byte cursors', async () => {
+    const previewData = {
+      sessionId: baseSession.sessionId,
+      displayName: 'Alpha',
+      projectPath: baseSession.projectPath,
+      agentType: 'codex',
+      lastActivityAt: baseSession.lastActivityAt,
+      totalLines: null,
+      startLine: 0,
+      endLine: 2,
+      startByte: 1200,
+      endByte: 1400,
+      hasMoreBefore: true,
+      lineKeys: ['b:1200', 'b:1300'],
+      lines: [
+        JSON.stringify({ type: 'user', message: { content: 'Recent one' } }),
+        JSON.stringify({ type: 'assistant', message: { content: 'Recent two' } }),
+      ],
+    }
+    const earlierData = {
+      ...previewData,
+      startByte: 1000,
+      endByte: 1200,
+      hasMoreBefore: false,
+      lineKeys: ['b:1000', 'b:1100'],
+      lines: [
+        JSON.stringify({ type: 'user', message: { content: 'Earlier one' } }),
+        JSON.stringify({ type: 'assistant', message: { content: 'Earlier two' } }),
+      ],
+    }
+
+    const controller = createFetchController([
+      createJsonResponse(previewData),
+      createJsonResponse(earlierData),
+    ])
+
+    const renderer = await createModal(
+      <SessionPreviewModal
+        session={baseSession}
+        onClose={() => {}}
+        onResume={() => {}}
+      />
+    )
+
+    await resolveAndFlush(controller)
+
+    let html = JSON.stringify(renderer.toJSON())
+    expect(html).toContain('Recent one')
+    expect(html).toContain('Recent two')
+    expect(html).toContain('Showing 2 recent log entries')
+    expect(html).not.toContain('Line 1')
+
+    clickButton(renderer, 'Load earlier')
+    await resolveAndFlush(controller)
+
+    html = JSON.stringify(renderer.toJSON())
+    expect(html).toContain('Earlier one')
+    expect(html).toContain('Recent two')
+    expect(html).toContain('Showing 4 recent log entries')
+    expect(controller.calls[1]).toBe('/api/session-preview/session-12345678?limit=200&beforeByte=1200')
+
+    await cleanup(renderer)
+  })
+
   test('renders message content as markdown', async () => {
     const controller = createFetchController([
       createJsonResponse({

--- a/src/client/components/SessionPreviewContent.tsx
+++ b/src/client/components/SessionPreviewContent.tsx
@@ -19,11 +19,14 @@ interface PreviewData {
   projectPath: string
   agentType: string
   lastActivityAt: string
-  totalLines: number
+  totalLines: number | null
   startLine: number
   endLine: number
   hasMoreBefore: boolean
   lines: string[]
+  lineKeys?: string[]
+  startByte?: number
+  endByte?: number
 }
 
 interface ParsedEntry {
@@ -31,16 +34,20 @@ interface ParsedEntry {
   kind: NormalizedEventKind
   content: string
   raw: string
+  sourceKey: string
   lineNumber: number
   // Index of this entry within its source line. Combined with lineNumber it forms
   // a stable React key that survives prepending earlier history (positional keys
   // would shift and force a full remount, collapsing expanded tool entries).
   seq: number
+  exactLineNumber: boolean
   timestamp?: string
 }
 
 interface StructuredLogLine {
+  sourceKey: string
   lineNumber: number
+  exactLineNumber: boolean
   parsed: boolean
   raw: string
   source: string
@@ -143,13 +150,20 @@ function inferLogSource(record: Record<string, unknown>): string {
   return 'log'
 }
 
-function parseStructuredLogLine(line: string, lineNumber: number): StructuredLogLine {
+function parseStructuredLogLine(
+  line: string,
+  sourceKey: string,
+  lineNumber: number,
+  exactLineNumber: boolean
+): StructuredLogLine {
   try {
     const parsed = JSON.parse(line) as unknown
     const record = asRecord(parsed)
     if (!record) {
       return {
         lineNumber,
+        sourceKey,
+        exactLineNumber,
         parsed: true,
         raw: line,
         source: 'json',
@@ -204,6 +218,8 @@ function parseStructuredLogLine(line: string, lineNumber: number): StructuredLog
 
     return {
       lineNumber,
+      sourceKey,
+      exactLineNumber,
       parsed: true,
       raw: line,
       source,
@@ -218,6 +234,8 @@ function parseStructuredLogLine(line: string, lineNumber: number): StructuredLog
   } catch {
     return {
       lineNumber,
+      sourceKey,
+      exactLineNumber,
       parsed: false,
       raw: line,
       source: 'text',
@@ -269,7 +287,12 @@ function mapNormalizedRoleToEntryType(role: string): ParsedEntry['type'] {
   return 'other'
 }
 
-function parseLogEntry(line: string, lineNumber: number): ParsedEntry[] {
+function parseLogEntry(
+  line: string,
+  sourceKey: string,
+  lineNumber: number,
+  exactLineNumber: boolean
+): ParsedEntry[] {
   const parsed = parseAndNormalizeAgentLogLine(line)
   if (!parsed) return []
   // Reuse the object parseAndNormalizeAgentLogLine already parsed instead of
@@ -283,8 +306,10 @@ function parseLogEntry(line: string, lineNumber: number): ParsedEntry[] {
       kind: event.kind,
       content: event.text.trim(),
       raw: line,
+      sourceKey,
       lineNumber,
       seq,
+      exactLineNumber,
       ...(timestamp ? { timestamp } : {}),
     }))
     .filter((entry) => entry.content.length > 0)
@@ -294,14 +319,34 @@ function parseLogEntry(line: string, lineNumber: number): ParsedEntry[] {
   }
 
   if (!parsed.parsed && line.trim()) {
-    return [{ type: 'other', kind: 'unknown', content: line.trim(), raw: line, lineNumber, seq: 0 }]
+    return [{
+      type: 'other',
+      kind: 'unknown',
+      content: line.trim(),
+      raw: line,
+      sourceKey,
+      lineNumber,
+      seq: 0,
+      exactLineNumber,
+    }]
   }
 
   return []
 }
 
 function lineKey(entry: ParsedEntry) {
-  return `${entry.lineNumber}:${entry.seq}`
+  return `${entry.sourceKey}:${entry.seq}`
+}
+
+function lineTitle(lineNumber: number, timestamp: string | undefined, exactLineNumber: boolean) {
+  if (!exactLineNumber) return timestamp
+  return timestamp ? `Line ${lineNumber + 1} · ${timestamp}` : undefined
+}
+
+function lineMarker(lineNumber: number, timestamp: string | undefined, exactLineNumber: boolean) {
+  const formatted = formatLogTimestamp(timestamp)
+  if (formatted) return formatted
+  return exactLineNumber ? `Line ${lineNumber + 1}` : 'Entry'
 }
 
 function entryLabel(entry: ParsedEntry) {
@@ -321,8 +366,7 @@ function entryToneClass(entry: ParsedEntry) {
 
 function ToolEntry({ entry }: { entry: ParsedEntry }) {
   const [expanded, setExpanded] = useState(false)
-  const timestamp = formatLogTimestamp(entry.timestamp)
-  const marker = timestamp ?? `Line ${entry.lineNumber + 1}`
+  const marker = lineMarker(entry.lineNumber, entry.timestamp, entry.exactLineNumber)
   const label = entry.kind === 'tool_call' ? entry.content : 'Result'
 
   return (
@@ -336,7 +380,7 @@ function ToolEntry({ entry }: { entry: ParsedEntry }) {
         <span className="min-w-0 truncate">
           <span
             className="mr-2 text-[10px] uppercase tracking-wide text-muted"
-            title={timestamp ? `Line ${entry.lineNumber + 1} · ${entry.timestamp}` : undefined}
+            title={lineTitle(entry.lineNumber, entry.timestamp, entry.exactLineNumber)}
           >
             {marker}
           </span>
@@ -420,8 +464,7 @@ function TranscriptEntry({ entry }: { entry: ParsedEntry }) {
   if (entry.kind === 'tool_call' || entry.kind === 'result') {
     return <ToolEntry entry={entry} />
   }
-  const timestamp = formatLogTimestamp(entry.timestamp)
-  const marker = timestamp ?? `Line ${entry.lineNumber + 1}`
+  const marker = lineMarker(entry.lineNumber, entry.timestamp, entry.exactLineNumber)
 
   return (
     <article className="grid grid-cols-[5.75rem_minmax(0,1fr)] gap-3 border-b border-border/60 py-4 last:border-b-0 sm:grid-cols-[6.75rem_minmax(0,1fr)]">
@@ -431,7 +474,7 @@ function TranscriptEntry({ entry }: { entry: ParsedEntry }) {
         </div>
         <div
           className="mt-1 text-[10px] tabular-nums text-muted"
-          title={timestamp ? `Line ${entry.lineNumber + 1} · ${entry.timestamp}` : undefined}
+          title={lineTitle(entry.lineNumber, entry.timestamp, entry.exactLineNumber)}
         >
           {marker}
         </div>
@@ -460,9 +503,9 @@ function StructuredLogEntry({ entry }: { entry: StructuredLogLine }) {
       <div className="grid grid-cols-[5.75rem_minmax(0,1fr)] gap-3 px-3 py-2 sm:grid-cols-[6.75rem_minmax(0,1fr)]">
         <div
           className="select-none text-right text-[11px] tabular-nums text-muted"
-          title={entry.timestamp ? `Line ${entry.lineNumber + 1} · ${entry.timestamp}` : undefined}
+          title={lineTitle(entry.lineNumber, entry.timestamp, entry.exactLineNumber)}
         >
-          {timestamp ?? `Line ${entry.lineNumber + 1}`}
+          {timestamp ?? (entry.exactLineNumber ? `Line ${entry.lineNumber + 1}` : 'Entry')}
         </div>
         <div className="min-w-0 space-y-2">
           <div className="flex flex-wrap items-center gap-2">
@@ -615,10 +658,12 @@ export default function SessionPreviewContent({
     setError(null)
 
     try {
-      const params = new URLSearchParams({
-        limit: String(PREVIEW_LINE_LIMIT),
-        beforeLine: String(previewData.startLine),
-      })
+      const params = new URLSearchParams({ limit: String(PREVIEW_LINE_LIMIT) })
+      if (typeof previewData.startByte === 'number') {
+        params.set('beforeByte', String(previewData.startByte))
+      } else {
+        params.set('beforeLine', String(previewData.startLine))
+      }
       const data = await fetchPreviewWindow(
         `/api/session-preview/${session.sessionId}?${params.toString()}`,
         controller.signal
@@ -627,9 +672,18 @@ export default function SessionPreviewContent({
         if (!current) return data
         return {
           ...current,
+          totalLines: data.totalLines ?? current.totalLines,
           startLine: data.startLine,
+          endLine: current.endLine,
           hasMoreBefore: data.hasMoreBefore,
+          startByte: data.startByte,
+          endByte: current.endByte,
           lines: [...data.lines, ...current.lines],
+          lineKeys: [
+            ...(data.lineKeys ?? data.lines.map((_, index) => String(data.startLine + index))),
+            ...(current.lineKeys ??
+              current.lines.map((_, index) => String(current.startLine + index))),
+          ],
         }
       })
     } catch (err) {
@@ -665,16 +719,26 @@ export default function SessionPreviewContent({
   // load-earlier spinner, etc.). previewData is replaced wholesale when it changes.
   const parsedEntries = useMemo(
     () =>
-      previewData?.lines.flatMap((line, index) =>
-        parseLogEntry(line, previewData.startLine + index)
-      ) ?? [],
+      previewData?.lines.flatMap((line, index) => {
+        const exactLineNumber = previewData.totalLines !== null
+        const lineNumber = exactLineNumber
+          ? previewData.startLine + index
+          : (previewData.startByte ?? 0) + index
+        const sourceKey = previewData.lineKeys?.[index] ?? String(lineNumber)
+        return parseLogEntry(line, sourceKey, lineNumber, exactLineNumber)
+      }) ?? [],
     [previewData]
   )
   const structuredLines = useMemo(
     () =>
-      previewData?.lines.map((line, index) =>
-        parseStructuredLogLine(line, previewData.startLine + index)
-      ) ?? [],
+      previewData?.lines.map((line, index) => {
+        const exactLineNumber = previewData.totalLines !== null
+        const lineNumber = exactLineNumber
+          ? previewData.startLine + index
+          : (previewData.startByte ?? 0) + index
+        const sourceKey = previewData.lineKeys?.[index] ?? String(lineNumber)
+        return parseStructuredLogLine(line, sourceKey, lineNumber, exactLineNumber)
+      }) ?? [],
     [previewData]
   )
   // Reverse-chronological display (newest first). The data model stays oldest-first
@@ -684,7 +748,9 @@ export default function SessionPreviewContent({
   const lineRangeLabel = previewData
     ? previewData.totalLines === 0
       ? 'No transcript entries'
-      : `Showing ${previewData.lines.length} of ${previewData.totalLines} log entries`
+      : previewData.totalLines === null
+        ? `Showing ${previewData.lines.length} recent log entries`
+        : `Showing ${previewData.lines.length} of ${previewData.totalLines} log entries`
     : 'Derived from the saved session log.'
 
   return (

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -4913,6 +4913,88 @@ describe('server fetch handlers', () => {
     }
   })
 
+  test('returns large session previews from the tail with byte cursors', async () => {
+    const { serveOptions } = await loadIndex()
+    const fetchHandler = serveOptions.fetch
+    if (!fetchHandler) {
+      throw new Error('Fetch handler not configured')
+    }
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-preview-large-'))
+    const logPath = path.join(tempDir, 'session.jsonl')
+    const lines = Array.from(
+      { length: 5200 },
+      (_, index) => `line-${String(index).padStart(4, '0')}-${'x'.repeat(1000)}`
+    )
+    await fs.writeFile(logPath, lines.join('\n'))
+
+    seedRecord(
+      makeRecord({
+        sessionId: 'session-preview-large',
+        logFilePath: logPath,
+        displayName: 'Large Preview',
+        projectPath: '/tmp/preview',
+        agentType: 'codex',
+      })
+    )
+
+    try {
+      const response = await fetchHandler.call(
+        {} as Bun.Server<unknown>,
+        new Request('http://localhost/api/session-preview/session-preview-large?limit=25'),
+        {} as Bun.Server<unknown>
+      )
+
+      if (!response) {
+        throw new Error('Expected response for large session preview')
+      }
+
+      expect(response.ok).toBe(true)
+      const payload = (await response.json()) as {
+        totalLines: number | null
+        startByte: number
+        endByte: number
+        hasMoreBefore: boolean
+        lines: string[]
+        lineKeys: string[]
+      }
+      expect(payload.totalLines).toBeNull()
+      expect(payload.hasMoreBefore).toBe(true)
+      expect(payload.lines).toHaveLength(25)
+      expect(payload.lines[0]?.startsWith('line-5175-')).toBe(true)
+      expect(payload.lines[24]?.startsWith('line-5199-')).toBe(true)
+      expect(payload.startByte).toBeLessThan(payload.endByte)
+      expect(payload.lineKeys).toHaveLength(25)
+      expect(payload.lineKeys[0]).toMatch(/^b:\d+$/)
+
+      const earlierResponse = await fetchHandler.call(
+        {} as Bun.Server<unknown>,
+        new Request(
+          `http://localhost/api/session-preview/session-preview-large?limit=25&beforeByte=${payload.startByte}`
+        ),
+        {} as Bun.Server<unknown>
+      )
+
+      if (!earlierResponse) {
+        throw new Error('Expected earlier response for large session preview')
+      }
+
+      expect(earlierResponse.ok).toBe(true)
+      const earlierPayload = (await earlierResponse.json()) as {
+        totalLines: number | null
+        endByte: number
+        lines: string[]
+      }
+      expect(earlierPayload.totalLines).toBeNull()
+      expect(earlierPayload.endByte).toBe(payload.startByte)
+      expect(earlierPayload.lines).toHaveLength(25)
+      expect(earlierPayload.lines[0]?.startsWith('line-5150-')).toBe(true)
+      expect(earlierPayload.lines[24]?.startsWith('line-5174-')).toBe(true)
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
   test('serves fresh content after the preview log is rewritten', async () => {
     const { serveOptions } = await loadIndex()
     const fetchHandler = serveOptions.fetch

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -4924,9 +4924,9 @@ describe('server fetch handlers', () => {
     const logPath = path.join(tempDir, 'session.jsonl')
     const lines = Array.from(
       { length: 5200 },
-      (_, index) => `line-${String(index).padStart(4, '0')}-${'x'.repeat(1000)}`
+      (_, index) => `line-${String(index).padStart(4, '0')}-🙂-${'x'.repeat(1000)}`
     )
-    await fs.writeFile(logPath, lines.join('\n'))
+    await fs.writeFile(logPath, `${lines.join('\r\n')}\r\n`)
 
     seedRecord(
       makeRecord({
@@ -4963,9 +4963,12 @@ describe('server fetch handlers', () => {
       expect(payload.lines).toHaveLength(25)
       expect(payload.lines[0]?.startsWith('line-5175-')).toBe(true)
       expect(payload.lines[24]?.startsWith('line-5199-')).toBe(true)
+      expect(payload.lines[0]).toContain('🙂')
+      expect(payload.lines.join('\n')).not.toContain('�')
       expect(payload.startByte).toBeLessThan(payload.endByte)
       expect(payload.lineKeys).toHaveLength(25)
       expect(payload.lineKeys[0]).toMatch(/^b:\d+$/)
+      expect(payload.lineKeys[0]).toBe(`b:${payload.startByte}`)
 
       const earlierResponse = await fetchHandler.call(
         {} as Bun.Server<unknown>,
@@ -4990,6 +4993,8 @@ describe('server fetch handlers', () => {
       expect(earlierPayload.lines).toHaveLength(25)
       expect(earlierPayload.lines[0]?.startsWith('line-5150-')).toBe(true)
       expect(earlierPayload.lines[24]?.startsWith('line-5174-')).toBe(true)
+      expect(earlierPayload.lines[0]).toContain('🙂')
+      expect(earlierPayload.lines.join('\n')).not.toContain('�')
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true })
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -182,14 +182,6 @@ async function readAllLogLines(logPath: string): Promise<string[]> {
   return lines
 }
 
-function splitTailChunk(text: string): string[] {
-  const lines = text.split(/\r?\n/)
-  if (lines.length > 0 && lines[lines.length - 1] === '') {
-    lines.pop()
-  }
-  return lines
-}
-
 // Streaming fallback for compatibility with older beforeLine requests. This still
 // scans the whole file, so byte cursors are used for large-log pagination below.
 async function streamLogLineWindow(
@@ -256,7 +248,7 @@ async function readLogLineWindowFromEnd(
 
   const handle = await fs.open(logPath, 'r')
   const chunkSize = 64 * 1024
-  const chunks: string[] = []
+  const chunks: Buffer[] = []
   let cursor = endByte
   let newlineCount = 0
   let sawNonEmptyContent = false
@@ -268,20 +260,42 @@ async function readLogLineWindowFromEnd(
       const buffer = Buffer.allocUnsafe(readSize)
       const { bytesRead } = await handle.read(buffer, 0, readSize, start)
       if (bytesRead <= 0) break
-      const chunk = buffer.subarray(0, bytesRead).toString('utf8')
+      const chunk = buffer.subarray(0, bytesRead)
       chunks.unshift(chunk)
-      if (chunk.trimEnd().length > 0) sawNonEmptyContent = true
-      newlineCount += (chunk.match(/\n/g) ?? []).length
+      for (const byte of chunk) {
+        if (byte === 0x0a) newlineCount += 1
+        if (byte > 0x20) sawNonEmptyContent = true
+      }
       cursor = start
     }
   } finally {
     await handle.close()
   }
 
-  const text = chunks.join('')
-  const lines = splitTailChunk(text)
-  const selectedLines = lines.slice(-limit)
-  if (selectedLines.length === 0 && !sawNonEmptyContent) {
+  const buffer = Buffer.concat(chunks)
+  let contentEnd = buffer.length
+  if (contentEnd > 0 && buffer[contentEnd - 1] === 0x0a) {
+    contentEnd -= 1
+  }
+
+  const lineStarts = [0]
+  for (let index = 0; index < contentEnd; index += 1) {
+    if (buffer[index] === 0x0a) {
+      lineStarts.push(index + 1)
+    }
+  }
+
+  const selectedStarts = lineStarts.slice(-limit)
+  const selectedLines = selectedStarts.map((startOffset, index) => {
+    const nextStart = selectedStarts[index + 1]
+    let endOffset = nextStart === undefined ? contentEnd : nextStart - 1
+    if (endOffset > startOffset && buffer[endOffset - 1] === 0x0d) {
+      endOffset -= 1
+    }
+    return buffer.subarray(startOffset, endOffset).toString('utf8')
+  })
+
+  if (contentEnd === 0 && !sawNonEmptyContent) {
     return {
       totalLines: null,
       startLine: 0,
@@ -293,17 +307,9 @@ async function readLogLineWindowFromEnd(
     }
   }
 
-  const selectedText = selectedLines.join('\n')
-  const encodedLength = Buffer.byteLength(selectedText, 'utf8')
-  const hasTrailingNewline = text.endsWith('\n')
-  const trailingBytes = hasTrailingNewline ? 1 : 0
-  const startByte = Math.max(0, endByte - trailingBytes - encodedLength)
-  let lineStartByte = startByte
-  const lineKeys = selectedLines.map((line) => {
-    const key = `b:${lineStartByte}`
-    lineStartByte += Buffer.byteLength(line, 'utf8') + 1
-    return key
-  })
+  const selectedStartByte = selectedStarts[0] ?? contentEnd
+  const startByte = Math.max(0, cursor + selectedStartByte)
+  const lineKeys = selectedStarts.map((startOffset) => `b:${cursor + startOffset}`)
 
   return {
     totalLines: null,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -106,11 +106,14 @@ function checkPortAvailable(port: number): void {
 }
 
 interface LogLineWindow {
-  totalLines: number
+  totalLines: number | null
   startLine: number
   endLine: number
   hasMoreBefore: boolean
   lines: string[]
+  lineKeys?: string[]
+  startByte?: number
+  endByte?: number
 }
 
 // Hibernated session logs are static (the session is no longer writing to them),
@@ -179,8 +182,16 @@ async function readAllLogLines(logPath: string): Promise<string[]> {
   return lines
 }
 
-// Streaming fallback for logs too large to cache: holds only the requested window
-// in memory while counting total lines.
+function splitTailChunk(text: string): string[] {
+  const lines = text.split(/\r?\n/)
+  if (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop()
+  }
+  return lines
+}
+
+// Streaming fallback for compatibility with older beforeLine requests. This still
+// scans the whole file, so byte cursors are used for large-log pagination below.
 async function streamLogLineWindow(
   logPath: string,
   limit: number,
@@ -221,14 +232,106 @@ async function streamLogLineWindow(
   }
 }
 
+// Large transcripts should open at the end without counting every preceding
+// line. Read backwards in chunks until we have the requested complete lines, then
+// return byte cursors so the client can page earlier without a linear scan.
+async function readLogLineWindowFromEnd(
+  logPath: string,
+  stats: { size: number },
+  limit: number,
+  beforeByte: number
+): Promise<LogLineWindow> {
+  const endByte = Math.max(0, Math.min(stats.size, Math.trunc(beforeByte)))
+  if (endByte === 0) {
+    return {
+      totalLines: null,
+      startLine: 0,
+      endLine: 0,
+      hasMoreBefore: false,
+      lines: [],
+      startByte: 0,
+      endByte: 0,
+    }
+  }
+
+  const handle = await fs.open(logPath, 'r')
+  const chunkSize = 64 * 1024
+  const chunks: string[] = []
+  let cursor = endByte
+  let newlineCount = 0
+  let sawNonEmptyContent = false
+
+  try {
+    while (cursor > 0 && newlineCount <= limit) {
+      const readSize = Math.min(chunkSize, cursor)
+      const start = cursor - readSize
+      const buffer = Buffer.allocUnsafe(readSize)
+      const { bytesRead } = await handle.read(buffer, 0, readSize, start)
+      if (bytesRead <= 0) break
+      const chunk = buffer.subarray(0, bytesRead).toString('utf8')
+      chunks.unshift(chunk)
+      if (chunk.trimEnd().length > 0) sawNonEmptyContent = true
+      newlineCount += (chunk.match(/\n/g) ?? []).length
+      cursor = start
+    }
+  } finally {
+    await handle.close()
+  }
+
+  const text = chunks.join('')
+  const lines = splitTailChunk(text)
+  const selectedLines = lines.slice(-limit)
+  if (selectedLines.length === 0 && !sawNonEmptyContent) {
+    return {
+      totalLines: null,
+      startLine: 0,
+      endLine: 0,
+      hasMoreBefore: cursor > 0,
+      lines: [],
+      startByte: endByte,
+      endByte,
+    }
+  }
+
+  const selectedText = selectedLines.join('\n')
+  const encodedLength = Buffer.byteLength(selectedText, 'utf8')
+  const hasTrailingNewline = text.endsWith('\n')
+  const trailingBytes = hasTrailingNewline ? 1 : 0
+  const startByte = Math.max(0, endByte - trailingBytes - encodedLength)
+  let lineStartByte = startByte
+  const lineKeys = selectedLines.map((line) => {
+    const key = `b:${lineStartByte}`
+    lineStartByte += Buffer.byteLength(line, 'utf8') + 1
+    return key
+  })
+
+  return {
+    totalLines: null,
+    startLine: 0,
+    endLine: selectedLines.length,
+    hasMoreBefore: startByte > 0,
+    lines: selectedLines,
+    lineKeys,
+    startByte,
+    endByte,
+  }
+}
+
 async function readLogLineWindow(
   logPath: string,
   stats: { size: number; mtimeMs: number },
   limit: number,
-  beforeLine: number
+  beforeLine: number,
+  beforeByte?: number
 ): Promise<LogLineWindow> {
   // Don't cache oversized logs; stream a bounded window so memory stays in check.
   if (stats.size > MAX_CACHEABLE_LOG_BYTES) {
+    if (beforeByte !== undefined && Number.isFinite(beforeByte)) {
+      return readLogLineWindowFromEnd(logPath, stats, limit, beforeByte)
+    }
+    if (!Number.isFinite(beforeLine)) {
+      return readLogLineWindowFromEnd(logPath, stats, limit, stats.size)
+    }
     return streamLogLineWindow(logPath, limit, beforeLine)
   }
 
@@ -1273,7 +1376,20 @@ app.get('/api/session-preview/:sessionId', async (c) => {
     const rawBeforeLine = beforeLineQuery === undefined || beforeLineQuery === ''
       ? Number.POSITIVE_INFINITY
       : Number(beforeLineQuery)
-    const lineWindow = await readLogLineWindow(logPath, stats, limit, rawBeforeLine)
+    const beforeByteQuery = c.req.query('beforeByte')
+    const rawBeforeByte = beforeByteQuery === undefined || beforeByteQuery === ''
+      ? undefined
+      : Number(beforeByteQuery)
+    const beforeByte = rawBeforeByte !== undefined && Number.isFinite(rawBeforeByte)
+      ? Math.max(0, Math.trunc(rawBeforeByte))
+      : undefined
+    const lineWindow = await readLogLineWindow(
+      logPath,
+      stats,
+      limit,
+      rawBeforeLine,
+      beforeByte
+    )
 
     return c.json({
       sessionId,


### PR DESCRIPTION
## Summary
- Tail-read large transcript logs so hibernated session previews return quickly.
- Add byte-cursor pagination so older entries load from the end without rescanning full logs.
- Harden tail cursors for CRLF logs and multibyte UTF-8 split across read chunks.
- Bump package version to 0.3.2.

## Root Cause
Large transcript previews were read and scanned from the start, which could exceed the client timeout for hibernating sessions with multi-megabyte logs. The initial tail-reader also needed byte-level cursor handling to avoid corrupting split UTF-8 characters or miscounting CRLF logs.

## Validation
- bun run lint && bun run typecheck && bun run test
- Served locally from this branch over Tailscale and verified the app loaded at http://100.82.11.20:5173/
