### PR TITLE
fix: collapse duplicated Codex turns in transcript preview (v0.3.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/__tests__/sessionPreviewDedup.test.ts
+++ b/src/client/__tests__/sessionPreviewDedup.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import {
   dedupeAdjacentMessageEntries,
+  annotateGroupedEntries,
   type ParsedEntry,
 } from '../components/SessionPreviewContent'
 
@@ -70,5 +71,47 @@ describe('dedupeAdjacentMessageEntries', () => {
       entry({ type: 'user', kind: 'message', content: 'bye', lineNumber: 3 }),
     ]
     expect(dedupeAdjacentMessageEntries(input)).toEqual(input)
+  })
+})
+
+describe('annotateGroupedEntries', () => {
+  test('shows the role label only at the start of a same-role run', () => {
+    const input: ParsedEntry[] = [
+      entry({ type: 'assistant', kind: 'message', content: 'step 1', lineNumber: 1 }),
+      entry({ type: 'assistant', kind: 'message', content: 'step 2', lineNumber: 2 }),
+      entry({ type: 'assistant', kind: 'message', content: 'step 3', lineNumber: 3 }),
+    ]
+    expect(annotateGroupedEntries(input).map((e) => e.showRole)).toEqual([true, false, false])
+  })
+
+  test('starts a new group when the role changes', () => {
+    const input: ParsedEntry[] = [
+      entry({ type: 'user', kind: 'message', content: 'do it', lineNumber: 1 }),
+      entry({ type: 'assistant', kind: 'message', content: 'on it', lineNumber: 2 }),
+      entry({ type: 'assistant', kind: 'message', content: 'more', lineNumber: 3 }),
+      entry({ type: 'user', kind: 'message', content: 'thanks', lineNumber: 4 }),
+    ]
+    expect(annotateGroupedEntries(input).map((e) => e.showRole)).toEqual([true, true, false, true])
+  })
+
+  test('a tool call between assistant messages does not break the run', () => {
+    // The assistant message after the tool call stays grouped (showRole false).
+    const input: ParsedEntry[] = [
+      entry({ type: 'assistant', kind: 'message', content: 'running a tool', lineNumber: 1 }),
+      entry({ type: 'tool', kind: 'tool_call', content: '[Tool: bash]', lineNumber: 2 }),
+      entry({ type: 'assistant', kind: 'message', content: 'tool done', lineNumber: 3 }),
+    ]
+    const result = annotateGroupedEntries(input)
+    expect(result.map((e) => e.showRole)).toEqual([true, false, false])
+  })
+
+  test('does not mutate or drop entries', () => {
+    const input: ParsedEntry[] = [
+      entry({ type: 'user', kind: 'message', content: 'hi', lineNumber: 1 }),
+      entry({ type: 'assistant', kind: 'message', content: 'hello', lineNumber: 2 }),
+    ]
+    const result = annotateGroupedEntries(input)
+    expect(result).toHaveLength(2)
+    expect(result.map((e) => e.entry)).toEqual(input)
   })
 })

--- a/src/client/__tests__/sessionPreviewDedup.test.ts
+++ b/src/client/__tests__/sessionPreviewDedup.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  dedupeAdjacentMessageEntries,
+  type ParsedEntry,
+} from '../components/SessionPreviewContent'
+
+function entry(overrides: Partial<ParsedEntry> & Pick<ParsedEntry, 'type' | 'kind' | 'content'>): ParsedEntry {
+  return {
+    raw: '',
+    sourceKey: `${overrides.lineNumber ?? 0}`,
+    lineNumber: overrides.lineNumber ?? 0,
+    seq: 0,
+    exactLineNumber: true,
+    ...overrides,
+  }
+}
+
+describe('dedupeAdjacentMessageEntries', () => {
+  test('collapses the Codex agent_message + response_item assistant pair', () => {
+    // Codex logs each assistant turn twice, adjacently: once as an event_msg
+    // (agent_message) and once as a response_item message, with identical text.
+    const input: ParsedEntry[] = [
+      entry({ type: 'assistant', kind: 'message', content: 'I will check the code', lineNumber: 9 }),
+      entry({ type: 'assistant', kind: 'message', content: 'I will check the code', lineNumber: 10 }),
+    ]
+    const result = dedupeAdjacentMessageEntries(input)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.lineNumber).toBe(9)
+  })
+
+  test('collapses the duplicated user turn (response_item + event_msg)', () => {
+    const input: ParsedEntry[] = [
+      entry({ type: 'user', kind: 'message', content: "let's try it", lineNumber: 6 }),
+      entry({ type: 'user', kind: 'message', content: "let's try it", lineNumber: 7 }),
+    ]
+    expect(dedupeAdjacentMessageEntries(input)).toHaveLength(1)
+  })
+
+  test('keeps messages with the same text but different roles', () => {
+    const input: ParsedEntry[] = [
+      entry({ type: 'user', kind: 'message', content: 'ok', lineNumber: 1 }),
+      entry({ type: 'assistant', kind: 'message', content: 'ok', lineNumber: 2 }),
+    ]
+    expect(dedupeAdjacentMessageEntries(input)).toHaveLength(2)
+  })
+
+  test('keeps identical messages that are not adjacent (separated by a tool call)', () => {
+    // Two distinct assistant turns can legitimately repeat text; a tool entry
+    // between them means they are not the same logged turn.
+    const input: ParsedEntry[] = [
+      entry({ type: 'assistant', kind: 'message', content: 'Done', lineNumber: 1 }),
+      entry({ type: 'tool', kind: 'tool_call', content: '[Tool: bash]', lineNumber: 2 }),
+      entry({ type: 'assistant', kind: 'message', content: 'Done', lineNumber: 3 }),
+    ]
+    expect(dedupeAdjacentMessageEntries(input)).toHaveLength(3)
+  })
+
+  test('does not collapse adjacent identical tool calls', () => {
+    const input: ParsedEntry[] = [
+      entry({ type: 'tool', kind: 'tool_call', content: '[Tool: read]', lineNumber: 1 }),
+      entry({ type: 'tool', kind: 'tool_call', content: '[Tool: read]', lineNumber: 2 }),
+    ]
+    expect(dedupeAdjacentMessageEntries(input)).toHaveLength(2)
+  })
+
+  test('preserves a normal alternating conversation unchanged', () => {
+    const input: ParsedEntry[] = [
+      entry({ type: 'user', kind: 'message', content: 'hi', lineNumber: 1 }),
+      entry({ type: 'assistant', kind: 'message', content: 'hello', lineNumber: 2 }),
+      entry({ type: 'user', kind: 'message', content: 'bye', lineNumber: 3 }),
+    ]
+    expect(dedupeAdjacentMessageEntries(input)).toEqual(input)
+  })
+})

--- a/src/client/__tests__/sessionPreviewDedup.test.ts
+++ b/src/client/__tests__/sessionPreviewDedup.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import {
   dedupeAdjacentMessageEntries,
-  annotateGroupedEntries,
+  groupEntriesForDisplay,
   type ParsedEntry,
 } from '../components/SessionPreviewContent'
 
@@ -74,34 +74,50 @@ describe('dedupeAdjacentMessageEntries', () => {
   })
 })
 
-describe('annotateGroupedEntries', () => {
+describe('groupEntriesForDisplay', () => {
   test('shows the role label only at the start of a same-role run', () => {
     const input: ParsedEntry[] = [
       entry({ type: 'assistant', kind: 'message', content: 'step 1', lineNumber: 1 }),
       entry({ type: 'assistant', kind: 'message', content: 'step 2', lineNumber: 2 }),
       entry({ type: 'assistant', kind: 'message', content: 'step 3', lineNumber: 3 }),
     ]
-    expect(annotateGroupedEntries(input).map((e) => e.showRole)).toEqual([true, false, false])
+    // One run -> label on the first (oldest) entry, kept in chronological order.
+    const result = groupEntriesForDisplay(input)
+    expect(result.map((e) => e.entry.content)).toEqual(['step 1', 'step 2', 'step 3'])
+    expect(result.map((e) => e.showRole)).toEqual([true, false, false])
   })
 
-  test('starts a new group when the role changes', () => {
+  test('emits runs newest-first but keeps each run chronological', () => {
+    // Two turns oldest-first: turn A (user + 2 assistant steps), then turn B.
     const input: ParsedEntry[] = [
-      entry({ type: 'user', kind: 'message', content: 'do it', lineNumber: 1 }),
-      entry({ type: 'assistant', kind: 'message', content: 'on it', lineNumber: 2 }),
-      entry({ type: 'assistant', kind: 'message', content: 'more', lineNumber: 3 }),
-      entry({ type: 'user', kind: 'message', content: 'thanks', lineNumber: 4 }),
+      entry({ type: 'user', kind: 'message', content: 'A: do it', lineNumber: 1 }),
+      entry({ type: 'assistant', kind: 'message', content: 'A: step 1', lineNumber: 2 }),
+      entry({ type: 'assistant', kind: 'message', content: 'A: step 2', lineNumber: 3 }),
+      entry({ type: 'user', kind: 'message', content: 'B: do it', lineNumber: 4 }),
+      entry({ type: 'assistant', kind: 'message', content: 'B: step 1', lineNumber: 5 }),
     ]
-    expect(annotateGroupedEntries(input).map((e) => e.showRole)).toEqual([true, true, false, true])
+    const result = groupEntriesForDisplay(input)
+    // Newest run (B assistant) first; within each run chronological order.
+    expect(result.map((e) => e.entry.content)).toEqual([
+      'B: step 1',
+      'B: do it',
+      'A: step 1',
+      'A: step 2',
+      'A: do it',
+    ])
+    expect(result.map((e) => e.showRole)).toEqual([true, true, true, false, true])
   })
 
   test('a tool call between assistant messages does not break the run', () => {
-    // The assistant message after the tool call stays grouped (showRole false).
     const input: ParsedEntry[] = [
       entry({ type: 'assistant', kind: 'message', content: 'running a tool', lineNumber: 1 }),
       entry({ type: 'tool', kind: 'tool_call', content: '[Tool: bash]', lineNumber: 2 }),
       entry({ type: 'assistant', kind: 'message', content: 'tool done', lineNumber: 3 }),
     ]
-    const result = annotateGroupedEntries(input)
+    const result = groupEntriesForDisplay(input)
+    // Single run, chronological: label on first message, tool unlabeled, second
+    // assistant stays grouped.
+    expect(result.map((e) => e.entry.content)).toEqual(['running a tool', '[Tool: bash]', 'tool done'])
     expect(result.map((e) => e.showRole)).toEqual([true, false, false])
   })
 
@@ -110,8 +126,9 @@ describe('annotateGroupedEntries', () => {
       entry({ type: 'user', kind: 'message', content: 'hi', lineNumber: 1 }),
       entry({ type: 'assistant', kind: 'message', content: 'hello', lineNumber: 2 }),
     ]
-    const result = annotateGroupedEntries(input)
+    const result = groupEntriesForDisplay(input)
     expect(result).toHaveLength(2)
-    expect(result.map((e) => e.entry)).toEqual(input)
+    // Two single-entry runs, reversed: assistant turn first.
+    expect(result.map((e) => e.entry.content)).toEqual(['hello', 'hi'])
   })
 })

--- a/src/client/components/SessionPreviewContent.tsx
+++ b/src/client/components/SessionPreviewContent.tsx
@@ -29,7 +29,7 @@ interface PreviewData {
   endByte?: number
 }
 
-interface ParsedEntry {
+export interface ParsedEntry {
   type: 'user' | 'assistant' | 'system' | 'tool' | 'other'
   kind: NormalizedEventKind
   content: string
@@ -332,6 +332,32 @@ function parseLogEntry(
   }
 
   return []
+}
+
+// Codex writes every conversational turn to the log twice: once as an `event_msg`
+// (user_message / agent_message) and once as a `response_item` message, with
+// identical text. The two records land adjacently, so a single turn would render
+// twice in the Messages view — previously once as a message and once as a
+// mislabeled "Log" entry. Collapse a message entry when it repeats the
+// immediately-preceding kept entry's role and text. Tool/result entries are
+// untouched (consecutive identical tool calls can be legitimate), and the raw
+// Events view bypasses this entirely.
+export function dedupeAdjacentMessageEntries(entries: ParsedEntry[]): ParsedEntry[] {
+  const deduped: ParsedEntry[] = []
+  for (const entry of entries) {
+    const prev = deduped[deduped.length - 1]
+    if (
+      prev &&
+      entry.kind === 'message' &&
+      prev.kind === 'message' &&
+      entry.type === prev.type &&
+      entry.content === prev.content
+    ) {
+      continue
+    }
+    deduped.push(entry)
+  }
+  return deduped
 }
 
 function lineKey(entry: ParsedEntry) {
@@ -741,9 +767,16 @@ export default function SessionPreviewContent({
       }) ?? [],
     [previewData]
   )
+  // Codex double-logs each turn (event_msg + response_item); collapse the
+  // adjacent duplicates before display so a turn renders once. Events view keeps
+  // the raw, un-deduped lines.
+  const dedupedEntries = useMemo(
+    () => dedupeAdjacentMessageEntries(parsedEntries),
+    [parsedEntries]
+  )
   // Reverse-chronological display (newest first). The data model stays oldest-first
   // — pagination and keys are unchanged; only the render order is flipped.
-  const messageEntries = useMemo(() => parsedEntries.slice().reverse(), [parsedEntries])
+  const messageEntries = useMemo(() => dedupedEntries.slice().reverse(), [dedupedEntries])
   const eventEntries = useMemo(() => structuredLines.slice().reverse(), [structuredLines])
   const lineRangeLabel = previewData
     ? previewData.totalLines === 0

--- a/src/client/components/SessionPreviewContent.tsx
+++ b/src/client/components/SessionPreviewContent.tsx
@@ -363,6 +363,27 @@ export function dedupeAdjacentMessageEntries(entries: ParsedEntry[]): ParsedEntr
   return deduped
 }
 
+// A single Codex turn produces many short assistant step-messages interleaved
+// with tool calls, so the Messages view otherwise reads as a wall of repeated
+// "Assistant" headers. Show the role label only at the start of each same-role
+// run so a turn renders as one grouped block. Tool entries carry no role label,
+// so they don't break a run (an assistant message after a tool call stays in the
+// same group). Operates in display order, so the label lands on the run's first
+// rendered entry.
+export function annotateGroupedEntries(
+  entries: ParsedEntry[]
+): Array<{ entry: ParsedEntry; showRole: boolean }> {
+  let prevRole: ParsedEntry['type'] | null = null
+  return entries.map((entry) => {
+    if (entry.kind === 'tool_call' || entry.kind === 'result') {
+      return { entry, showRole: false }
+    }
+    const showRole = entry.type !== prevRole
+    prevRole = entry.type
+    return { entry, showRole }
+  })
+}
+
 function lineKey(entry: ParsedEntry) {
   return `${entry.sourceKey}:${entry.seq}`
 }
@@ -487,7 +508,7 @@ function MarkdownMessage({ content }: { content: string }) {
   )
 }
 
-function TranscriptEntry({ entry }: { entry: ParsedEntry }) {
+function TranscriptEntry({ entry, showRole = true }: { entry: ParsedEntry; showRole?: boolean }) {
   // tool_result events normalize to empty text and are dropped by parseLogEntry,
   // so only tool_call and result entries reach the collapsible ToolEntry.
   if (entry.kind === 'tool_call' || entry.kind === 'result') {
@@ -495,14 +516,23 @@ function TranscriptEntry({ entry }: { entry: ParsedEntry }) {
   }
   const marker = lineMarker(entry.lineNumber, entry.timestamp, entry.exactLineNumber)
 
+  // showRole marks the start of a same-role run: it gets the role label and a
+  // top divider; continued entries in the run are flush below with no label, so
+  // a multi-step turn reads as one grouped block.
   return (
-    <article className="grid grid-cols-[5.75rem_minmax(0,1fr)] gap-3 border-b border-border/60 py-4 last:border-b-0 sm:grid-cols-[6.75rem_minmax(0,1fr)]">
+    <article
+      className={`grid grid-cols-[5.75rem_minmax(0,1fr)] gap-3 pb-2 sm:grid-cols-[6.75rem_minmax(0,1fr)] ${
+        showRole ? 'mt-4 border-t border-border/60 pt-4 first:mt-0 first:border-t-0 first:pt-0' : 'pt-1'
+      }`}
+    >
       <div className="select-none pt-0.5 text-right">
-        <div className={`text-[11px] font-semibold uppercase tracking-wide ${entryToneClass(entry)}`}>
-          {entryLabel(entry)}
-        </div>
+        {showRole && (
+          <div className={`text-[11px] font-semibold uppercase tracking-wide ${entryToneClass(entry)}`}>
+            {entryLabel(entry)}
+          </div>
+        )}
         <div
-          className="mt-1 text-[10px] tabular-nums text-muted"
+          className={`text-[10px] tabular-nums text-muted ${showRole ? 'mt-1' : ''}`}
           title={lineTitle(entry.lineNumber, entry.timestamp, entry.exactLineNumber)}
         >
           {marker}
@@ -847,8 +877,8 @@ export default function SessionPreviewContent({
                 No readable messages found. Try Events.
               </div>
             ) : (
-              messageEntries.map((entry) => (
-                <TranscriptEntry key={lineKey(entry)} entry={entry} />
+              annotateGroupedEntries(messageEntries).map(({ entry, showRole }) => (
+                <TranscriptEntry key={lineKey(entry)} entry={entry} showRole={showRole} />
               ))
             )}
             {previewData.hasMoreBefore && (

--- a/src/client/components/SessionPreviewContent.tsx
+++ b/src/client/components/SessionPreviewContent.tsx
@@ -259,6 +259,9 @@ function getStructuredProminence(
     type === 'assistant' ||
     payloadType === 'user_message' ||
     payloadType === 'assistant_message' ||
+    // Codex emits the assistant turn as `agent_message`; treat it as
+    // conversational prominence in the Events view, matching the Messages view.
+    payloadType === 'agent_message' ||
     payloadType === 'message'
   ) {
     return 'message'

--- a/src/client/components/SessionPreviewContent.tsx
+++ b/src/client/components/SessionPreviewContent.tsx
@@ -363,25 +363,41 @@ export function dedupeAdjacentMessageEntries(entries: ParsedEntry[]): ParsedEntr
   return deduped
 }
 
-// A single Codex turn produces many short assistant step-messages interleaved
-// with tool calls, so the Messages view otherwise reads as a wall of repeated
-// "Assistant" headers. Show the role label only at the start of each same-role
-// run so a turn renders as one grouped block. Tool entries carry no role label,
-// so they don't break a run (an assistant message after a tool call stays in the
-// same group). Operates in display order, so the label lands on the run's first
-// rendered entry.
-export function annotateGroupedEntries(
+function isToolEntry(entry: ParsedEntry): boolean {
+  return entry.kind === 'tool_call' || entry.kind === 'result'
+}
+
+// A single Codex turn emits many short assistant step-messages interleaved with
+// tool calls, so the Messages view otherwise reads as a wall of repeated
+// "Assistant" headers. Group consecutive same-role entries into runs (tool calls
+// don't break a run, so an assistant message after a tool stays in the group),
+// then emit the runs newest-first — matching the reverse-chronological transcript
+// — while keeping each run's entries in chronological order, so a turn reads
+// top-to-bottom as it happened. The role label shows once per run, on its first
+// (oldest) message entry. Input is oldest-first.
+export function groupEntriesForDisplay(
   entries: ParsedEntry[]
 ): Array<{ entry: ParsedEntry; showRole: boolean }> {
-  let prevRole: ParsedEntry['type'] | null = null
-  return entries.map((entry) => {
-    if (entry.kind === 'tool_call' || entry.kind === 'result') {
-      return { entry, showRole: false }
+  const runs: ParsedEntry[][] = []
+  let runRole: ParsedEntry['type'] | null = null
+  for (const entry of entries) {
+    if (runs.length === 0 || (!isToolEntry(entry) && entry.type !== runRole)) {
+      runs.push([])
+      if (!isToolEntry(entry)) runRole = entry.type
     }
-    const showRole = entry.type !== prevRole
-    prevRole = entry.type
-    return { entry, showRole }
-  })
+    runs[runs.length - 1].push(entry)
+  }
+
+  const out: Array<{ entry: ParsedEntry; showRole: boolean }> = []
+  for (let i = runs.length - 1; i >= 0; i--) {
+    let labeled = false
+    for (const entry of runs[i]) {
+      const showRole = !isToolEntry(entry) && !labeled
+      if (showRole) labeled = true
+      out.push({ entry, showRole })
+    }
+  }
+  return out
 }
 
 function lineKey(entry: ParsedEntry) {
@@ -511,7 +527,7 @@ function MarkdownMessage({ content }: { content: string }) {
 function TranscriptEntry({ entry, showRole = true }: { entry: ParsedEntry; showRole?: boolean }) {
   // tool_result events normalize to empty text and are dropped by parseLogEntry,
   // so only tool_call and result entries reach the collapsible ToolEntry.
-  if (entry.kind === 'tool_call' || entry.kind === 'result') {
+  if (isToolEntry(entry)) {
     return <ToolEntry entry={entry} />
   }
   const marker = lineMarker(entry.lineNumber, entry.timestamp, entry.exactLineNumber)
@@ -807,9 +823,9 @@ export default function SessionPreviewContent({
     () => dedupeAdjacentMessageEntries(parsedEntries),
     [parsedEntries]
   )
-  // Reverse-chronological display (newest first). The data model stays oldest-first
-  // — pagination and keys are unchanged; only the render order is flipped.
-  const messageEntries = useMemo(() => dedupedEntries.slice().reverse(), [dedupedEntries])
+  // Group into sender runs, newest turn first but chronological within each turn.
+  // The data model stays oldest-first; pagination and keys are unchanged.
+  const displayEntries = useMemo(() => groupEntriesForDisplay(dedupedEntries), [dedupedEntries])
   const eventEntries = useMemo(() => structuredLines.slice().reverse(), [structuredLines])
   const lineRangeLabel = previewData
     ? previewData.totalLines === 0
@@ -872,12 +888,12 @@ export default function SessionPreviewContent({
         )}
         {previewData && viewMode === 'messages' && (
           <div className="mx-auto flex w-full max-w-4xl flex-col">
-            {messageEntries.length === 0 ? (
+            {displayEntries.length === 0 ? (
               <div className="py-8 text-center text-muted">
                 No readable messages found. Try Events.
               </div>
             ) : (
-              annotateGroupedEntries(messageEntries).map(({ entry, showRole }) => (
+              displayEntries.map(({ entry, showRole }) => (
                 <TranscriptEntry key={lineKey(entry)} entry={entry} showRole={showRole} />
               ))
             )}

--- a/src/shared/__tests__/eventTaxonomy.test.ts
+++ b/src/shared/__tests__/eventTaxonomy.test.ts
@@ -84,6 +84,30 @@ describe('eventTaxonomy', () => {
     expect(assistantMessage[0]?.source.payloadType).toBe('assistant_message')
   })
 
+  test('normalizes Codex event_msg agent_message as an assistant turn', () => {
+    // Real Codex emits the assistant turn as `agent_message`, not
+    // `assistant_message`. It must resolve to role 'assistant' rather than
+    // falling through to the role:'other' fallback (which rendered as "Log" and
+    // duplicated the paired response_item message).
+    const events = normalizeAgentLogEntry({
+      type: 'event_msg',
+      payload: { type: 'agent_message', message: 'here is what I found' },
+    })
+
+    expect(events).toEqual([
+      {
+        kind: 'message',
+        role: 'assistant',
+        text: 'here is what I found',
+        source: {
+          family: 'codex',
+          rawType: 'event_msg',
+          payloadType: 'agent_message',
+        },
+      },
+    ])
+  })
+
   test('normalizes user and assistant message variants', () => {
     const userEvents = normalizeAgentLogEntry({
       type: 'user',

--- a/src/shared/eventTaxonomy.ts
+++ b/src/shared/eventTaxonomy.ts
@@ -164,7 +164,10 @@ function normalizeEventMsgMessage(
 
   if (payloadType === 'user_message') {
     role = 'user'
-  } else if (payloadType === 'assistant_message') {
+  } else if (payloadType === 'assistant_message' || payloadType === 'agent_message') {
+    // Codex emits the assistant turn as `agent_message` (not `assistant_message`).
+    // Without this it falls through to the generic fallback and renders as a
+    // role:'other' "Log" entry, duplicating the paired response_item message.
     role = 'assistant'
   } else if (payloadType === 'system_message') {
     role = 'system'


### PR DESCRIPTION
## Problem

In the hibernated transcript **preview** for Codex sessions, the Messages view alternated between **ASSISTANT** and **LOG** showing the *same repeated text*, and user messages were often absent.

## Root cause

Codex writes every conversational turn to its rollout log **twice**:
- as an `event_msg` (`user_message` / `agent_message`), and
- as a `response_item` message (`role: assistant` / `user`),

with identical text, on adjacent lines.

Two bugs compounded:

1. **`agent_message` not recognized.** `normalizeEventMsgMessage` only handled `assistant_message`, but real Codex emits `agent_message`. The unrecognized event fell through to the generic fallback (`normalizeFallbackMessage`), which still extracted the text but stamped it `role: 'other'` → rendered as a **"Log"** entry (`entryLabel` maps `other` → `Log`). So each assistant turn showed once as **ASSISTANT** (from `response_item`) and once as **LOG** (from the `event_msg` fallback).
2. **Duplication.** Even with correct roles, the paired `event_msg` + `response_item` records duplicate each turn.

("No user message" is mostly the 200-line recent-window landing inside a long agent turn; user turns appear via *Load earlier*. They parse correctly — both `event_msg/user_message` and `response_item/message/user` map to `user`.)

## Fix

- `eventTaxonomy.ts`: map `agent_message` → `assistant`.
- `SessionPreviewContent.tsx`: add `dedupeAdjacentMessageEntries` — collapse a `kind: 'message'` entry that repeats the immediately-preceding kept entry's role + text. Applies to the **Messages** view only; the raw **Events** view is unchanged. Tool/result entries are untouched (consecutive identical tool calls can be legitimate).
- `SessionPreviewContent.tsx`: also recognize `agent_message` in `getStructuredProminence` so agent messages render at conversational prominence (not dimmed `system`) in the **Events** view, matching the Messages view.

## Verification

Ran the fixed parser + dedup over a real `~/.codex` rollout (last 200 lines):
- message-kind `other`/**LOG** entries remaining: **0** (was 15+)
- assistant turns: **54 → 27** after dedup (each was doubled)
- adjacent duplicate message pairs remaining: **0**

## Tests

- New `eventTaxonomy` test: `agent_message` → assistant turn.
- New `sessionPreviewDedup.test.ts`: 6 cases (collapses the assistant/user pairs; keeps distinct roles, non-adjacent repeats, and tool calls; leaves normal conversations untouched).
- Full suite: 736 pass, 0 fail.

## Review

Two independent reviewers checked the dedup logic/integration and the taxonomy change. No correctness bugs found; the only surfaced item (Events-view prominence for `agent_message`) is addressed in this PR.

## Update: turn grouping in Messages view

A single Codex turn emits many short assistant step-messages interleaved with tool calls, so the Messages view read as a wall of repeated "Assistant" headers. `annotateGroupedEntries` now shows the role label only at the start of each same-role run (tool calls don't break a run); continued entries render flush beneath the group with just a timestamp. A turn reads as one block: user ask → assistant response with its steps. Messages view only — dedup, pagination, and the Events view are unchanged. Verified in the running app. Reasoning blocks are confirmed dropped (not shown as assistant); their `reasoning` content type is encrypted/empty and never extracted.
