### PR TITLE
fix(terminal): read pty client identity via list-clients instead of display-message -c

### DIFF
--- a/src/server/__tests__/isolated/terminalProxy.test.ts
+++ b/src/server/__tests__/isolated/terminalProxy.test.ts
@@ -4,6 +4,11 @@ import { buildTmuxFormat } from '../../tmuxFormat'
 
 const CLIENT_TTY_OUTPUT = `${buildTmuxFormat(['/dev/pts/9', '4242'])}\n`
 const CLIENT_TTY_FORMAT = buildTmuxFormat(['#{client_tty}', '#{client_pid}'])
+const CLIENT_IDENTITY_FORMAT = buildTmuxFormat([
+  '#{client_tty}',
+  '#{session_name}',
+  '#{window_id}',
+])
 
 function getTmuxCommand(args: string[]): string {
   const tmuxArgs = args[0] === 'tmux' ? args.slice(1) : args
@@ -69,6 +74,30 @@ function createSpawnHarness() {
     spawnSyncCalls.push({ args, options: _options })
     const command = getTmuxCommand(args)
     if (command === 'list-clients') {
+      // Real tmux expands list-clients formats per client, so answer by the
+      // requested format: the tty+pid discovery format keeps its canned
+      // output, while the identity format reports each client's session from
+      // the tracked switch-client state. A second, more recently active
+      // client is listed first — display-message -p -c would have reported
+      // that one's session (the bug the identity read was moved off of).
+      const tmuxArgs = args[0] === 'tmux' ? args.slice(1) : args
+      const formatIndex = tmuxArgs.indexOf('-F')
+      const format = formatIndex >= 0 ? tmuxArgs[formatIndex + 1] ?? '' : ''
+      if (format === CLIENT_IDENTITY_FORMAT) {
+        const [sessionName, windowTarget = '@1'] = activeTarget.split(':')
+        const windowId = windowTarget.includes('.')
+          ? windowTarget.slice(0, windowTarget.indexOf('.'))
+          : windowTarget
+        const rows = [
+          buildTmuxFormat(['/dev/pts/1', 'other-session', '@9']),
+          buildTmuxFormat(['/dev/pts/9', sessionName, windowId || '@1']),
+        ]
+        return {
+          exitCode: 0,
+          stdout: Buffer.from(rows.join('\n') + '\n'),
+          stderr: Buffer.from(''),
+        } as ReturnType<typeof Bun.spawnSync>
+      }
       return {
         exitCode: 0,
         stdout: Buffer.from(CLIENT_TTY_OUTPUT),
@@ -211,6 +240,35 @@ describe('TerminalProxy', () => {
       options: expect.objectContaining({ timeout: 3000 }),
     })
     expect(proxy.getCurrentWindow()).toBe('@2')
+  })
+
+  test('switchTo verifies against our own client when another client is more recently active', async () => {
+    // The harness lists a foreign client (/dev/pts/1, other-session) FIRST in
+    // list-clients output — the position display-message -p -c would have
+    // reported. Verification must read our own client's row instead; a
+    // regression back to most-recently-active semantics fails this switch.
+    const harness = createSpawnHarness()
+    const proxy = new TerminalProxy({
+      connectionId: 'abc',
+      sessionName: 'agentboard-ws-abc',
+      baseSession: 'agentboard',
+      onData: () => {},
+      spawn: harness.spawn,
+      spawnSync: harness.spawnSync,
+      wait: async () => {},
+    })
+
+    await proxy.start()
+    await proxy.switchTo('external:@2')
+
+    expect(proxy.getCurrentWindow()).toBe('@2')
+    expect(
+      harness.spawnSyncCalls.some(
+        (call) =>
+          getTmuxCommand(call.args) === 'display-message' &&
+          call.args.includes('-c')
+      )
+    ).toBe(false)
   })
 
   test('paste stages via load-buffer stdin and replays into the grouped session', async () => {

--- a/src/server/terminal/PtyTerminalProxy.ts
+++ b/src/server/terminal/PtyTerminalProxy.ts
@@ -11,6 +11,11 @@ const TARGET_IDENTITY_FORMAT = buildTmuxFormat([
   '#{session_name}',
   '#{window_id}',
 ])
+const CLIENT_IDENTITY_FORMAT = buildTmuxFormat([
+  '#{client_tty}',
+  '#{session_name}',
+  '#{window_id}',
+])
 
 // `set-clipboard` is a server-global tmux option, so enabling it touches the
 // user's whole tmux server (and isn't reverted on disconnect). It's on by
@@ -395,18 +400,29 @@ class PtyTerminalProxy extends TerminalProxyBase {
     if (!this.clientTty) {
       throw new Error('Terminal client not ready')
     }
+    // display-message -p -c expands formats against the most recently active
+    // client's session, not the -c client, so it misreports whenever another
+    // tmux client is more recently active. list-clients expands formats per
+    // client, so filter by tty instead (same approach as discoverClientTty).
     const output = this.runParsedTmux([
-      'display-message',
-      '-p',
-      '-c',
-      this.clientTty,
-      TARGET_IDENTITY_FORMAT,
-    ]).trim()
-    const identity = this.parseTargetIdentity(output)
-    if (!identity) {
-      throw new Error(`Unable to resolve tmux client identity for ${this.clientTty}`)
+      'list-clients',
+      '-F',
+      CLIENT_IDENTITY_FORMAT,
+    ])
+    for (const line of output.split('\n')) {
+      const cleaned = line.replace(/\r$/, '')
+      if (!cleaned) continue
+      const parts = splitTmuxFields(cleaned, 3)
+      if (!parts) continue
+      const [tty, sessionName, windowId] = parts
+      if (tty !== this.clientTty) continue
+      if (!sessionName) break
+      return {
+        sessionName,
+        windowId: windowId?.trim() || null,
+      }
     }
-    return identity
+    throw new Error(`Unable to resolve tmux client identity for ${this.clientTty}`)
   }
 
   private parseTargetIdentity(output: string): TmuxTargetIdentity | null {


### PR DESCRIPTION
Fixes #161.

## What

`display-message -p -c <tty>` expands formats against the most-recently-active client's session, not the `-c` client (verified on tmux 3.4 and 3.5a — minimal repro in the issue). This made pty-mode switch verification report false `ERR_TMUX_SWITCH_FAILED` whenever any other tmux client on the server was more recently active — i.e. whenever the user also uses tmux locally while agentboard is open.

`readClientIdentity()` now enumerates `list-clients -F '#{client_tty}\t#{session_name}\t#{window_id}'` and picks the row matching our client tty — the same approach `discoverClientTty()` already relies on. Rows that don't parse (e.g. control-mode clients with an empty tty) are skipped. No other behavior change.

## Test changes

The spawn harness in `isolated/terminalProxy.test.ts` needed two deliberate changes (context in [this comment on #161](https://github.com/gbasin/agentboard/issues/161#issuecomment-5044650982)):

- **Harness fidelity:** the mock's `display-message -c` branch replays the last `switch-client` target — it implements the semantics the production code *assumed*, which is how this bug survived with all unit tests green. The `list-clients` branch now answers per requested `-F` format like real tmux does. No existing assertion was loosened; all 12 prior test cases are unchanged and still pass.
- **New regression test:** `switchTo verifies against our own client when another client is more recently active` — the harness lists a foreign, more recently active client first, the exact condition that fooled `display-message -p -c`. Sanity-checked by mutation: this test fails against master's implementation, as intended.

## Verification

- Container (Debian trixie, tmux 3.5a, non-root, `HOSTNAME=127.0.0.1`): full suite **including the real-tmux integration layer that CI skips** — green; coverage mode and `vite build` also pass.
- Host (Ubuntu 24.04, tmux 3.4): reproduced the original end-to-end failure before the fix; gone after.
- The underlying tmux behavior was verified identical on 3.4 and 3.5a, so the fix needs no version gate (`list-clients -F` is available on all supported versions, including the 3.2a from #156).

Feel free to rework or take this over entirely — happy either way.
