### PR TITLE
fix(terminal): paste into the session the pty client is attached to

### DIFF
--- a/src/server/terminal/PtyTerminalProxy.ts
+++ b/src/server/terminal/PtyTerminalProxy.ts
@@ -32,6 +32,11 @@ class PtyTerminalProxy extends TerminalProxyBase {
   private rows = 24
   private clientTty: string | null = null
   private startAttemptId = 0
+  // Session the client was last switched into. Paste targets its active
+  // window: for externally-discovered sessions the client leaves the grouped
+  // ws session entirely, so pasting into the ws session would hit its own
+  // (bootstrap) window instead of the window on screen.
+  private lastEffectiveSession: string | null = null
 
   getMode(): 'pty' {
     return 'pty'
@@ -57,9 +62,13 @@ class PtyTerminalProxy extends TerminalProxyBase {
     if (!data || this.state === TerminalState.DEAD) {
       return
     }
-    // Target the grouped session's active pane (the window this client switched
-    // to). tmux decides bracketing from that real pane's mode.
-    this.deliverPasteViaTmux(this.options.sessionName, data)
+    // Target the active window of the session this client is attached to.
+    // tmux decides bracketing from that real pane's mode. Falling back to
+    // the grouped session name covers the pre-switch state.
+    this.deliverPasteViaTmux(
+      this.lastEffectiveSession ?? this.options.sessionName,
+      data
+    )
   }
 
   resize(cols: number, rows: number): void {
@@ -101,6 +110,7 @@ class PtyTerminalProxy extends TerminalProxyBase {
 
     this.clientTty = null
     this.currentWindow = null
+    this.lastEffectiveSession = null
     this.readyAt = null
     this.startPromise = null
   }
@@ -346,6 +356,7 @@ class PtyTerminalProxy extends TerminalProxyBase {
       } else {
         this.setCurrentWindow(effectiveTarget)
       }
+      this.lastEffectiveSession = actualIdentity.sessionName
       const durationMs = this.now() - startedAt
       this.logEvent('terminal_switch_success', {
         sessionName: this.options.sessionName,


### PR DESCRIPTION
Fixes #162.

## What

`paste()` targeted the grouped ws session unconditionally; after switching into an externally-discovered session the buffer landed in the ws session's own bootstrap window and the paste was silently lost (verified against master's exact command sequence — see the issue). The proxy now records `lastEffectiveSession` from the verified switch identity and pastes into that session's active pane, falling back to the ws session before the first switch (reset on dispose). Session-level targeting also keeps following manual `prefix+n` window changes made inside the terminal.

## Verification

- Container (Debian trixie, tmux 3.5a, non-root, `HOSTNAME=127.0.0.1`): full suite including the real-tmux layer — green; coverage mode and build pass.
- The paste-into-bootstrap-pane behavior was reproduced with master's literal command sequence on an isolated tmux socket (probe text: 1 hit in the hidden bootstrap pane, 0 hits in the on-screen window); with the fix the probe lands on screen.

Tiny fix — feel free to fold it into anything else or rework as you prefer.
