### PR TITLE
feat(settings): runtime toggle for prefer-window-name

### DIFF
--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -117,6 +117,8 @@ export default function SettingsModal({
   // Server-side settings (fetched from API)
   const [tmuxMouseMode, setTmuxMouseMode] = useState(true)
   const [tmuxMouseModeLoading, setTmuxMouseModeLoading] = useState(false)
+  const [preferWindowName, setPreferWindowName] = useState(false)
+  const [preferWindowNameLoading, setPreferWindowNameLoading] = useState(false)
   const [historyMaxAgeHours, setHistoryMaxAgeHours] = useState(24)
   const [historyMaxAgeHoursLoading, setHistoryMaxAgeHoursLoading] = useState(false)
 
@@ -164,6 +166,10 @@ export default function SettingsModal({
       fetch('/api/settings/history-max-age-hours')
         .then((res) => res.json())
         .then((data: { hours: number }) => setHistoryMaxAgeHours(data.hours))
+        .catch(() => {})
+      fetch('/api/settings/prefer-window-name')
+        .then((res) => res.json())
+        .then((data: { enabled: boolean }) => setPreferWindowName(data.enabled))
         .catch(() => {})
       // Disable terminal textarea when modal opens to prevent keyboard capture
       if (typeof document !== 'undefined') {
@@ -310,6 +316,18 @@ export default function SettingsModal({
     })
       .catch(() => setTmuxMouseMode(!enabled)) // Revert on error
       .finally(() => setTmuxMouseModeLoading(false))
+  }
+
+  const handlePreferWindowNameChange = (enabled: boolean) => {
+    setPreferWindowNameLoading(true)
+    setPreferWindowName(enabled)
+    fetch('/api/settings/prefer-window-name', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled }),
+    })
+      .catch(() => setPreferWindowName(!enabled)) // Revert on error
+      .finally(() => setPreferWindowNameLoading(false))
   }
 
   const handleHistoryMaxAgeHoursChange = (hours: number) => {
@@ -707,6 +725,21 @@ export default function SettingsModal({
                 checked={tmuxMouseMode}
                 onCheckedChange={handleTmuxMouseModeChange}
                 disabled={tmuxMouseModeLoading}
+              />
+            </div>
+
+            <div className="mt-4 flex items-center justify-between">
+              <div>
+                <div className="text-sm text-primary">Prefer Window Names</div>
+                <div className="text-[10px] text-muted">
+                  Label discovered sessions with their tmux window name instead
+                  of the session name. Applies immediately.
+                </div>
+              </div>
+              <Switch
+                checked={preferWindowName}
+                onCheckedChange={handlePreferWindowNameChange}
+                disabled={preferWindowNameLoading}
               />
             </div>
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -500,6 +500,15 @@ if (!Number.isFinite(runtimeHistoryMaxAgeHours) || runtimeHistoryMaxAgeHours < 1
   runtimeHistoryMaxAgeHours = 24
 }
 
+// Read prefer-window-name setting from DB. The env var
+// (AGENTBOARD_PREFER_WINDOW_NAME, already folded into config) is only the
+// initial default; once set from the UI the stored value wins.
+const PREFER_WINDOW_NAME_KEY = 'prefer_window_name'
+const storedPreferWindowName = db.getAppSetting(PREFER_WINDOW_NAME_KEY)
+if (storedPreferWindowName !== null) {
+  config.preferWindowName = storedPreferWindowName === 'true'
+}
+
 const sessionManager = new SessionManager(undefined, {
   displayNameExists: (name, excludeSessionId) => db.displayNameExists(name, excludeSessionId),
   mouseMode: initialMouseMode,
@@ -1122,7 +1131,10 @@ async function refreshSessionsAsync(): Promise<void> {
         const sessions = await sessionRefreshWorker.refresh(
           config.tmuxSession,
           config.discoverPrefixes,
-          { expectedWindowCount: estimateRefreshWindowCount() }
+          {
+            expectedWindowCount: estimateRefreshWindowCount(),
+            preferWindowName: config.preferWindowName,
+          }
         )
         // Mutation happened while we were listing windows — discard and retry
         if (gen !== refreshGeneration) continue
@@ -1640,6 +1652,51 @@ app.put('/api/settings/tmux-mouse-mode', async (c) => {
     return c.json({ error: 'Unable to persist tmux mouse mode' }, 500)
   }
 
+  return c.json({ enabled: body.enabled })
+})
+
+app.get('/api/settings/prefer-window-name', (c) => {
+  return c.json({ enabled: config.preferWindowName })
+})
+
+app.put('/api/settings/prefer-window-name', async (c) => {
+  let body: { enabled?: unknown }
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json({ error: 'Invalid request body' }, 400)
+  }
+
+  if (typeof body.enabled !== 'boolean') {
+    return c.json({ error: 'enabled must be a boolean' }, 400)
+  }
+
+  const previousValue = config.preferWindowName
+  config.preferWindowName = body.enabled
+  try {
+    db.setAppSetting(PREFER_WINDOW_NAME_KEY, String(body.enabled))
+  } catch (error) {
+    // Same contract as tmux-mouse-mode: never leave the runtime value
+    // diverging from what will be restored after a restart.
+    config.preferWindowName = previousValue
+    logger.warn('prefer_window_name_persist_failed', {
+      message: error instanceof Error ? error.message : String(error),
+    })
+    return c.json({ error: 'Unable to persist prefer window name' }, 500)
+  }
+  // Connected clients keep their own copy from the open-time server-config
+  // message (mobile tab labels read it); rebroadcast so they all converge.
+  broadcast({
+    type: 'server-config',
+    remoteAllowControl: config.remoteAllowControl,
+    remoteAllowAttach: config.remoteAllowAttach,
+    hostLabel: config.hostLabel,
+    preferWindowName: config.preferWindowName,
+    clientLogLevel: logLevel,
+  })
+  // Names are recomputed on refresh; schedule one so the sidebar updates
+  // promptly instead of waiting for the next poll tick.
+  scheduleEnterRefresh()
   return c.json({ enabled: body.enabled })
 })
 

--- a/src/server/sessionRefreshWorker.ts
+++ b/src/server/sessionRefreshWorker.ts
@@ -76,6 +76,10 @@ export type RefreshWorkerRequest =
       kind: 'refresh'
       managedSession: string
       discoverPrefixes: string[]
+      // Runtime value from the main process; the worker's own config only
+      // reflects the env at spawn time and would go stale when the setting
+      // is changed from the UI.
+      preferWindowName?: boolean
     }
   | {
       id: string
@@ -139,7 +143,11 @@ ctx.onmessage = (event: MessageEvent<RefreshWorkerRequest>) => {
       return
     }
 
-    const sessions = listAllWindows(payload.managedSession, payload.discoverPrefixes)
+    const sessions = listAllWindows(
+      payload.managedSession,
+      payload.discoverPrefixes,
+      payload.preferWindowName ?? config.preferWindowName
+    )
 
     // Clean up cache entries for windows that no longer exist
     const currentWindows = new Set(sessions.map((s) => s.tmuxWindow))
@@ -281,7 +289,11 @@ function captureScrollback(tmuxWindow: string, lines: number): string {
   }
 }
 
-function listAllWindows(managedSession: string, discoverPrefixes: string[]): Session[] {
+function listAllWindows(
+  managedSession: string,
+  discoverPrefixes: string[],
+  preferWindowName: boolean
+): Session[] {
   const allWindows = listAllWindowData()
   const now = Date.now()
   const wsPrefix = `${managedSession}-ws-`
@@ -328,7 +340,7 @@ function listAllWindows(managedSession: string, discoverPrefixes: string[]): Ses
 
     const creationTimestamp = window.creation ? window.creation * 1000 : now
     const displayName = source === 'external'
-      ? resolveExternalDisplayName(sessionName, window.windowName, config.preferWindowName)
+      ? resolveExternalDisplayName(sessionName, window.windowName, preferWindowName)
       : window.windowName
     const normalizedPath = normalizeProjectPath(window.path)
 

--- a/src/server/sessionRefreshWorkerClient.ts
+++ b/src/server/sessionRefreshWorkerClient.ts
@@ -72,7 +72,7 @@ export class SessionRefreshWorkerClient {
   async refresh(
     managedSession: string,
     discoverPrefixes: string[],
-    options: { expectedWindowCount?: number } = {}
+    options: { expectedWindowCount?: number; preferWindowName?: boolean } = {}
   ): Promise<Session[]> {
     if (this.disposed) {
       throw new Error('Session refresh worker is disposed')
@@ -88,6 +88,7 @@ export class SessionRefreshWorkerClient {
       kind: 'refresh',
       managedSession,
       discoverPrefixes,
+      preferWindowName: options.preferWindowName,
     }
 
     return new Promise<Session[]>((resolve, reject) => {


### PR DESCRIPTION
Fixes #164.

## What

`AGENTBOARD_PREFER_WINDOW_NAME` currently requires a server restart and isn't discoverable. This wires it into the existing runtime-settings pattern (like `tmux-mouse-mode`):

- `GET/PUT /api/settings/prefer-window-name`, persisted under `prefer_window_name` in `app_settings`; the env var remains the initial default, a stored value wins once toggled (same contract as `history-max-age-hours`). Persist failure rolls back the runtime value and returns 500 (same contract as `tmux-mouse-mode`).
- The session refresh worker receives the value per request (`RefreshWorkerRequest.preferWindowName`) since its own `config` snapshot is frozen at spawn time.
- `PUT` rebroadcasts `server-config` so already-connected clients (mobile tab labels read `preferWindowName` from the session store) converge without a reload, and schedules a refresh so sidebar names update within about a second.
- Settings modal: a "Prefer Window Names" switch placed next to Mouse Mode (the immediate-apply section, not the draft section, so Cancel semantics stay honest).

## Verification

- Container (Debian trixie, non-root, `HOSTNAME=127.0.0.1`): full suite green, coverage mode and `vite build` pass on this branch in isolation.
- Manually exercised end-to-end on a live deployment: toggling flips sidebar labels between session names and window names within one refresh tick, persists across restarts, and the env var still seeds the initial default.

Feel free to rework or take this over entirely — happy either way.
