### PR TITLE
feat(terminal): per-connection grouped sessions for externally-discovered sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ Reasons to opt out: fullscreen rendering keeps the conversation in the alternate
 
 `AGENTBOARD_TMUX_SYNC` controls whether Agentboard's tmux client advertises synchronized-update support (`tmux -T sync`, tmux 3.2+). By default it does, so tmux wraps redraws in DEC 2026 frame markers and the browser terminal paints each frame atomically instead of tearing during fast fullscreen repaints (e.g. Claude Code's no-flicker renderer). The flag applies only to Agentboard's own client and does not change tmux server options. Set `AGENTBOARD_TMUX_SYNC=0` (or `false`) to disable.
 
+When you open an externally-discovered tmux session, Agentboard attaches through a per-connection session grouped with it (`agentboard-ws-<connection>-x-<session>-<hash>`), so focus in the browser stays independent of your own tmux clients. Two side effects: these derived sessions appear in `tmux ls` while a viewer is attached (they are removed on switch-away and disconnect, and pruned at startup), and killing the raw session keeps its windows alive until the last grouped viewer switches away (tmux keeps a group's windows while any member session exists).
+
 `TERMINAL_MONITOR_TARGETS` (pipe-pane only) polls tmux to detect closed targets (set to `false` to disable).
 
 `VITE_ALLOWED_HOSTS` allows access to the Vite dev server from other hostnames. Useful with Tailscale MagicDNS - add your machine name (e.g., `nuc`) to access the dev server at `http://nuc:5173` from other devices on your tailnet.

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -279,7 +279,7 @@ class TerminalProxyMock {
     return Promise.resolve(true)
   }
 
-  resolveEffectiveTarget(target: string) {
+  ensureEffectiveTarget(target: string) {
     if (target === this.options.baseSession) {
       return this.options.sessionName
     }

--- a/src/server/__tests__/isolated/terminalProxy.test.ts
+++ b/src/server/__tests__/isolated/terminalProxy.test.ts
@@ -169,6 +169,118 @@ function createSpawnHarness({ tmuxVersion = 'tmux 3.4' } = {}) {
   }
 }
 
+// Stateful fake tmux for the external-grouped-session tests below: tracks
+// which sessions exist and their window ids so has-session/new-session/
+// kill-session/list-windows behave like the real thing instead of the
+// generic harness's always-empty-success default (which made
+// derivedContainsWindow vacuously false and left this whole area untested).
+interface FakeSession {
+  windows: string[]
+  group?: string
+}
+
+function ok(stdout: string): ReturnType<typeof Bun.spawnSync> {
+  return { exitCode: 0, stdout: Buffer.from(stdout), stderr: Buffer.from('') } as ReturnType<typeof Bun.spawnSync>
+}
+function fail(stderr: string): ReturnType<typeof Bun.spawnSync> {
+  return { exitCode: 1, stdout: Buffer.from(''), stderr: Buffer.from(stderr) } as ReturnType<typeof Bun.spawnSync>
+}
+
+function createStatefulTmuxSpawnSync(
+  sessions: Map<string, FakeSession>,
+  initialClientSession: string
+) {
+  let clientSession = initialClientSession
+  let clientWindow: string | null = null
+  const calls: string[][] = []
+  const arg = (args: string[], flag: string) => {
+    const i = args.indexOf(flag)
+    return i >= 0 ? args[i + 1] ?? '' : ''
+  }
+  const currentWindow = () =>
+    clientWindow ?? sessions.get(clientSession)?.windows[0] ?? '@1'
+  const spawnSync = (args: string[]) => {
+    calls.push(args)
+    const command = getTmuxCommand(args)
+    if (command === '-V') {
+      // Without this the version probe falls through to the ok('') default,
+      // tmuxSupportsClientFeatures fails closed, and every test here would
+      // attach without -T sync — unlike the real tmux 3.4 these tests model.
+      return ok('tmux 3.4\n')
+    }
+    if (command === 'list-clients') {
+      const tmuxArgs = args[0] === 'tmux' ? args.slice(1) : args
+      const format = tmuxArgs[tmuxArgs.indexOf('-F') + 1] ?? ''
+      if (format === CLIENT_IDENTITY_FORMAT) {
+        return ok(buildTmuxFormat(['/dev/pts/9', clientSession, currentWindow()]) + '\n')
+      }
+      return ok(CLIENT_TTY_OUTPUT)
+    }
+    if (command === 'has-session') {
+      const name = arg(args, '-t').replace(/^=/, '')
+      return sessions.has(name) ? ok('') : fail("can't find session")
+    }
+    if (command === 'new-session') {
+      const rawName = arg(args, '-t').replace(/^=/, '')
+      const newName = arg(args, '-s')
+      const raw = sessions.get(rawName)
+      if (!raw) return fail("can't find session")
+      sessions.set(newName, { windows: [...raw.windows] })
+      return ok('')
+    }
+    if (command === 'kill-session') {
+      sessions.delete(arg(args, '-t').replace(/^=/, ''))
+      return ok('')
+    }
+    if (command === 'list-windows') {
+      const windows = sessions.get(arg(args, '-t').replace(/^=/, ''))?.windows ?? []
+      return ok(windows.length ? windows.join('\n') + '\n' : '')
+    }
+    if (command === 'list-sessions') {
+      // Ungrouped sessions report an empty group, matching real tmux.
+      const rows = [...sessions.entries()].map(([name, s]) =>
+        buildTmuxFormat([name, s.group ?? ''])
+      )
+      return ok(rows.join('\n') + '\n')
+    }
+    if (command === 'switch-client') {
+      const target = arg(args, '-t').replace(/^=/, '')
+      const colonIdx = target.indexOf(':')
+      if (colonIdx > 0) {
+        clientSession = target.slice(0, colonIdx)
+        clientWindow = target.slice(colonIdx + 1)
+      } else {
+        clientSession = target
+        clientWindow = null
+      }
+      return ok('')
+    }
+    if (command === 'display-message') {
+      // readTargetIdentity always calls this with -t <target> (not -c); it
+      // reports the TARGET's own session:window, not the client's position.
+      const target = arg(args, '-t').replace(/^=/, '')
+      const colonIdx = target.indexOf(':')
+      const sessionName = colonIdx > 0 ? target.slice(0, colonIdx) : target
+      const windowId =
+        colonIdx > 0
+          ? target.slice(colonIdx + 1)
+          : sessions.get(sessionName)?.windows[0] ?? '@1'
+      return ok(buildTmuxFormat([sessionName, windowId]))
+    }
+    return ok('')
+  }
+  return { spawnSync, calls, getClientSession: () => clientSession }
+}
+
+// Mirrors PtyTerminalProxy's private resolveExternalGroupedTarget naming so
+// tests can seed/assert against the exact derived session name without
+// hardcoding a hash that would drift from the implementation.
+function deriveExternalSessionName(managedSession: string, rawSession: string): string {
+  const sanitized = rawSession.replace(/[^A-Za-z0-9_-]/g, '-')
+  const suffix = Bun.hash(rawSession).toString(36).slice(0, 6)
+  return `${managedSession}-x-${sanitized}-${suffix}`
+}
+
 describe('TerminalProxy', () => {
   test('starts tmux client and discovers tty', async () => {
     const harness = createSpawnHarness()
@@ -847,5 +959,474 @@ describe('TerminalProxy', () => {
       options: expect.objectContaining({ timeout: 15000 }),
     })
     expect(proxy.isReady()).toBe(false)
+  })
+
+  test('ensureEffectiveTarget creates a derived grouped session for an external target', async () => {
+    const sessions = new Map<string, FakeSession>([
+      ['agentboard', { windows: ['@0'] }],
+      ['work', { windows: ['@1', '@2'] }],
+    ])
+    const fake = createStatefulTmuxSpawnSync(sessions, 'agentboard-ws-abc')
+    const harness = createSpawnHarness()
+
+    const proxy = new TerminalProxy({
+      connectionId: 'abc',
+      sessionName: 'agentboard-ws-abc',
+      baseSession: 'agentboard',
+      onData: () => {},
+      spawn: harness.spawn,
+      spawnSync: fake.spawnSync,
+      wait: async () => {},
+    })
+
+    await proxy.start()
+    const effective = proxy.ensureEffectiveTarget('work:@1')
+
+    expect(effective).toMatch(/^agentboard-ws-abc-x-work-[0-9a-z]+:@1$/)
+    expect(
+      fake.calls.some(
+        (c) => getTmuxCommand(c) === 'new-session' && c.includes('=work')
+      )
+    ).toBe(true)
+    expect(
+      fake.calls.some(
+        (c) => getTmuxCommand(c) === 'list-windows' && c.some((a) => a.startsWith('=agentboard-ws-abc-x-work-'))
+      )
+    ).toBe(true)
+  })
+
+  test('ensureEffectiveTarget short-circuits on the warm path without re-issuing has-session', async () => {
+    const sessions = new Map<string, FakeSession>([
+      ['agentboard', { windows: ['@0'] }],
+      ['work', { windows: ['@1'] }],
+    ])
+    const fake = createStatefulTmuxSpawnSync(sessions, 'agentboard-ws-abc')
+    const harness = createSpawnHarness()
+
+    const proxy = new TerminalProxy({
+      connectionId: 'abc',
+      sessionName: 'agentboard-ws-abc',
+      baseSession: 'agentboard',
+      onData: () => {},
+      spawn: harness.spawn,
+      spawnSync: fake.spawnSync,
+      wait: async () => {},
+    })
+
+    await proxy.start()
+    proxy.ensureEffectiveTarget('work:@1')
+    const callsAfterFirst = fake.calls.length
+    const second = proxy.ensureEffectiveTarget('work:@1')
+    const hasSessionCallsAfterSecond = fake.calls
+      .slice(callsAfterFirst)
+      .filter((c) => getTmuxCommand(c) === 'has-session')
+
+    expect(second).toMatch(/^agentboard-ws-abc-x-work-[0-9a-z]+:@1$/)
+    expect(hasSessionCallsAfterSecond).toHaveLength(0)
+  })
+
+  test('recovers from a stale derived session bound to a killed-and-recreated raw session', async () => {
+    const staleDerived = deriveExternalSessionName('agentboard-ws-abc', 'work')
+    const sessions = new Map<string, FakeSession>([
+      ['agentboard', { windows: ['@0'] }],
+      // Simulates a ghost: a derived session from an earlier connection,
+      // still holding the OLD windows of a "work" session that has since
+      // been killed and recreated with different window ids.
+      [staleDerived, { windows: ['@1'] }],
+      ['work', { windows: ['@5'] }],
+    ])
+    const fake = createStatefulTmuxSpawnSync(sessions, 'agentboard-ws-abc')
+    const harness = createSpawnHarness()
+
+    const proxy = new TerminalProxy({
+      connectionId: 'abc',
+      sessionName: 'agentboard-ws-abc',
+      baseSession: 'agentboard',
+      onData: () => {},
+      spawn: harness.spawn,
+      spawnSync: fake.spawnSync,
+      wait: async () => {},
+    })
+
+    await proxy.start()
+    const effective = proxy.ensureEffectiveTarget('work:@5')
+
+    // Resolves through the same derived name (recreated in place), now bound
+    // to work's current windows instead of the stale ones.
+    expect(effective).toBe(`${staleDerived}:@5`)
+    expect(sessions.get(staleDerived)?.windows).toEqual(['@5'])
+    // The stale ghost got killed along the way (before being recreated).
+    expect(
+      fake.calls.some(
+        (c) =>
+          getTmuxCommand(c) === 'kill-session' && c.includes(`=${staleDerived}`)
+      )
+    ).toBe(true)
+  })
+
+  test('evacuates the client before killing a stale derived session it is attached to', async () => {
+    const staleDerived = deriveExternalSessionName('agentboard-ws-abc', 'work')
+    const sessions = new Map<string, FakeSession>([
+      ['agentboard', { windows: ['@0'] }],
+      [staleDerived, { windows: ['@1'] }],
+      ['work', { windows: ['@5'] }],
+    ])
+    // The client is sitting on the stale derived session when the switch
+    // that discovers it's stale happens.
+    const fake = createStatefulTmuxSpawnSync(sessions, staleDerived)
+    const harness = createSpawnHarness()
+
+    const proxy = new TerminalProxy({
+      connectionId: 'abc',
+      sessionName: 'agentboard-ws-abc',
+      baseSession: 'agentboard',
+      onData: () => {},
+      spawn: harness.spawn,
+      spawnSync: fake.spawnSync,
+      wait: async () => {},
+    })
+
+    await proxy.start()
+    proxy.ensureEffectiveTarget('work:@5')
+
+    const evacuateIndex = fake.calls.findIndex(
+      (c) =>
+        getTmuxCommand(c) === 'switch-client' &&
+        c.includes('=agentboard-ws-abc')
+    )
+    const killIndex = fake.calls.findIndex(
+      (c) =>
+        getTmuxCommand(c) === 'kill-session' && c.includes(`=${staleDerived}`)
+    )
+    expect(evacuateIndex).toBeGreaterThanOrEqual(0)
+    expect(killIndex).toBeGreaterThan(evacuateIndex)
+  })
+
+  test('gives up and falls back to the raw target when recreation still lands in a stale group', async () => {
+    const sessions = new Map<string, FakeSession>([
+      ['agentboard', { windows: ['@0'] }],
+      ['work', { windows: ['@5'] }],
+    ])
+    const fake = createStatefulTmuxSpawnSync(sessions, 'agentboard-ws-abc')
+    // The derived session never actually contains the requested window, no
+    // matter how many times it's (re)created — simulates the group-name
+    // race where new-session -t joins a surviving stale group instead of
+    // the recreated raw session, without needing to model that race itself.
+    const originalSpawnSync = fake.spawnSync
+    const spawnSync = (args: string[]) => {
+      if (getTmuxCommand(args) === 'list-windows') {
+        return ok('')
+      }
+      return originalSpawnSync(args)
+    }
+    const harness = createSpawnHarness()
+
+    const proxy = new TerminalProxy({
+      connectionId: 'abc',
+      sessionName: 'agentboard-ws-abc',
+      baseSession: 'agentboard',
+      onData: () => {},
+      spawn: harness.spawn,
+      spawnSync,
+      wait: async () => {},
+    })
+
+    await proxy.start()
+    const effective = proxy.ensureEffectiveTarget('work:@5')
+
+    // Degrades to the raw target unchanged rather than looping or throwing.
+    expect(effective).toBe('work:@5')
+    expect(
+      fake.calls.some(
+        (c) =>
+          getTmuxCommand(c) === 'kill-session' &&
+          c.some((a) => a.startsWith('=agentboard-ws-abc-x-work-'))
+      )
+    ).toBe(true)
+  })
+
+  test('bare-session targets also give up on a stale group after recreation, instead of trusting it blindly', async () => {
+    const sessions = new Map<string, FakeSession>([
+      ['agentboard', { windows: ['@0'] }],
+      ['work', { windows: ['@5'], group: 'work' }],
+    ])
+    const fake = createStatefulTmuxSpawnSync(sessions, 'agentboard-ws-abc')
+    // The derived session's group never matches the raw session's group, no
+    // matter how many times it's (re)created -- same race as the window-id
+    // case, but for a bare-session target (no ":@id" suffix), which the
+    // recreation path used to skip re-validating entirely.
+    const originalSpawnSync = fake.spawnSync
+    const spawnSync = (args: string[]) => {
+      if (getTmuxCommand(args) === 'list-sessions') {
+        const derived = deriveExternalSessionName('agentboard-ws-abc', 'work')
+        const rows = [
+          buildTmuxFormat(['work', 'work']),
+          buildTmuxFormat([derived, 'stale-group']),
+        ]
+        return ok(rows.join('\n') + '\n')
+      }
+      return originalSpawnSync(args)
+    }
+    const harness = createSpawnHarness()
+
+    const proxy = new TerminalProxy({
+      connectionId: 'abc',
+      sessionName: 'agentboard-ws-abc',
+      baseSession: 'agentboard',
+      onData: () => {},
+      spawn: harness.spawn,
+      spawnSync,
+      wait: async () => {},
+    })
+
+    await proxy.start()
+    const effective = proxy.ensureEffectiveTarget('work') // no ":@id" suffix
+
+    // Degrades to the raw target unchanged rather than trusting a
+    // freshly-recreated session that landed in the wrong group.
+    expect(effective).toBe('work')
+    expect(
+      fake.calls.some(
+        (c) =>
+          getTmuxCommand(c) === 'kill-session' &&
+          c.some((a) => a.startsWith('=agentboard-ws-abc-x-work-'))
+      )
+    ).toBe(true)
+  })
+
+  test('falls back to the raw target when the raw session no longer exists', async () => {
+    const sessions = new Map<string, FakeSession>([
+      ['agentboard', { windows: ['@0'] }],
+      // "work" is absent — killed with no replacement.
+    ])
+    const fake = createStatefulTmuxSpawnSync(sessions, 'agentboard-ws-abc')
+    const harness = createSpawnHarness()
+
+    const proxy = new TerminalProxy({
+      connectionId: 'abc',
+      sessionName: 'agentboard-ws-abc',
+      baseSession: 'agentboard',
+      onData: () => {},
+      spawn: harness.spawn,
+      spawnSync: fake.spawnSync,
+      wait: async () => {},
+    })
+
+    await proxy.start()
+    const effective = proxy.ensureEffectiveTarget('work:@5')
+
+    expect(effective).toBe('work:@5')
+    expect(
+      fake.calls.some((c) => getTmuxCommand(c) === 'new-session' && c.includes('=work'))
+    ).toBe(false)
+  })
+
+  test('bare-session targets validate via session-group membership, not window-set', async () => {
+    // A pre-existing, correctly-grouped derived session so the warm
+    // re-validation branch (has-session succeeds) runs; only that branch
+    // reads sessionGroupsMatch/derivedContainsWindow at all.
+    const derived = deriveExternalSessionName('agentboard-ws-abc', 'work')
+    const sessions = new Map<string, FakeSession>([
+      ['agentboard', { windows: ['@0'] }],
+      ['work', { windows: ['@1'], group: 'work' }],
+      [derived, { windows: ['@1'], group: 'work' }],
+    ])
+    const fake = createStatefulTmuxSpawnSync(sessions, 'agentboard-ws-abc')
+    const harness = createSpawnHarness()
+
+    const proxy = new TerminalProxy({
+      connectionId: 'abc',
+      sessionName: 'agentboard-ws-abc',
+      baseSession: 'agentboard',
+      onData: () => {},
+      spawn: harness.spawn,
+      spawnSync: fake.spawnSync,
+      wait: async () => {},
+    })
+
+    await proxy.start()
+    const effective = proxy.ensureEffectiveTarget('work') // no ":@id" suffix
+
+    expect(effective).toBe(derived)
+    expect(
+      fake.calls.some((c) => getTmuxCommand(c) === 'list-sessions')
+    ).toBe(true)
+    // Bare targets have no window to check, so the window-set path never runs.
+    expect(
+      fake.calls.some((c) => getTmuxCommand(c) === 'list-windows')
+    ).toBe(false)
+  })
+
+  test('releaseUnusedExternalGroupedSessions kills derived sessions the client already switched away from', async () => {
+    const sessions = new Map<string, FakeSession>([
+      ['agentboard', { windows: ['@0'] }],
+      ['work-a', { windows: ['@1'] }],
+      ['work-b', { windows: ['@2'] }],
+    ])
+    const fake = createStatefulTmuxSpawnSync(sessions, 'agentboard-ws-abc')
+    const harness = createSpawnHarness()
+
+    const proxy = new TerminalProxy({
+      connectionId: 'abc',
+      sessionName: 'agentboard-ws-abc',
+      baseSession: 'agentboard',
+      onData: () => {},
+      spawn: harness.spawn,
+      spawnSync: fake.spawnSync,
+      wait: async () => {},
+    })
+
+    await proxy.start()
+    await proxy.switchTo('work-a:@1')
+    const derivedA = fake.getClientSession()
+    expect(sessions.has(derivedA)).toBe(true)
+
+    await proxy.switchTo('work-b:@2')
+
+    // Switching away kills the now-unused derived-a session...
+    expect(sessions.has(derivedA)).toBe(false)
+    // ...but the one just switched into survives.
+    expect(sessions.has(fake.getClientSession())).toBe(true)
+  })
+
+  test('dispose kills every tracked external grouped session', async () => {
+    const sessions = new Map<string, FakeSession>([
+      ['agentboard', { windows: ['@0'] }],
+      ['work', { windows: ['@1'] }],
+    ])
+    const fake = createStatefulTmuxSpawnSync(sessions, 'agentboard-ws-abc')
+    const harness = createSpawnHarness()
+
+    const proxy = new TerminalProxy({
+      connectionId: 'abc',
+      sessionName: 'agentboard-ws-abc',
+      baseSession: 'agentboard',
+      onData: () => {},
+      spawn: harness.spawn,
+      spawnSync: fake.spawnSync,
+      wait: async () => {},
+    })
+
+    await proxy.start()
+    await proxy.switchTo('work:@1')
+    const derivedName = fake.getClientSession()
+    expect(sessions.has(derivedName)).toBe(true)
+
+    await proxy.dispose()
+
+    expect(
+      fake.calls.some(
+        (c) => getTmuxCommand(c) === 'kill-session' && c.includes(`=${derivedName}`)
+      )
+    ).toBe(true)
+  })
+
+  test('disposed proxy does not resurrect a derived session on ensureEffectiveTarget', async () => {
+    const sessions = new Map<string, FakeSession>([
+      ['agentboard', { windows: ['@0'] }],
+      ['work', { windows: ['@1'] }],
+    ])
+    const fake = createStatefulTmuxSpawnSync(sessions, 'agentboard-ws-abc')
+    const harness = createSpawnHarness()
+
+    const proxy = new TerminalProxy({
+      connectionId: 'abc',
+      sessionName: 'agentboard-ws-abc',
+      baseSession: 'agentboard',
+      onData: () => {},
+      spawn: harness.spawn,
+      spawnSync: fake.spawnSync,
+      wait: async () => {},
+    })
+
+    await proxy.start()
+    await proxy.dispose()
+
+    const callsBeforeRace = fake.calls.length
+    // Simulates an in-flight attach that loses the race with a WebSocket
+    // close: the caller still holds a reference to this (now-disposed) proxy
+    // and calls ensureEffectiveTarget on it, as switchTo() would internally.
+    const effective = proxy.ensureEffectiveTarget('work:@1')
+
+    expect(effective).toBe('work:@1')
+    expect(fake.calls.length).toBe(callsBeforeRace)
+    expect(
+      fake.calls
+        .slice(callsBeforeRace)
+        .some((c) => getTmuxCommand(c) === 'new-session')
+    ).toBe(false)
+  })
+
+  test('a dispose() that lands mid-switchTo still blocks a later resurrection (the case the disposed flag exists for)', async () => {
+    // The test above (disposed proxy does not resurrect...) is satisfied
+    // just as well by the pre-existing `state === DEAD` check, because
+    // dispose() sets state to DEAD synchronously before this test ever calls
+    // ensureEffectiveTarget again -- it doesn't actually prove `disposed` is
+    // load-bearing. This test reproduces the real race the flag guards
+    // against: dispose() runs WHILE a switchTo() is suspended mid-flight
+    // (e.g. the WebSocket closed while verifyClientTarget was retrying).
+    // switchTo()'s own completion (success or failure) unconditionally
+    // writes state back to READY afterward, "reviving" it -- only the
+    // disposed flag (never touched by switchTo) still remembers we're gone.
+    const sessions = new Map<string, FakeSession>([
+      ['agentboard', { windows: ['@0'] }],
+      ['work', { windows: ['@1'] }],
+    ])
+    const fake = createStatefulTmuxSpawnSync(sessions, 'agentboard-ws-abc')
+
+    let proxy!: TerminalProxy
+    let disposeStarted = false
+    // verifyClientTarget only calls wait() once its first (no-wait) identity
+    // check fails to match, i.e. only once forced into its retry loop below.
+    const wait = async () => {
+      if (!disposeStarted) {
+        disposeStarted = true
+        await proxy.dispose()
+      }
+    }
+
+    let identityChecks = 0
+    const spawnSync = (args: string[]) => {
+      const tmuxArgs = args[0] === 'tmux' ? args.slice(1) : args
+      const formatIndex = tmuxArgs.indexOf('-F')
+      const format = formatIndex >= 0 ? tmuxArgs[formatIndex + 1] ?? '' : ''
+      if (getTmuxCommand(args) === 'list-clients' && format === CLIENT_IDENTITY_FORMAT) {
+        identityChecks += 1
+        if (identityChecks === 1) {
+          // First check reports the client still on its old window, so
+          // verifyClientTarget's iteration 1 mismatches and falls into the
+          // retry loop -- which is where dispose() gets to run via wait().
+          return ok(buildTmuxFormat(['/dev/pts/9', 'agentboard-ws-abc', '@0']))
+        }
+      }
+      return fake.spawnSync(args)
+    }
+
+    proxy = new TerminalProxy({
+      connectionId: 'abc',
+      sessionName: 'agentboard-ws-abc',
+      baseSession: 'agentboard',
+      onData: () => {},
+      spawn: createSpawnHarness().spawn,
+      spawnSync,
+      wait,
+    })
+
+    await proxy.start()
+    // Resolves without throwing: doSwitch's own catch swallows the failure
+    // mode here (a stale-map eviction at worst), which is not what this test
+    // is about -- what matters is what state switchTo() leaves behind.
+    await proxy.switchTo('work:@1').catch(() => {})
+
+    expect(disposeStarted).toBe(true)
+    // The race really happened: switchTo()'s completion clobbered state back
+    // away from DEAD after dispose() had already set it.
+    expect((proxy as unknown as { state: string }).state).not.toBe('DEAD')
+
+    const callsBeforeRace = fake.calls.length
+    const effective = proxy.ensureEffectiveTarget('work:@1')
+
+    expect(effective).toBe('work:@1')
+    expect(fake.calls.length).toBe(callsBeforeRace)
   })
 })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4036,7 +4036,7 @@ async function attachTerminalPersistent(
     terminal.resize(cols, rows)
   }
 
-  const effectiveTarget = terminal.resolveEffectiveTarget(target)
+  const effectiveTarget = terminal.ensureEffectiveTarget(target)
 
   // Deduplicate rapid re-attaches to the same session+target (e.g. two
   // terminal-attach messages arriving within ~34ms).  Skip the expensive

--- a/src/server/terminal/PtyTerminalProxy.ts
+++ b/src/server/terminal/PtyTerminalProxy.ts
@@ -42,10 +42,23 @@ class PtyTerminalProxy extends TerminalProxyBase {
   private rows = 24
   private clientTty: string | null = null
   private startAttemptId = 0
-  // Session the client was last switched into. Paste targets its active
-  // window: for externally-discovered sessions the client leaves the grouped
-  // ws session entirely, so pasting into the ws session would hit its own
-  // (bootstrap) window instead of the window on screen.
+  // Set once dispose() runs. Distinct from state === DEAD (which a natural
+  // pty death also sets): an in-flight attach that lost the race with a
+  // WebSocket close could otherwise resurrect the proxy via switchTo() →
+  // start(), recreating the ws session and derived sessions with nobody
+  // left to dispose them.
+  private disposed = false
+  // Grouped sessions created for externally-discovered tmux sessions, keyed
+  // by grouped session name. Joining an external session directly would share
+  // its current-window pointer with the user's own attached clients, so every
+  // switch in the browser would also flip the user's terminal (and vice
+  // versa). A per-connection grouped session shares the windows but keeps an
+  // independent focus.
+  private externalGroupedSessions = new Map<string, string>()
+  // Session the client was last switched into (grouped ws session or derived
+  // external group). Paste targets its active window so it follows manual
+  // in-terminal window switches, which currentWindow (last programmatic
+  // switch) does not.
   private lastEffectiveSession: string | null = null
 
   getMode(): 'pty' {
@@ -56,12 +69,251 @@ class PtyTerminalProxy extends TerminalProxyBase {
     return this.clientTty
   }
 
-  resolveEffectiveTarget(target: string): string {
-    return resolveGroupedSessionSwitchTarget(
+  ensureEffectiveTarget(target: string): string {
+    const resolved = resolveGroupedSessionSwitchTarget(
       target,
       this.options.baseSession,
       this.options.sessionName
     )
+    if (resolved !== target) {
+      return resolved
+    }
+    // A disposed proxy must not create tmux sessions: an in-flight attach
+    // that lost the race with a WebSocket close would otherwise leak a
+    // derived session with nobody left to clean it up. The disposed flag
+    // (unlike state, which start() resets) also covers the resurrection path.
+    if (this.disposed || this.state === TerminalState.DEAD) {
+      return target
+    }
+    const external = this.resolveExternalGroupedTarget(target)
+    if (external === target) {
+      return target
+    }
+    // Callers (scrollback capture, dedup keys, the switch itself) all expect
+    // the effective target to be addressable, so the grouped session is
+    // created here. Idempotent: guarded by externalGroupedSessions.
+    try {
+      this.ensureExternalGroupedSession(target, external)
+      return external
+    } catch (error) {
+      this.logEvent('terminal_external_group_failed', {
+        sessionName: this.options.sessionName,
+        target,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return target
+    }
+  }
+
+  private externalGroupedPrefix(): string {
+    return `${this.options.sessionName}-x-`
+  }
+
+  private resolveExternalGroupedTarget(target: string): string {
+    const colonIndex = target.indexOf(':')
+    const rawSession = colonIndex > 0 ? target.slice(0, colonIndex) : target
+    if (
+      !rawSession ||
+      rawSession === this.options.baseSession ||
+      rawSession === this.options.sessionName ||
+      rawSession.startsWith(this.externalGroupedPrefix())
+    ) {
+      return target
+    }
+    const sanitized = rawSession.replace(/[^A-Za-z0-9_-]/g, '-')
+    // Sanitizing can collapse distinct raw names onto the same derived name
+    // (e.g. "a.b" and "a-b" both become "a-b"); a short hash of the raw name
+    // keeps derived names collision-free without widening the tmux target
+    // charset the validator accepts.
+    const suffix = Bun.hash(rawSession).toString(36).slice(0, 6)
+    const derived = `${this.externalGroupedPrefix()}${sanitized}-${suffix}`
+    const windowPart = colonIndex > 0 ? target.slice(colonIndex + 1) : ''
+    return windowPart ? `${derived}:${windowPart}` : derived
+  }
+
+  // True when the derived session contains the requested window — the actual
+  // precondition switch-client needs. This is deliberately NOT a session-group
+  // comparison: tmux groups are keyed by name, so a stale group with any
+  // surviving member (another connection's derived session, or the user's own
+  // paired session) makes group names lie after a kill/recreate of the raw
+  // session, while the window set cannot.
+  private derivedContainsWindow(
+    effSession: string,
+    windowPart: string
+  ): boolean {
+    let output = ''
+    try {
+      output = this.runParsedTmux([
+        'list-windows',
+        '-t',
+        `=${effSession}`,
+        '-F',
+        '#{window_id}',
+      ])
+    } catch {
+      return false
+    }
+    return output
+      .split('\n')
+      .some((line) => line.replace(/\r$/, '').trim() === windowPart)
+  }
+
+  // Moves our own tmux client off the given session before it gets killed.
+  // With the default detach-on-destroy, killing the session a client sits on
+  // exits the attach process, which would take the whole proxy down (DEAD)
+  // instead of recovering.
+  private evacuateClientFrom(effSession: string): void {
+    if (!this.clientTty) return
+    try {
+      const identity = this.readClientIdentity()
+      if (identity.sessionName !== effSession) return
+      this.runTmux([
+        'switch-client',
+        '-c',
+        this.clientTty,
+        '-t',
+        `=${this.options.sessionName}`,
+      ])
+    } catch {
+      // Best-effort; worst case the proxy dies and the client reconnects.
+    }
+  }
+
+  // True when the derived grouped session and the raw session are members of
+  // the same (non-empty) session group. Only used for bare-session targets
+  // where there is no window id to check; group names can lie after a
+  // kill/recreate of the raw session (see derivedContainsWindow), but bare
+  // targets never come from the UI.
+  private sessionGroupsMatch(effSession: string, rawSession: string): boolean {
+    let output = ''
+    try {
+      output = this.runParsedTmux([
+        'list-sessions',
+        '-F',
+        buildTmuxFormat(['#{session_name}', '#{session_group}']),
+      ])
+    } catch {
+      return false
+    }
+    let effGroup: string | null = null
+    let rawGroup: string | null = null
+    for (const line of output.split('\n')) {
+      const parts = splitTmuxFields(line.replace(/\r$/, ''), 2)
+      if (!parts) continue
+      const [name, group] = parts
+      if (name === effSession) effGroup = group ?? ''
+      if (name === rawSession) rawGroup = group ?? ''
+    }
+    return Boolean(effGroup) && effGroup === rawGroup
+  }
+
+  // Creates the grouped session backing an external effective target if it
+  // does not exist yet. No-op for the base grouped session and raw targets.
+  // Idempotent: warm targets short-circuit on externalGroupedSessions; the
+  // map entry is evicted when a switch through it fails.
+  private ensureExternalGroupedSession(
+    target: string,
+    effectiveTarget: string
+  ): void {
+    const colonIndex = effectiveTarget.indexOf(':')
+    const effSession =
+      colonIndex > 0 ? effectiveTarget.slice(0, colonIndex) : effectiveTarget
+    if (!effSession.startsWith(this.externalGroupedPrefix())) {
+      return
+    }
+    if (this.externalGroupedSessions.has(effSession)) {
+      return
+    }
+    const windowPart =
+      colonIndex > 0 ? effectiveTarget.slice(colonIndex + 1) : ''
+    const rawColon = target.indexOf(':')
+    const rawSession = rawColon > 0 ? target.slice(0, rawColon) : target
+    let exists = false
+    try {
+      this.runTmux(['has-session', '-t', `=${effSession}`])
+      exists = true
+    } catch {
+      // Create below
+    }
+    // Window-id targets get the authoritative membership check; bare-session
+    // or name/index-style targets (API-only; the UI always sends @ids) fall
+    // back to the group heuristic.
+    const windowId = windowPart.startsWith('@') ? windowPart : ''
+    if (exists) {
+      const valid = windowId
+        ? this.derivedContainsWindow(effSession, windowId)
+        : this.sessionGroupsMatch(effSession, rawSession)
+      if (valid) {
+        this.externalGroupedSessions.set(effSession, rawSession)
+        return
+      }
+      // Stale leftover: the raw session was killed (and possibly recreated
+      // under the same name) while the derived session survived, so it is
+      // bound to the old group's windows. Discard it — after moving our own
+      // client off it, or the kill would take the proxy down with it.
+      this.evacuateClientFrom(effSession)
+      try {
+        this.runTmuxMutation(['kill-session', '-t', `=${effSession}`])
+      } catch {
+        // Ignore; new-session below will surface a real conflict
+      }
+    }
+    // new-session -t with a non-matching name silently starts a fresh,
+    // unrelated group named after the literal target instead of failing, so
+    // confirm the raw session still exists first. (=name also disables the
+    // prefix matching that could otherwise group with the wrong session.)
+    this.runTmux(['has-session', '-t', `=${rawSession}`])
+    this.runTmuxMutation([
+      'new-session',
+      '-d',
+      '-t',
+      `=${rawSession}`,
+      '-s',
+      effSession,
+    ])
+    const rejoinedStaleGroup = windowId
+      ? !this.derivedContainsWindow(effSession, windowId)
+      : !this.sessionGroupsMatch(effSession, rawSession)
+    if (rejoinedStaleGroup) {
+      // tmux resolves new-session -t group names by NAME, so if a stale
+      // same-named group still has surviving members (another connection or
+      // the user's own paired session), the recreated derived session joins
+      // the stale group instead of the recreated raw session. Do not loop on
+      // a session bound to the wrong windows — give up so the caller falls
+      // back to attaching the raw session directly (shared focus, but
+      // functional).
+      try {
+        this.runTmuxMutation(['kill-session', '-t', `=${effSession}`])
+      } catch {
+        // Ignore cleanup failures
+      }
+      throw new Error(
+        `Derived session ${effSession} joined a stale group for ${rawSession}`
+      )
+    }
+    this.externalGroupedSessions.set(effSession, rawSession)
+    // Same reasoning as the base grouped session: session options come from
+    // the global default, so mirror the raw session's mouse setting.
+    try {
+      const mouseValue = this.runTmux([
+        'show-option',
+        '-t',
+        `=${rawSession}`,
+        '-v',
+        'mouse',
+      ]).trim()
+      if (mouseValue) {
+        this.runTmuxMutation([
+          'set-option',
+          '-t',
+          `=${effSession}`,
+          'mouse',
+          mouseValue,
+        ])
+      }
+    } catch {
+      // Raw session may not have an explicit mouse override; ignore
+    }
   }
 
   write(data: string): void {
@@ -72,15 +324,19 @@ class PtyTerminalProxy extends TerminalProxyBase {
     if (!data || this.state === TerminalState.DEAD) {
       return
     }
-    // Target the active window of the session this client is attached to.
-    // tmux decides bracketing from that real pane's mode. Falling back to
-    // the grouped session name covers the pre-switch state. NOTE: the name
-    // must stay bare — paste-buffer takes a target-PANE, whose parser
-    // rejects the `=name` exact-match form that target-session commands
-    // accept (verified on tmux 3.7b: "can't find pane: =name"). Exact-name
-    // collisions are a non-issue here because tmux prefers an exact session
-    // match over a prefix match whenever the session exists, and this name
-    // comes from a verified identity read.
+    // Target the active window of the session this client is attached to
+    // (grouped ws session or derived external group): it tracks manual
+    // in-terminal window switches, unlike currentWindow which only records
+    // the last programmatic switch. tmux decides bracketing from that real
+    // pane's mode. (Targeting the base grouped session unconditionally
+    // pasted into its own current window, which for externally-discovered
+    // sessions was the bootstrap window, not the window on screen.) NOTE:
+    // the name must stay bare — paste-buffer takes a target-PANE, whose
+    // parser rejects the `=name` exact-match form that target-session
+    // commands accept (verified on tmux 3.7b: "can't find pane: =name").
+    // Exact-name collisions are a non-issue here because tmux prefers an
+    // exact session match over a prefix match whenever the session exists,
+    // and this name comes from a verified identity read.
     this.deliverPasteViaTmux(
       this.lastEffectiveSession ?? this.options.sessionName,
       data
@@ -102,6 +358,7 @@ class PtyTerminalProxy extends TerminalProxyBase {
     // Invalidate any in-flight start attempt so doStart bails out before
     // mutating state after we've disposed.
     this.startAttemptId += 1
+    this.disposed = true
     this.state = TerminalState.DEAD
     this.outputSuppressed = false
 
@@ -124,14 +381,30 @@ class PtyTerminalProxy extends TerminalProxyBase {
       // Ignore cleanup failures
     }
 
+    for (const groupedName of this.externalGroupedSessions.keys()) {
+      try {
+        this.runTmuxMutation(['kill-session', '-t', `=${groupedName}`])
+      } catch {
+        // Ignore cleanup failures
+      }
+    }
+    this.externalGroupedSessions.clear()
+    this.lastEffectiveSession = null
+
     this.clientTty = null
     this.currentWindow = null
-    this.lastEffectiveSession = null
     this.readyAt = null
     this.startPromise = null
   }
 
   protected async doStart(): Promise<void> {
+    if (this.disposed) {
+      throw new TerminalProxyError(
+        'ERR_NOT_READY',
+        'Terminal proxy already disposed',
+        true
+      )
+    }
     if (this.process) {
       return
     }
@@ -335,7 +608,7 @@ class PtyTerminalProxy extends TerminalProxyBase {
       )
     }
 
-    const effectiveTarget = this.resolveEffectiveTarget(target)
+    const effectiveTarget = this.ensureEffectiveTarget(target)
     this.state = TerminalState.SWITCHING
     this.outputSuppressed = true
     const startedAt = this.now()
@@ -379,6 +652,7 @@ class PtyTerminalProxy extends TerminalProxyBase {
         this.setCurrentWindow(effectiveTarget)
       }
       this.lastEffectiveSession = actualIdentity.sessionName
+      this.releaseUnusedExternalGroupedSessions(actualIdentity.sessionName)
       const durationMs = this.now() - startedAt
       this.logEvent('terminal_switch_success', {
         sessionName: this.options.sessionName,
@@ -393,6 +667,24 @@ class PtyTerminalProxy extends TerminalProxyBase {
     } catch (error) {
       this.outputSuppressed = false
       this.state = TerminalState.READY
+      // A failed switch through a derived grouped session may mean the
+      // session went stale (raw session killed/recreated). Kill it and evict
+      // it from the warm-path map so the next attach re-validates and
+      // recreates it — otherwise it leaks until the process restarts, since
+      // releaseUnusedExternalGroupedSessions and dispose() only ever see
+      // what's still tracked in the map.
+      const effColon = effectiveTarget.indexOf(':')
+      const effSession =
+        effColon > 0 ? effectiveTarget.slice(0, effColon) : effectiveTarget
+      if (this.externalGroupedSessions.has(effSession)) {
+        try {
+          this.runTmuxMutation(['kill-session', '-t', `=${effSession}`])
+        } catch {
+          // Best-effort; it may already be gone (that's often why the
+          // switch itself failed).
+        }
+        this.externalGroupedSessions.delete(effSession)
+      }
       this.logEvent('terminal_switch_failure', {
         sessionName: this.options.sessionName,
         tmuxWindow: target,
@@ -428,6 +720,23 @@ class PtyTerminalProxy extends TerminalProxyBase {
     }
   }
 
+  // Kills derived grouped sessions the client is no longer attached to.
+  // Shrinks the window in which a derived session pins alive the windows of
+  // a raw session the user killed (tmux keeps group windows alive while any
+  // member session exists), and stops leftover groups from hijacking the
+  // user's own `new-session -t <name>` usage.
+  private releaseUnusedExternalGroupedSessions(currentSession: string): void {
+    for (const name of this.externalGroupedSessions.keys()) {
+      if (name === currentSession) continue
+      try {
+        this.runTmuxMutation(['kill-session', '-t', `=${name}`])
+      } catch {
+        // Ignore; prune-on-startup is the fallback
+      }
+      this.externalGroupedSessions.delete(name)
+    }
+  }
+
   private readTargetIdentity(target: string): TmuxTargetIdentity {
     const output = this.runParsedTmux([
       'display-message',
@@ -448,9 +757,9 @@ class PtyTerminalProxy extends TerminalProxyBase {
       throw new Error('Terminal client not ready')
     }
     // display-message -p -c expands formats against the most recently active
-    // client's session, not the -c client, so it misreports whenever another
-    // tmux client is more recently active. list-clients expands formats per
-    // client, so filter by tty instead (same approach as discoverClientTty).
+    // session, not the -c client, so it misreports whenever another tmux
+    // client is active. list-clients expands formats per client, so filter
+    // by tty instead (same approach as discoverClientTty).
     const output = this.runParsedTmux([
       'list-clients',
       '-F',

--- a/src/server/terminal/TerminalProxyBase.ts
+++ b/src/server/terminal/TerminalProxyBase.ts
@@ -109,7 +109,7 @@ abstract class TerminalProxyBase implements ITerminalProxy {
     return this.state === TerminalState.READY
   }
 
-  resolveEffectiveTarget(target: string): string {
+  ensureEffectiveTarget(target: string): string {
     return target
   }
 

--- a/src/server/terminal/types.ts
+++ b/src/server/terminal/types.ts
@@ -53,7 +53,10 @@ interface TerminalProxyOptions {
 interface ITerminalProxy {
   start(): Promise<void>
   switchTo(target: string, onReady?: () => void): Promise<boolean>
-  resolveEffectiveTarget(target: string): string
+  // For external (non-managed) sessions this may create a backing tmux
+  // session as a side effect (see PtyTerminalProxy) — the name reflects
+  // that this "resolve" step is not free to call speculatively.
+  ensureEffectiveTarget(target: string): string
   write(data: string): void
   paste(data: string): void
   resize(cols: number, rows: number): void


### PR DESCRIPTION
Reference implementation for #163 — opened as a **draft on purpose**: if you prefer a different approach, close this freely and keep the pitfall list in the issue; it applies to any solution in this space.

Now a single commit on current master — the #165/#166 prerequisites are merged, and the first-pass review items are folded in.

## What

On first switch into an externally-discovered session S, create `agentboard-ws-<conn>-x-<S>-<hash>` grouped with S (`new-session -d -t =S`) and switch the client into that. The short hash of the raw name keeps sanitized names collision-free (`a.b` vs `a-b`). Windows stay shared; focus and per-window sizing become independent of the user's own attached clients, and copy-mode entered from the user's terminal no longer swallows browser keystrokes.

## Robustness

Each of these guards a failure hit during adversarial testing on tmux 3.4:

- Staleness is validated by **window-set membership** (`list-windows -F '#{window_id}'` contains the requested `@id`), not `#{session_group}` equality — group names are keyed by name and lie once ghost members survive a kill/recreate of S. Window ids are server-global and never reused, so membership is a sound invariant.
- Every `-t` uses `=` exact matching, and `new-session` is preceded by a `has-session` guard (`new-session -t =missing` silently creates an unrelated group literally named `=missing` instead of failing).
- Before discarding a stale derived session, our own client is evacuated to the ws session — with the default `detach-on-destroy`, killing the session under the client would take the whole proxy down.
- Derived sessions are destroyed on every switch-away and on dispose; the startup prune covers crash leftovers. A recreation that lands in a ghost group degrades to attaching S directly (shared focus, but functional) rather than erroring or looping.
- A failed switch through a derived session kills it before dropping it from tracking — no leak until restart.
- Ghost-group re-validation after recreation applies to bare-session targets too (session-group membership when no window id is present); the `disposed` flag is now covered by a test reproducing the dispose-lands-mid-switchTo race.
- A `disposed` flag blocks a lost-race in-flight attach from resurrecting the proxy after dispose and leaking sessions.

## Known trade-offs (accepted for our deployment, maintainer call for upstream)

- While the viewed session's derived session exists, `kill-session` on S does not kill its windows until the viewer switches away.
- `tmux ls` shows the per-connection derived sessions.
- Brief session churn per attach while a ghost group persists.

The first two are documented in the README's tmux notes.

## Verification

- `bun run lint && bun run typecheck && bun run test` green on the rebased commit, locally and in a clean non-root Ubuntu 24.04 container (733 tests).
- Earlier round on the pre-rebase build: Debian trixie container (tmux 3.5a) including the real-tmux integration layer; production deployment (Ubuntu 24.04, tmux 3.4) exercised the #163 scenarios including the kill/recreate-same-name recovery path. The grouped-session logic is unchanged by the rebase.
