### PR TITLE
fix(client): persist manual session order across refreshes

### DIFF
--- a/src/client/__tests__/settingsStore.test.ts
+++ b/src/client/__tests__/settingsStore.test.ts
@@ -402,6 +402,27 @@ describe('settings persistence migration', () => {
   })
 })
 
+describe('manual session order persistence', () => {
+  test('setManualSessionOrder writes the order to persisted settings', () => {
+    useSettingsStore.getState().setManualSessionOrder(['abc123', 'session:@2'])
+
+    const persisted = JSON.parse(storage.getItem('agentboard-settings') || '{}')
+    expect(persisted.state.manualSessionOrder).toEqual(['abc123', 'session:@2'])
+  })
+
+  test('persisted manual order rehydrates into the store', async () => {
+    storage.setItem('agentboard-settings', JSON.stringify({
+      state: { manualSessionOrder: ['session:@7'], sessionSortMode: 'manual' },
+      version: 6,
+    }))
+
+    await useSettingsStore.persist.rehydrate()
+
+    expect(useSettingsStore.getState().manualSessionOrder).toEqual(['session:@7'])
+    expect(useSettingsStore.getState().sessionSortMode).toBe('manual')
+  })
+})
+
 afterAll(() => {
   globalAny.window = originalWindow
   globalAny.localStorage = originalLocalStorage

--- a/src/client/stores/settingsStore.ts
+++ b/src/client/stores/settingsStore.ts
@@ -268,11 +268,6 @@ export const useSettingsStore = create<SettingsState>()(
       name: 'agentboard-settings',
       storage: createJSONStorage(() => safeStorage),
       version: 6,
-      partialize: (state) => {
-        // Exclude manualSessionOrder from persistence (session-only state)
-        const { manualSessionOrder: _, ...rest } = state
-        return rest
-      },
       migrate: (persistedState: unknown, version: number) => {
         const state = persistedState as Record<string, unknown>
         if (


### PR DESCRIPTION
Fixes #157.

## What

Dragging a session row flips `sessionSortMode` to `'manual'` — which **is** persisted — but the order array itself was stripped from persistence by a `partialize` in the settings store ("session-only state"). Net effect: every refresh reverted the list to an empty manual order, exactly as reported.

Removes the `partialize` exclusion so `manualSessionOrder` persists to localStorage alongside the mode. Stale ids in a persisted order are harmless: `sortSessions` sends unknown keys to the end (sorted by createdAt), and kill-time pruning of the order array already exists.

## Replication (before this change)

Playwright against an isolated instance: drag changed DOM order (gamma,beta,alpha → alpha,gamma,beta), reload reverted it; localStorage showed `sessionSortMode: "manual"` persisted while `manualSessionOrder` was absent.

## Tests

- `setManualSessionOrder` writes the order into persisted settings (fails on master)
- persisted order + manual mode rehydrate into the store

`bun run lint && bun run typecheck && bun run test` green.