### PR TITLE
fix(client): snap session rows on auto-resort instead of animating

### DIFF
--- a/src/client/components/SessionList.tsx
+++ b/src/client/components/SessionList.tsx
@@ -387,12 +387,9 @@ export default function SessionList({
   // Track active drag state for drop indicator
   const [activeId, setActiveId] = useState<string | null>(null)
   const [overId, setOverId] = useState<string | null>(null)
-  // Disable layout animations briefly after drag to prevent conflicts
-  const [layoutAnimationsDisabled, setLayoutAnimationsDisabled] = useState(false)
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
     setActiveId(event.active.id as string)
-    setLayoutAnimationsDisabled(true)
   }, [])
 
   const handleDragOver = useCallback((event: DragOverEvent) => {
@@ -406,15 +403,12 @@ export default function SessionList({
       setOverId(null)
 
       if (!over || active.id === over.id) {
-        // Re-enable layout animations after a brief delay
-        setTimeout(() => setLayoutAnimationsDisabled(false), 100)
         return
       }
 
       const oldIndex = filteredSessions.findIndex((s) => s.id === active.id)
       const newIndex = filteredSessions.findIndex((s) => s.id === over.id)
       if (oldIndex === -1 || newIndex === -1) {
-        setTimeout(() => setLayoutAnimationsDisabled(false), 100)
         return
       }
 
@@ -437,8 +431,6 @@ export default function SessionList({
         setSessionSortMode('manual')
       }
       setManualSessionOrder(newOrder)
-      // Re-enable layout animations after state settles
-      setTimeout(() => setLayoutAnimationsDisabled(false), 100)
     },
     [
       filteredSessions,
@@ -452,23 +444,16 @@ export default function SessionList({
   const handleDragCancel = useCallback(() => {
     setActiveId(null)
     setOverId(null)
-    setTimeout(() => setLayoutAnimationsDisabled(false), 100)
   }, [])
 
   useEffect(() => {
     if (!activeId && !overId) return
     const currentIds = new Set(filteredSessions.map((s) => s.id))
-    let shouldReset = false
     if (activeId && !currentIds.has(activeId)) {
       setActiveId(null)
-      shouldReset = true
     }
     if (overId && !currentIds.has(overId)) {
       setOverId(null)
-      shouldReset = true
-    }
-    if (shouldReset) {
-      setLayoutAnimationsDisabled(false)
     }
   }, [filteredSessions, activeId, overId])
 
@@ -551,10 +536,10 @@ export default function SessionList({
                   strategy={verticalListSortingStrategy}
                 >
                   <div key={filterKey}>
-                    <AnimatePresence
-                      initial={false}
-                      mode={useSafariLayoutFallback ? 'sync' : 'popLayout'}
-                    >
+                    {/* sync (not popLayout): without per-row layout animation,
+                        popLayout would overlap an exiting row with the sibling
+                        snapping into its place */}
+                    <AnimatePresence initial={false} mode="sync">
                       {filteredSessions.map((session, index) => {
                         const isTrulyNew = newlyActiveIds.has(session.id)
                         const isFilteredIn = newlyFilteredInIds.has(session.id)
@@ -583,7 +568,6 @@ export default function SessionList({
                             exitDuration={EXIT_DURATION}
                             prefersReducedMotion={prefersReducedMotion}
                             useSafariLayoutFallback={useSafariLayoutFallback}
-                            layoutAnimationsDisabled={layoutAnimationsDisabled}
                             isSelected={session.id === selectedSessionId}
                             isEditing={session.id === editingSessionId}
                             showSessionIdPrefix={showSessionIdPrefix}
@@ -738,7 +722,6 @@ interface SortableSessionItemProps {
   exitDuration: number
   prefersReducedMotion: boolean | null
   useSafariLayoutFallback: boolean
-  layoutAnimationsDisabled: boolean
   isSelected: boolean
   isEditing: boolean
   showSessionIdPrefix: boolean
@@ -761,7 +744,6 @@ const SortableSessionItem = forwardRef<HTMLDivElement, SortableSessionItemProps>
   exitDuration,
   prefersReducedMotion,
   useSafariLayoutFallback,
-  layoutAnimationsDisabled,
   isSelected,
   isEditing,
   showSessionIdPrefix,
@@ -810,13 +792,13 @@ const SortableSessionItem = forwardRef<HTMLDivElement, SortableSessionItemProps>
   )
 
   return (
+    // Deliberately no framer `layout` prop: animated resorts slide rows through
+    // each other, overlapping two sessions' text mid-flight (#159). Rows snap to
+    // their new position; drag previews still animate via the dnd-kit transform.
     <motion.div
       ref={setRefs}
       style={{ ...style, overflow: 'hidden' }}
       className="relative"
-      layout={!prefersReducedMotion && !isDragging && !layoutAnimationsDisabled && !isNew
-        ? (useSafariLayoutFallback ? false : true)
-        : false}
       transformTemplate={(_, generatedTransform) =>
         composeSortableTransform({
           useSafariLayoutFallback,
@@ -855,7 +837,6 @@ const SortableSessionItem = forwardRef<HTMLDivElement, SortableSessionItemProps>
               height: { duration: exitDuration / 1000, ease: 'easeOut' },
             }
             : {
-              layout: { type: 'spring', stiffness: 500, damping: 35 },
               opacity: { duration: exitDuration / 1000 },
               scale: { duration: exitDuration / 1000, ease: [0.34, 1.56, 0.64, 1] },
               height: { duration: exitDuration / 1000, ease: 'easeOut' },


### PR DESCRIPTION
Fixes #159.

## What

The reporter's screenshot shows two sessions' names character-interleaved in a single row. Replicated: with status-based sorting, a status flip (e.g. a session going working↔waiting as you click around) triggers a framer-motion layout animation that slides rows *through* each other — a frame capture caught two rows' text overlapped mid-flight, matching the screenshot. Transient on Chromium; on a browser where the layout animation stalls (the component already carries a Safari fallback for exactly that), the overlap sticks.

Per the maintainer's call: auto-resorts now **snap** instead of animating.

- Remove the per-row framer `layout` prop and the `layoutAnimationsDisabled` plumbing that existed only to fence it off during drags.
- `AnimatePresence` switches `popLayout` → `sync`: without sibling layout animations, popLayout would overlap an exiting row with the row snapping into its place; sync collapses the exiting row in flow (exit already animates `height: 0`).
- Drag previews still animate via dnd-kit transforms; enter/exit animations unchanged.

## Verification

Frame-capture harness (60ms interval) against an isolated instance, status sort, forced status flip while clicking another session:
- **Before:** intermediate frames show two rows' text overlapped.
- **After:** order changes atomically between consecutive frames; zero overlap frames. Drag reorder still works.

`bun run lint && bun run typecheck && bun run test` green.