### PR TITLE
chore: release v0.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",


### PR DESCRIPTION
Bumps version to 0.4.5. Included since 0.4.4:

- fix(terminal): read pty client identity via list-clients instead of display-message -c (#165) — fixes #161 and the tmux 3.2a failure in #156
- fix(terminal): paste into the session the pty client is attached to (#166)
- feat(settings): runtime toggle for prefer-window-name (#167)
- fix(client): persist manual session order across refreshes (#169) — fixes #157
- fix(client): snap session rows on auto-resort instead of animating (#170) — fixes #159

Merging triggers the tag + release workflow.