### PR TITLE
feat(shortcuts): add jump-to-session digit shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ bun run deps:risk -- --threshold moderate
 | Next session | `Ctrl+Option+]` | `Ctrl+Shift+]` |
 | New session | `Ctrl+Option+N` | `Ctrl+Shift+N` |
 | Kill session | `Ctrl+Option+X` | `Ctrl+Shift+X` |
+| Jump to session 1-9 | `Ctrl+Option+1..9` | `Ctrl+Shift+1..9` |
+
+The modifier is configurable in Settings. **Jump To Session** has its own chord
+setting so you can use a bare `Cmd`/`Ctrl` for digits while the letter shortcuts
+keep a safer combo (`Cmd+X` is Cut, `Ctrl+N` is meaningful in a terminal).
+
+Note that browsers reserve `Cmd`/`Ctrl`+`1..9` for tab switching, so those
+chords only reach the page in an [installed (standalone) window](docs/pwa-install.md).
+In a normal tab the browser keeps them and the shortcut never fires.
 
 ## Environment
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -20,7 +20,7 @@ import { useVisualViewport } from './hooks/useVisualViewport'
 import { sortSessions } from './utils/sessions'
 import { flushSync } from 'react-dom'
 import { setClientLogLevel } from './utils/clientLog'
-import { getEffectiveModifier, matchesModifier } from './utils/device'
+import { getEffectiveModifier, matchesJumpChord, matchesModifier } from './utils/device'
 import { playPermissionSound, playIdleSound, primeAudio, needsUserGesture } from './utils/sound'
 
 interface ServerInfo {
@@ -105,6 +105,7 @@ export default function App() {
   )
   const addRecentPath = useSettingsStore((state) => state.addRecentPath)
   const shortcutModifier = useSettingsStore((state) => state.shortcutModifier)
+  const sessionJumpChord = useSettingsStore((state) => state.sessionJumpChord)
   const sidebarWidth = useSettingsStore((state) => state.sidebarWidth)
   const setSidebarWidth = useSettingsStore((state) => state.setSidebarWidth)
   const projectFilters = useSettingsStore((state) => state.projectFilters)
@@ -812,6 +813,28 @@ export default function App() {
         return
       }
 
+      // Jump to session by index: [chord]+1..9
+      // Note: with chord 'meta'/'ctrl' the browser reserves these for tab
+      // switching in a normal tab, so they only arrive in a standalone window.
+      if (/^Digit[1-9]$/.test(code) && matchesJumpChord(event, sessionJumpChord, effectiveModifier)) {
+        const index = Number(code.slice(5)) - 1
+        const activeNav = filteredSortedSessions
+        const target = activeNav.length > 0 ? activeNav[index] : undefined
+        if (target) {
+          event.preventDefault()
+          setSelectedSessionId(target.id)
+          return
+        }
+        if (activeNav.length === 0) {
+          const hibernating = filteredHibernatingSessions[index]
+          if (hibernating) {
+            event.preventDefault()
+            setSelectedHibernatingSessionId(hibernating.sessionId)
+          }
+        }
+        return
+      }
+
       // New session: [mod]+N
       if (isShortcut && code === 'KeyN') {
         event.preventDefault()
@@ -843,6 +866,7 @@ export default function App() {
     filteredHibernatingSessions,
     handleKillSession,
     shortcutModifier,
+    sessionJumpChord,
     settingsHydrated,
   ])
 

--- a/src/client/__tests__/app.test.tsx
+++ b/src/client/__tests__/app.test.tsx
@@ -1088,6 +1088,83 @@ describe('App', () => {
     // but kill-failed test below proves it works)
   })
 
+  test('jumps to a session by index with the digit shortcut', () => {
+    const sessionB = {
+      ...baseSession,
+      id: 'session-2',
+      name: 'beta',
+      createdAt: '2024-01-02T00:00:00.000Z',
+    }
+
+    useSessionStore.setState({
+      sessions: [baseSession, sessionB],
+      selectedSessionId: baseSession.id,
+      hasLoaded: true,
+    })
+
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    act(() => {
+      renderer = TestRenderer.create(<App />)
+    })
+    activeRenderer = renderer
+
+    const digit = (index: number, mods: Partial<KeyboardEvent>) =>
+      ({
+        key: String(index),
+        code: `Digit${index}`,
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+        metaKey: false,
+        defaultPrevented: false,
+        preventDefault: () => {},
+        ...mods,
+      }) as KeyboardEvent
+
+    // Default chord is 'modifier', which resolves to ctrl-shift off-Mac
+    act(() => {
+      getKeyHandler()(digit(2, { ctrlKey: true, shiftKey: true }))
+    })
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-2')
+
+    act(() => {
+      getKeyHandler()(digit(1, { ctrlKey: true, shiftKey: true }))
+    })
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-1')
+
+    // Out-of-range digits are left alone for the browser
+    act(() => {
+      getKeyHandler()(digit(9, { ctrlKey: true, shiftKey: true }))
+    })
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-1')
+
+    // A bare digit must not steal plain typing
+    act(() => {
+      getKeyHandler()(digit(2, {}))
+    })
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-1')
+
+    // Switching the chord to 'meta' makes bare Cmd+N jump instead
+    act(() => {
+      useSettingsStore.setState({ sessionJumpChord: 'meta' })
+    })
+    act(() => {
+      getKeyHandler()(digit(2, { metaKey: true }))
+    })
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-2')
+
+    // ...and the old modifier chord no longer jumps
+    act(() => {
+      getKeyHandler()(digit(1, { ctrlKey: true, shiftKey: true }))
+    })
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-2')
+
+    act(() => {
+      useSettingsStore.setState({ sessionJumpChord: 'modifier' })
+    })
+  })
+
   test('kill-failed restores optimistically removed session', () => {
     useSessionStore.setState({
       sessions: [baseSession],

--- a/src/client/__tests__/device.test.ts
+++ b/src/client/__tests__/device.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 import {
+  getJumpChordDisplay,
   getNavShortcutMod,
   isIOSDevice,
   isIOSPWA,
   isMacOS,
   isSafari,
+  matchesJumpChord,
 } from '../utils/device'
 
 const globalAny = globalThis as typeof globalThis & {
@@ -126,5 +128,45 @@ describe('device helpers', () => {
     } finally {
       globalAny.navigator = originalNavigator
     }
+  })
+})
+
+describe('matchesJumpChord', () => {
+  const ev = (init: Partial<KeyboardEvent>) => init as KeyboardEvent
+
+  test('off never matches', () => {
+    expect(matchesJumpChord(ev({ metaKey: true }), 'off', 'ctrl-option')).toBe(false)
+    expect(matchesJumpChord(ev({ ctrlKey: true }), 'off', 'ctrl-option')).toBe(false)
+  })
+
+  test('modifier delegates to the configured letter-shortcut combo', () => {
+    const ctrlAlt = ev({ ctrlKey: true, altKey: true, metaKey: false, shiftKey: false })
+    expect(matchesJumpChord(ctrlAlt, 'modifier', 'ctrl-option')).toBe(true)
+    expect(matchesJumpChord(ctrlAlt, 'modifier', 'cmd-shift')).toBe(false)
+  })
+
+  test('meta matches a bare Cmd only', () => {
+    const bare = ev({ metaKey: true, ctrlKey: false, altKey: false, shiftKey: false })
+    expect(matchesJumpChord(bare, 'meta', 'ctrl-option')).toBe(true)
+    // extra modifiers must not match, so ⌘⇧1 stays available to the browser
+    expect(matchesJumpChord(ev({ metaKey: true, shiftKey: true }), 'meta', 'ctrl-option')).toBe(
+      false
+    )
+    expect(matchesJumpChord(ev({ metaKey: false }), 'meta', 'ctrl-option')).toBe(false)
+  })
+
+  test('ctrl matches a bare Ctrl only', () => {
+    const bare = ev({ ctrlKey: true, metaKey: false, altKey: false, shiftKey: false })
+    expect(matchesJumpChord(bare, 'ctrl', 'ctrl-option')).toBe(true)
+    expect(matchesJumpChord(ev({ ctrlKey: true, altKey: true }), 'ctrl', 'ctrl-option')).toBe(false)
+  })
+})
+
+describe('getJumpChordDisplay', () => {
+  test('renders the chord symbols', () => {
+    expect(getJumpChordDisplay('meta', 'ctrl-option')).toBe('⌘')
+    expect(getJumpChordDisplay('ctrl', 'ctrl-option')).toBe('⌃')
+    expect(getJumpChordDisplay('modifier', 'cmd-shift')).toBe('⌘⇧')
+    expect(getJumpChordDisplay('off', 'ctrl-option')).toBe('')
   })
 })

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -8,11 +8,16 @@ import {
   type FontOption,
   type SessionSortDirection,
   type SessionSortMode,
+  type SessionJumpChord,
   type ShortcutModifier,
 } from '../stores/settingsStore'
 import { useThemeStore, type Theme } from '../stores/themeStore'
 import { HISTORY_MAX_AGE_MIN_HOURS, HISTORY_MAX_AGE_MAX_HOURS } from '@shared/types'
-import { getEffectiveModifier, getModifierDisplay } from '../utils/device'
+import {
+  getEffectiveModifier,
+  getJumpChordDisplay,
+  getModifierDisplay,
+} from '../utils/device'
 import { Switch } from './Switch'
 import { playPermissionSound, playIdleSound, primeAudio } from '../utils/sound'
 
@@ -63,6 +68,10 @@ export default function SettingsModal({
   const setShortcutModifier = useSettingsStore(
     (state) => state.setShortcutModifier
   )
+  const sessionJumpChord = useSettingsStore((state) => state.sessionJumpChord)
+  const setSessionJumpChord = useSettingsStore(
+    (state) => state.setSessionJumpChord
+  )
   const showProjectName = useSettingsStore((state) => state.showProjectName)
   const setShowProjectName = useSettingsStore(
     (state) => state.setShowProjectName
@@ -102,6 +111,8 @@ export default function SettingsModal({
   const [draftShortcutModifier, setDraftShortcutModifier] = useState<
     ShortcutModifier | 'auto'
   >(shortcutModifier)
+  const [draftSessionJumpChord, setDraftSessionJumpChord] =
+    useState<SessionJumpChord>(sessionJumpChord)
   const [draftShowProjectName, setDraftShowProjectName] =
     useState(showProjectName)
   const [draftShowLastUserMessage, setDraftShowLastUserMessage] = useState(
@@ -148,6 +159,7 @@ export default function SettingsModal({
       setDraftFontOption(fontOption)
       setDraftCustomFontFamily(customFontFamily)
       setDraftShortcutModifier(shortcutModifier)
+      setDraftSessionJumpChord(sessionJumpChord)
       setDraftShowProjectName(showProjectName)
       setDraftShowLastUserMessage(showLastUserMessage)
       setDraftShowSessionIdSuffix(showSessionIdPrefix)
@@ -213,6 +225,7 @@ export default function SettingsModal({
     fontOption,
     customFontFamily,
     shortcutModifier,
+    sessionJumpChord,
     showProjectName,
     showLastUserMessage,
     showSessionIdPrefix,
@@ -257,6 +270,7 @@ export default function SettingsModal({
     setFontOption(draftFontOption)
     setCustomFontFamily(draftCustomFontFamily)
     setShortcutModifier(draftShortcutModifier)
+    setSessionJumpChord(draftSessionJumpChord)
     setShowProjectName(draftShowProjectName)
     setShowLastUserMessage(draftShowLastUserMessage)
     setShowSessionIdPrefix(draftShowSessionIdPrefix)
@@ -891,6 +905,38 @@ export default function SettingsModal({
                 ? `Platform default: ${getModifierDisplay(getEffectiveModifier('auto'))}`
                 : `Shortcuts: ${getModifierDisplay(draftShortcutModifier)}+[N/X/[/]]`}
             </p>
+          </div>
+
+          <div className="border-t border-border pt-4">
+            <label className="mb-2 block text-xs text-secondary">
+              Jump To Session (1-9)
+            </label>
+            <div className="grid grid-cols-4 gap-1">
+              {(['modifier', 'meta', 'ctrl', 'off'] as const).map((chord) => (
+                <button
+                  key={chord}
+                  type="button"
+                  className={`btn text-xs px-2 ${draftSessionJumpChord === chord ? 'btn-primary' : ''}`}
+                  onClick={() => setDraftSessionJumpChord(chord)}
+                >
+                  {chord === 'modifier' ? 'Modifier' : chord === 'off' ? 'Off' : chord === 'meta' ? '⌘' : '⌃'}
+                </button>
+              ))}
+            </div>
+            <p className="mt-1.5 text-[10px] text-muted">
+              {draftSessionJumpChord === 'off'
+                ? 'Jump-to-session shortcuts disabled'
+                : `Jump: ${getJumpChordDisplay(
+                    draftSessionJumpChord,
+                    getEffectiveModifier(draftShortcutModifier)
+                  )}+1..9`}
+            </p>
+            {(draftSessionJumpChord === 'meta' || draftSessionJumpChord === 'ctrl') && (
+              <p className="mt-1 text-[10px] text-muted">
+                Browsers reserve this for tab switching. Works in an installed
+                (standalone) window; in a normal tab the browser keeps it.
+              </p>
+            )}
           </div>
         </div>
 

--- a/src/client/stores/settingsStore.ts
+++ b/src/client/stores/settingsStore.ts
@@ -46,6 +46,13 @@ export type SessionSortMode = 'status' | 'created' | 'manual'
 export type SessionSortDirection = 'asc' | 'desc'
 export type ShortcutModifier = 'ctrl-option' | 'ctrl-shift' | 'cmd-option' | 'cmd-shift'
 
+// Chord used by the jump-to-session digit shortcuts ([chord]+1..9).
+// Kept separate from ShortcutModifier because bare ⌘/⌃ are unsuitable for the
+// letter shortcuts (⌘X is Cut, ⌃N is next-line in a terminal) but are the
+// natural choice for digits. Browsers reserve bare ⌘/⌃+digit for tab switching
+// in a normal tab, so those only reach the page in a standalone/PWA window.
+export type SessionJumpChord = 'modifier' | 'meta' | 'ctrl' | 'off'
+
 // Command preset system
 export interface CommandPreset {
   id: string
@@ -136,6 +143,8 @@ interface SettingsState {
   setCustomFontFamily: (family: string) => void
   shortcutModifier: ShortcutModifier | 'auto'
   setShortcutModifier: (modifier: ShortcutModifier | 'auto') => void
+  sessionJumpChord: SessionJumpChord
+  setSessionJumpChord: (chord: SessionJumpChord) => void
   showProjectName: boolean
   setShowProjectName: (enabled: boolean) => void
   showLastUserMessage: boolean
@@ -202,6 +211,8 @@ export const useSettingsStore = create<SettingsState>()(
       setCustomFontFamily: (family) => set({ customFontFamily: family.slice(0, 256) }),
       shortcutModifier: 'auto',
       setShortcutModifier: (modifier) => set({ shortcutModifier: modifier }),
+      sessionJumpChord: 'modifier',
+      setSessionJumpChord: (chord) => set({ sessionJumpChord: chord }),
       showProjectName: true,
       setShowProjectName: (enabled) => set({ showProjectName: enabled }),
       showLastUserMessage: true,

--- a/src/client/utils/device.ts
+++ b/src/client/utils/device.ts
@@ -1,4 +1,4 @@
-import type { ShortcutModifier } from '../stores/settingsStore'
+import type { SessionJumpChord, ShortcutModifier } from '../stores/settingsStore'
 
 export function isIOSDevice(): boolean {
   if (typeof navigator === 'undefined') return false
@@ -66,6 +66,43 @@ export function matchesModifier(
       return event.metaKey && event.altKey && !event.ctrlKey && !event.shiftKey
     case 'cmd-shift':
       return event.metaKey && event.shiftKey && !event.ctrlKey && !event.altKey
+  }
+}
+
+// Check if a keyboard event matches the jump-to-session chord.
+// 'modifier' reuses the configured letter-shortcut combo; 'meta'/'ctrl' match a
+// bare ⌘/⌃ with no other modifiers held.
+export function matchesJumpChord(
+  event: KeyboardEvent,
+  chord: SessionJumpChord,
+  modifier: EffectiveModifier
+): boolean {
+  switch (chord) {
+    case 'off':
+      return false
+    case 'modifier':
+      return matchesModifier(event, modifier)
+    case 'meta':
+      return event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
+    case 'ctrl':
+      return event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey
+  }
+}
+
+// Display string for the jump-to-session chord, e.g. '⌘' or '⌃⌥'
+export function getJumpChordDisplay(
+  chord: SessionJumpChord,
+  modifier: EffectiveModifier
+): string {
+  switch (chord) {
+    case 'off':
+      return ''
+    case 'modifier':
+      return getModifierDisplay(modifier)
+    case 'meta':
+      return '⌘'
+    case 'ctrl':
+      return '⌃'
   }
 }
 


### PR DESCRIPTION
## What

Adds `[chord]+1..9` to jump straight to the Nth visible session, alongside the existing bracket navigation.

## Why a separate chord setting

Bare `Cmd`/`Ctrl` is the natural chord for digits, but a bad one for the existing letter shortcuts — `Cmd+X` is Cut and `Ctrl+N` is meaningful inside a terminal. So rather than extending `ShortcutModifier`, this adds a dedicated `sessionJumpChord` setting:

`'modifier' | 'meta' | 'ctrl' | 'off'`, defaulting to `'modifier'` — existing behaviour is unchanged unless the user opts in.

## Browser caveat (documented)

Browsers reserve `Cmd`/`Ctrl`+`1..9` for tab switching, so those chords only reach the page in an installed standalone window. In a normal tab the browser keeps them and the shortcut simply never fires. The settings panel says so inline when `meta`/`ctrl` is selected, and the README links to `docs/pwa-install.md`.

## Notes

- Out-of-range digits are deliberately left unhandled so the browser keeps them.
- Falls back to the hibernating bucket when no active sessions are visible, matching bracket navigation.
- No persist version bump needed: the store has no `partialize`, so the new key merges from defaults for existing users.

## Testing

- `bun run lint` — clean
- `bun run typecheck` — clean
- `bun test src/client/__tests__/` — 335 pass, +6 new covering the chord matcher, display helper, index jump, out-of-range, bare-digit passthrough, and chord switching