### PR TITLE
fix: black border around terminal on mobile (v0.4.7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/components/Terminal.tsx
+++ b/src/client/components/Terminal.tsx
@@ -1330,7 +1330,14 @@ export default function Terminal({
 
       {/* Terminal content - always rendered so ref is attached */}
       <div className="relative flex-1">
-        <div ref={containerRef} className="absolute inset-0" />
+        {/* Theme background on the container so the .xterm padding ring
+            matches the terminal — xterm.js 6.0 no longer paints the viewport
+            with the theme background (black-border regression on mobile). */}
+        <div
+          ref={containerRef}
+          className="absolute inset-0"
+          style={{ backgroundColor: terminalTheme.background }}
+        />
         {isSwitching && session && (
           <div className="absolute top-2 left-2 z-50 flex items-center gap-1.5 rounded-lg bg-black/60 px-2.5 py-1.5 text-xs text-white/90 shadow-lg backdrop-blur-md">
             <svg className="h-3 w-3 animate-spin" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/client/styles/index.css
+++ b/src/client/styles/index.css
@@ -367,6 +367,11 @@ body {
   /* Enable touch scrolling on mobile */
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
+  /* xterm.css paints the viewport #000 and, since xterm.js 6.0, no longer
+     overrides it inline with the theme background — which turned the .xterm
+     padding ring into a black border. The terminal container carries the
+     theme background instead (Terminal.tsx), so let it show through. */
+  background-color: transparent !important;
 }
 
 .xterm .xterm-viewport::-webkit-scrollbar {


### PR DESCRIPTION
Fixes the black border around the terminal view introduced by the xterm.js 6.0 upgrade in #180, reported on mobile Safari immediately after v0.4.6.

## Root cause

Agentboard gives `.xterm` an 8px padding ring. Through xterm.js 5.5, the library painted `.xterm-viewport` (which spans the full box, padding included) with the theme background via an inline style on every theme change, so the ring matched the terminal (`#2d2d2d`). xterm.js 6.0's viewport rework applies the theme background to its new scrollable-element node instead — leaving the viewport with `xterm.css`'s default `background-color: #000`. Result: an 8px pure-black frame around the terminal content, most visible on mobile where the terminal fills the screen.

Verified by DOM measurement under iPhone emulation: `.xterm-viewport` computed `rgb(0,0,0)` spanning 390×713 while `.xterm-screen` sat 8px inset painting the theme color.

## Fix

- `styles/index.css`: `.xterm .xterm-viewport { background-color: transparent !important }` — let the container show through.
- `Terminal.tsx`: the terminal container div now carries `terminalTheme.background` (reactive to theme switches), so the padding ring always matches the terminal content.

After the fix, the same measurement shows the viewport transparent over a `rgb(45,45,45)` container, and the mobile screenshot renders edge-to-edge theme background with no border.

## Notes

- `bun run lint && bun run typecheck && bun run test` green.
- Includes the version bump to 0.4.7 for release-on-merge.