### PR TITLE
fix: preserve PTY newline semantics in xterm

### DIFF
--- a/src/client/__tests__/useTerminal.test.tsx
+++ b/src/client/__tests__/useTerminal.test.tsx
@@ -34,7 +34,8 @@ class TerminalMock {
   private keyHandler?: (event: KeyboardEvent) => boolean
   private wheelHandler?: (event: WheelEvent) => boolean
 
-  constructor() {
+  constructor(options: Record<string, unknown> = {}) {
+    this.options = { ...options }
     TerminalMock.instances.push(this)
   }
 
@@ -502,6 +503,7 @@ describe('useTerminal', () => {
     if (!terminal) {
       throw new Error('Expected terminal instance')
     }
+    expect(terminal.options.convertEol).toBe(false)
 
     act(() => {
       terminal.emitData('ls')

--- a/src/client/hooks/useTerminal.ts
+++ b/src/client/hooks/useTerminal.ts
@@ -542,7 +542,9 @@ export function useTerminal({
       scrollback: 0, // Disabled - we use tmux scrollback instead
       cursorBlink: false,
       cursorStyle: 'underline',
-      convertEol: true,
+      // PTY/tmux output already carries the required cursor movement. Rewriting
+      // LF as CRLF corrupts column state for fullscreen applications.
+      convertEol: false,
       theme,
       screenReaderMode: isiOS,
       // Ensure text is readable even when apps use true color (24-bit RGB) sequences


### PR DESCRIPTION
## Summary

- disable xterm `convertEol` for the PTY-backed tmux stream
- preserve fullscreen applications' cursor-column semantics
- add a regression assertion for the terminal option

## Context

This is a follow-up to #158 and #180. The synchronized-output work in #180 is necessary, but v0.4.7 still reproduced the transient Claude fullscreen corruption in my environment across Windows Edge and Android Chrome/Firefox, with WebGL enabled and disabled. DEC 2026 probes showed balanced start/end markers, and forcing each browser write into a synchronized frame did not fix it.

The remaining issue was `convertEol: true`. Agentboard receives real PTY output through tmux, so xterm should not rewrite LF as CRLF. That rewrite resets the cursor column and interferes with fullscreen applications that manage cursor positioning themselves. xterm also documents this option as generally intended for non-PTY data.

Changing it to `false` stopped the corruption in the same phone reproduction while keeping Claude no-flicker/fullscreen enabled. Full diagnostic details are recorded in https://github.com/gbasin/agentboard/issues/158#issuecomment-5145696375.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test` (733 main tests plus all isolated and integration groups, zero failures)
- manual Claude fullscreen reproduction on phone
