### PR TITLE
fix(config): ignore ambient HOSTNAME that echoes the machine hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ AGENTBOARD_LOG_WATCH_MODE=watch
 AGENTBOARD_PASTE_IMAGE_MAX_BYTES=41943040
 ```
 
-`HOSTNAME` controls which interfaces the server binds to (default `127.0.0.1` for localhost-only). With the default localhost binding, if Tailscale is detected the server also binds to your Tailscale IP automatically. Set to `0.0.0.0` to listen on all interfaces.
+`HOSTNAME` controls which interfaces the server binds to (default `127.0.0.1` for localhost-only). With the default localhost binding, if Tailscale is detected the server also binds to your Tailscale IP automatically. Set to `0.0.0.0` to listen on all interfaces. A `HOSTNAME` that merely equals the machine hostname is treated as auto-exported by the environment (containers and some CI images do this) and ignored with a warning, keeping the localhost default.
 
 > **Security note:** Agentboard has no built-in authentication. Anyone who can reach the server has full access to your terminal sessions, including the ability to run commands as your user. The default localhost binding is safe. Tailscale provides network-level auth for remote access. Avoid setting `HOSTNAME=0.0.0.0` on untrusted networks (public WiFi, shared LANs) without an additional access control layer.
 

--- a/src/server/__tests__/config.test.ts
+++ b/src/server/__tests__/config.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, spyOn, test } from 'bun:test'
 import os from 'node:os'
 
 const ORIGINAL_ENV = {
@@ -193,6 +193,48 @@ describe('config', () => {
     expect(config.tmuxTimeoutMs).toBe(4500)
     expect(config.tmuxMutationTimeoutMs).toBe(12000)
     expect(config.pasteImageMaxBytes).toBe(4096)
+  })
+
+  test('ignores ambient HOSTNAME that echoes the machine hostname', async () => {
+    process.env.HOSTNAME = os.hostname()
+    delete process.env.AGENTBOARD_REMOTE_HOSTS
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      const config = await loadConfig('ambient-hostname')
+      expect(config.hostname).toBe('127.0.0.1')
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  test('treats empty HOSTNAME as unset', async () => {
+    process.env.HOSTNAME = ''
+
+    const config = await loadConfig('empty-hostname')
+    expect(config.hostname).toBe('127.0.0.1')
+  })
+
+  test('honors deliberately set HOSTNAME values', async () => {
+    process.env.HOSTNAME = '0.0.0.0'
+    delete process.env.AGENTBOARD_REMOTE_HOSTS
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      const config = await loadConfig('deliberate-hostname')
+      expect(config.hostname).toBe('0.0.0.0')
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  test('keeps honoring HOSTNAME=localhost', async () => {
+    process.env.HOSTNAME = 'localhost'
+
+    const config = await loadConfig('localhost-hostname')
+    expect(config.hostname).toBe('localhost')
   })
 
   test('defaults to watch mode for invalid AGENTBOARD_LOG_WATCH_MODE', async () => {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -141,6 +141,24 @@ const tmuxMutationTimeoutMs = Number.isFinite(tmuxMutationTimeoutMsRaw) && tmuxM
   ? Math.max(Math.floor(tmuxMutationTimeoutMsRaw), tmuxTimeoutMs)
   : Math.max(tmuxTimeoutMs * 5, 15000)
 
+// Bind address for the server. HOSTNAME doubles as the machine name in many
+// environments — containers and some CI images auto-export it — so a value
+// that merely echoes os.hostname() is treated as ambient and the localhost
+// default is kept instead of silently binding away from 127.0.0.1.
+function resolveBindHostname(): string {
+  const raw = process.env.HOSTNAME
+  if (!raw) return '127.0.0.1'
+  if (raw === os.hostname()) {
+    console.warn(
+      `[agentboard] Ignoring HOSTNAME="${raw}" — it matches the machine hostname, ` +
+        'so it was likely auto-exported by the environment. ' +
+        'Binding 127.0.0.1; set HOSTNAME=0.0.0.0 to listen on all interfaces.',
+    )
+    return '127.0.0.1'
+  }
+  return raw
+}
+
 const pasteImageMaxBytesRaw = Number(process.env.AGENTBOARD_PASTE_IMAGE_MAX_BYTES)
 const pasteImageMaxBytes = Number.isFinite(pasteImageMaxBytesRaw) && pasteImageMaxBytesRaw > 0
   ? Math.floor(pasteImageMaxBytesRaw)
@@ -148,7 +166,7 @@ const pasteImageMaxBytes = Number.isFinite(pasteImageMaxBytesRaw) && pasteImageM
 
 export const config = {
   port: Number(process.env.PORT) || 4040,
-  hostname: process.env.HOSTNAME || '127.0.0.1',
+  hostname: resolveBindHostname(),
   hostLabel,
   tmuxSession: process.env.TMUX_SESSION || 'agentboard',
   refreshIntervalMs: Number(process.env.REFRESH_INTERVAL_MS) || 2000,


### PR DESCRIPTION
Fixes #183

Containers and some CI runner images auto-export `HOSTNAME=<machine hostname>`, and `config.ts` reads `HOSTNAME` as the bind address — so in those environments the server silently binds to the machine hostname instead of localhost (full details and repro in #183).

Minimal guard: a `HOSTNAME` equal to `os.hostname()` is treated as ambient — a warning is logged (pointing at `HOSTNAME=0.0.0.0` for anyone who does want non-localhost binding) and the default `127.0.0.1` is kept. Deliberate values keep working unchanged: `0.0.0.0`, `127.0.0.1`, any interface IP, and `localhost` are passed through as before (covered by tests).

Deliberately not included (see the issue): a dedicated variable name and/or restricting the value to IP literals — both are policy calls; happy to follow up either way.
