### PR TITLE
fix(ios): stop identical repaints from destroying text selection (v0.4.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/scripts/ios-a11y-diag.mjs
+++ b/scripts/ios-a11y-diag.mjs
@@ -1,0 +1,147 @@
+/**
+ * Diagnose iOS terminal text-selection problems.
+ *
+ * On iOS the terminal canvas has no selectable text, so `screenReaderMode`
+ * builds a DOM mirror (the xterm accessibility tree) which Terminal.tsx aligns
+ * to the canvas grid. Native long-press selection acts on that mirror, so it
+ * breaks in two ways, and this script measures both:
+ *
+ *   align  glyph advances in the DOM must track the canvas cell grid, or the
+ *          highlight lands off the text it appears to cover
+ *   churn  the mirror's row nodes must stay attached long enough for a
+ *          ~500ms long-press to complete, or the gesture is aborted
+ *
+ * Run against a live instance (see scripts/ios-sim.sh for an isolated one):
+ *   bun scripts/ios-a11y-diag.mjs align
+ *   bun scripts/ios-a11y-diag.mjs churn
+ *
+ * Chromium is used deliberately: both properties are DOM/xterm level, not
+ * engine specific, and headless WebKit cannot reproduce native iOS selection
+ * anyway. Use scripts/ios-sim.sh for real gesture testing.
+ */
+import { chromium, devices } from '@playwright/test'
+
+const URL = process.env.DIAG_URL || 'http://localhost:4055/'
+const MODE = process.argv[2] || 'align'
+
+async function openTerminal() {
+  const browser = await chromium.launch()
+  const ctx = await browser.newContext({ ...devices['iPhone 13'], hasTouch: true, isMobile: true })
+  const page = await ctx.newPage()
+  await page.route('**/sw.js', (r) => r.abort())
+  await page.goto(URL, { waitUntil: 'domcontentloaded' })
+  await page.waitForSelector('.xterm-accessibility-tree', { timeout: 20000 })
+  await page.waitForTimeout(3000)
+  return { browser, page }
+}
+
+async function align(page) {
+  return page.evaluate(() => {
+    const screen = document.querySelector('.xterm-screen')
+    const tree = document.querySelector('.xterm-accessibility-tree')
+    if (!screen || !tree) return { error: 'terminal not ready' }
+
+    const rect = screen.getBoundingClientRect()
+    const probe = document.createElement('span')
+    probe.textContent = '0'.repeat(200)
+    probe.style.cssText =
+      'position:absolute;visibility:hidden;white-space:pre;pointer-events:none;letter-spacing:0px'
+    tree.appendChild(probe)
+    const domCharW = probe.getBoundingClientRect().width / 200
+    probe.remove()
+
+    const letterSpacing = parseFloat(getComputedStyle(tree).letterSpacing) || 0
+    const advance = domCharW + letterSpacing
+
+    // Walk a Range across a long row and compare each character's DOM x to the
+    // grid position the canvas drew it at.
+    const rows = Array.from(tree.children)
+    const row = rows
+      .map((r) => ({ r, text: r.textContent || '' }))
+      .filter((x) => x.text.trim().length > 40)
+      .sort((a, b) => b.text.length - a.text.length)[0]
+
+    let maxDriftPx = null
+    if (row && row.r.firstChild) {
+      const node = row.r.firstChild
+      const range = document.createRange()
+      const originRect = (() => {
+        range.setStart(node, 0)
+        range.setEnd(node, 1)
+        return range.getBoundingClientRect()
+      })()
+      maxDriftPx = 0
+      for (let col = 1; col < Math.min(row.text.length, 80); col++) {
+        range.setStart(node, col)
+        range.setEnd(node, col + 1)
+        const got = range.getBoundingClientRect().left
+        const want = originRect.left + col * advance
+        maxDriftPx = Math.max(maxDriftPx, Math.abs(got - want))
+      }
+      maxDriftPx = +maxDriftPx.toFixed(3)
+    }
+
+    return {
+      screenWidth: rect.width,
+      domCharWidth: +domCharW.toFixed(3),
+      letterSpacing: +letterSpacing.toFixed(3),
+      // Terminal.tsx clamps the correction to +/-2px; at the clamp the DOM can
+      // no longer be made to track the grid and the highlight visibly drifts.
+      letterSpacingClamped: Math.abs(letterSpacing) >= 2,
+      effectiveAdvance: +advance.toFixed(3),
+      maxDriftPx,
+      sampledRow: row ? row.text.slice(0, 50) : null,
+    }
+  })
+}
+
+async function churn(page, windowMs = 6000) {
+  return page.evaluate(async (ms) => {
+    const tree = document.querySelector('.xterm-accessibility-tree')
+    if (!tree) return { error: 'no accessibility tree' }
+
+    const events = []
+    const obs = new MutationObserver((records) => {
+      for (const r of records) events.push({ t: Math.round(performance.now()), type: r.type })
+    })
+    obs.observe(tree, { childList: true, subtree: true, characterData: true })
+
+    // Hold a reference to the text node a finger would land on. iOS needs it to
+    // stay attached for the whole gesture; if xterm replaces it the long-press
+    // produces no selection at all.
+    const anchor = Array.from(tree.children)
+      .map((r) => r.firstChild)
+      .find((n) => n && (n.textContent || '').trim().length > 10)
+    const startedAttached = !!(anchor && anchor.isConnected)
+
+    await new Promise((res) => setTimeout(res, ms))
+    obs.disconnect()
+
+    const times = events.map((e) => e.t).sort((a, b) => a - b)
+    let longestQuietGapMs = ms
+    if (times.length) {
+      longestQuietGapMs = Math.max(times[0], ms - times[times.length - 1])
+      for (let i = 1; i < times.length; i++) {
+        longestQuietGapMs = Math.max(longestQuietGapMs, times[i] - times[i - 1])
+      }
+    }
+
+    return {
+      windowMs: ms,
+      totalMutations: events.length,
+      mutationsPerSecond: +(events.length / (ms / 1000)).toFixed(1),
+      longestQuietGapMs,
+      // A long-press needs roughly this much uninterrupted time to register.
+      roomForLongPress: longestQuietGapMs >= 500,
+      selectionAnchorSurvived: startedAttached && !!(anchor && anchor.isConnected),
+    }
+  }, windowMs)
+}
+
+const { browser, page } = await openTerminal()
+try {
+  const out = MODE === 'churn' ? await churn(page) : await align(page)
+  console.log(JSON.stringify(out, null, 2))
+} finally {
+  await browser.close()
+}

--- a/scripts/ios-sim.sh
+++ b/scripts/ios-sim.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Drive agentboard in the iOS Simulator for touch/selection QA.
+#
+# Runs an agentboard instance isolated from the live one (its own tmux server,
+# port, DB and log) and drives real touch gestures through idb. Use it to test
+# iOS-only behaviour that headless browsers cannot reproduce: native long-press
+# text selection, the selection callout, and the on-screen keyboard.
+#
+# Requirements:
+#   Xcode with an iOS runtime, and idb (`pipx install fb-idb`).
+#   idb needs a Python whose pyexpat works; reinstall with
+#   `pipx reinstall fb-idb --python $(which python3.13)` if it fails to import.
+#
+# Usage:
+#   scripts/ios-sim.sh up            # build, start isolated server, boot sim, open app
+#   scripts/ios-sim.sh shot out.png  # screenshot the simulator
+#   scripts/ios-sim.sh tap X Y       # tap at device points
+#   scripts/ios-sim.sh press X Y [S] # long-press (default 1.5s) at device points
+#   scripts/ios-sim.sh swipe X1 Y1 X2 Y2 [S]
+#   scripts/ios-sim.sh down          # tear down server and tmux, leave sim booted
+#
+# Coordinates are device POINTS, not pixels. A screenshot of an iPhone 17 Pro is
+# 1206x2622 px for a 402x874 pt screen, so divide screenshot pixels by 3.
+
+set -euo pipefail
+
+DEVICE="${IOS_SIM_DEVICE:-iPhone 17 Pro}"
+PORT="${IOS_SIM_PORT:-4055}"
+SESSION="${IOS_SIM_TMUX_SESSION:-iossel}"
+# Keep this path short: the tmux unix socket path limit is ~104 chars.
+TMPDIR_TMUX="${IOS_SIM_TMUX_TMPDIR:-/tmp/absel}"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+export PATH="$HOME/.local/bin:$PATH"
+
+# The live agentboard exports AGENTBOARD_STATIC_DIR pointing at the *published*
+# npm bundle. Every shell spawned inside an agentboard tmux inherits it, which
+# makes a locally started server silently serve stale client code. Always pin it.
+run_isolated() {
+  env -u TMUX -u AGENTBOARD_STATIC_DIR \
+    TMUX_TMPDIR="$TMPDIR_TMUX" \
+    "$@"
+}
+
+udid() {
+  # Prefer an already-booted match so repeated commands keep hitting the same
+  # simulator when several runtimes expose the same device name.
+  local matches
+  matches="$(xcrun simctl list devices available | grep -F "$DEVICE (")"
+  printf '%s\n' "$matches" \
+    | grep -F "(Booted)" \
+    | head -1 \
+    | sed -E 's/.*\(([0-9A-F-]{36})\).*/\1/' \
+    | grep . && return 0
+  printf '%s\n' "$matches" \
+    | head -1 \
+    | sed -E 's/.*\(([0-9A-F-]{36})\).*/\1/'
+}
+
+cmd_up() {
+  mkdir -p "$TMPDIR_TMUX"
+
+  echo "==> building client"
+  (cd "$REPO" && env -u AGENTBOARD_STATIC_DIR bun run build >/dev/null)
+
+  if ! run_isolated tmux has-session -t "$SESSION" 2>/dev/null; then
+    echo "==> creating isolated tmux session '$SESSION'"
+    run_isolated tmux new-session -d -s "$SESSION" -x 100 -y 30
+  fi
+  # Guard against the classic failure: if TMUX_TMPDIR was ignored we would be
+  # driving the user's live tmux server instead of an isolated one.
+  local count
+  count="$(run_isolated tmux list-sessions -F '#{session_name}' | wc -l | tr -d ' ')"
+  if [ "$count" != "1" ]; then
+    echo "refusing to continue: expected 1 session on the isolated tmux server, found $count" >&2
+    echo "(TMUX_TMPDIR=$TMPDIR_TMUX was likely ignored — is the directory present?)" >&2
+    exit 1
+  fi
+
+  if ! curl -sf -o /dev/null "http://localhost:$PORT/"; then
+    echo "==> starting agentboard on :$PORT"
+    run_isolated \
+      PORT="$PORT" \
+      TMUX_SESSION="$SESSION" \
+      DISCOVER_PREFIXES="$SESSION" \
+      AGENTBOARD_DB_PATH="$TMPDIR_TMUX/ab.db" \
+      LOG_FILE="$TMPDIR_TMUX/ab.log" \
+      AGENTBOARD_STATIC_DIR="$REPO/dist/client" \
+      bun "$REPO/src/server/index.ts" >"$TMPDIR_TMUX/server.out" 2>&1 &
+    for _ in $(seq 1 30); do
+      curl -sf -o /dev/null "http://localhost:$PORT/" && break
+      sleep 1
+    done
+  fi
+
+  local id
+  id="$(udid)"
+  [ -n "$id" ] || { echo "no simulator matching '$DEVICE'" >&2; exit 1; }
+  xcrun simctl boot "$id" 2>/dev/null || true
+  open -a Simulator
+  sleep 5
+  xcrun simctl openurl "$id" "http://localhost:$PORT/"
+  echo "==> $DEVICE ($id) -> http://localhost:$PORT/"
+  echo "    Web Inspector: Safari > Develop > Simulator > localhost"
+}
+
+cmd_down() {
+  pkill -f "AGENTBOARD_DB_PATH=$TMPDIR_TMUX/ab.db" 2>/dev/null || true
+  # Fall back to port match: the env-based pattern misses when bun rewrites argv.
+  local pids
+  pids="$(lsof -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null || true)"
+  [ -n "$pids" ] && kill $pids 2>/dev/null || true
+  run_isolated tmux kill-server 2>/dev/null || true
+  echo "==> torn down (simulator left booted)"
+}
+
+main() {
+  local sub="${1:-up}"; shift || true
+  case "$sub" in
+    up)    cmd_up ;;
+    down)  cmd_down ;;
+    shot)  xcrun simctl io "$(udid)" screenshot "${1:-/tmp/absel/shot.png}" ;;
+    tap)   IDB_UDID="$(udid)" idb ui tap "$1" "$2" ;;
+    press) IDB_UDID="$(udid)" idb ui tap "$1" "$2" --duration "${3:-1.5}" ;;
+    swipe) IDB_UDID="$(udid)" idb ui swipe "$1" "$2" "$3" "$4" --duration "${5:-0.4}" ;;
+    *)     sed -n '2,30p' "${BASH_SOURCE[0]}"; exit 1 ;;
+  esac
+}
+
+main "$@"

--- a/src/client/components/Terminal.tsx
+++ b/src/client/components/Terminal.tsx
@@ -16,6 +16,7 @@ import { useEdgeSwipeToOpenDrawer } from '../hooks/useEdgeSwipeToOpenDrawer'
 import { useThemeStore, terminalThemes } from '../stores/themeStore'
 import { useSettingsStore, getFontFamily } from '../stores/settingsStore'
 import { isIOSDevice, getEffectiveModifier, getModifierDisplay } from '../utils/device'
+import { keepA11yRowsStable } from '../utils/a11yRowStability'
 import { formatRelativeTime } from '../utils/time'
 import { getPathLeaf } from '../utils/sessionLabel'
 import TerminalControls from './TerminalControls'
@@ -447,6 +448,8 @@ export default function Terminal({
     const container = containerRef.current
     if (!container) return
 
+    let disposeRowStability: (() => void) | null = null
+
     const syncA11yOverlay = () => {
       const terminal = terminalRef.current
       const root = container.querySelector('.xterm') as HTMLElement | null
@@ -456,6 +459,10 @@ export default function Terminal({
       const a11yRoot = root.querySelector('.xterm-accessibility') as HTMLElement | null
       const a11yTree = root.querySelector('.xterm-accessibility-tree') as HTMLElement | null
       if (!screen || !a11yRoot || !a11yTree) return
+
+      // Armed here rather than on mount because xterm builds the tree lazily;
+      // this runs again on rAF, a timeout and viewport resizes until it exists.
+      if (!disposeRowStability) disposeRowStability = keepA11yRowsStable(a11yTree)
 
       // 1) Position a11y overlay to match the screen rect (handles padding without transforms)
       const rootRect = root.getBoundingClientRect()
@@ -512,6 +519,7 @@ export default function Terminal({
       window.clearTimeout(retryId)
       window.visualViewport?.removeEventListener('resize', scheduleSync)
       window.removeEventListener('orientationchange', scheduleSync)
+      disposeRowStability?.()
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- use session?.id to avoid re-running on session data changes
   }, [containerRef, fontSize, isiOS, session?.id, terminalRef])

--- a/src/client/utils/a11yRowStability.ts
+++ b/src/client/utils/a11yRowStability.ts
@@ -4,23 +4,33 @@
  *
  * On iOS the terminal canvas holds no selectable text, so we enable xterm's
  * `screenReaderMode` and let native long-press select against the DOM mirror it
- * builds. xterm's AccessibilityManager repaints that mirror by assigning
- * `element.textContent` for every row in the refresh range, with no comparison
- * against what the row already holds. Assigning textContent destroys the
- * existing Text node and creates a new one even when the string is identical,
- * and a Selection anchored to the old node collapses.
+ * builds. A Selection is anchored to a specific Text node, so it dies the
+ * moment that node is replaced.
  *
- * RenderDebouncer makes it much worse: it coalesces pending refreshes into a
- * single min/max span, so one genuinely-changed row repaints every row between
- * it and any other dirty row. Measured against Claude Code in fullscreen, a
- * single keystroke in the prompt box rewrote the whole viewport, and 97% of
- * those rewrites wrote byte-identical text. Idle, it was 100% of them.
+ * xterm's AccessibilityManager repaints every row in the refresh range without
+ * comparing against what the row already holds, and one of its two write paths
+ * replaces the node unconditionally:
  *
- * We shadow `textContent`/`innerText` on each row element with a setter that
- * drops no-op writes and delegates real ones. Only the text write is guarded:
- * `aria-posinset` and `aria-setsize` are derived from `buffer.ydisp` and must
- * still be reassigned on every pass, because a row's position changes on scroll
- * even when its text does not.
+ *   element.innerText = ' '    blank rows — always replaces the child node,
+ *                                   even when the value is unchanged
+ *   element.textContent = lineData  populated rows — browsers collapse this onto
+ *                                   the existing node when the row already has
+ *                                   exactly one Text child, but it still
+ *                                   replaces when the row is empty
+ *
+ * RenderDebouncer widens the blast radius: it coalesces pending refreshes into
+ * a single min/max span, so one genuinely-changed row drags every row between
+ * it and any other dirty row into the repaint. Measured against Claude Code in
+ * fullscreen, a single keystroke in the prompt box rewrote the whole viewport
+ * and 97% of those rewrites wrote byte-identical text; idle, 100% of them did.
+ * A held Text node came back detached and a live selection collapsed within six
+ * seconds of an idle terminal.
+ *
+ * We shadow `textContent`/`innerText` on each row with a setter that drops
+ * no-op writes and delegates real ones, which takes the measured churn to zero.
+ * Only the text write is guarded: `aria-posinset` and `aria-setsize` derive
+ * from `buffer.ydisp` and must still be reassigned on every pass, because a
+ * row's position changes on scroll even when its text does not.
  *
  * The real home for this is a dirty check inside xterm's AccessibilityManager;
  * this is the same guard applied from outside, since the row elements are
@@ -29,14 +39,40 @@
 
 const GUARDED = new WeakSet<HTMLElement>()
 
-function describedTextSetter(prop: 'textContent' | 'innerText'): {
-  get: () => string
-  set: (value: string) => void
-} | null {
-  const proto = prop === 'textContent' ? Node.prototype : HTMLElement.prototype
+interface TextAccessor {
+  get: (this: HTMLElement) => string
+  set: (this: HTMLElement, value: string) => void
+  enumerable: boolean
+  configurable: boolean
+}
+
+function nativeAccessor(proto: object, prop: string): TextAccessor | null {
   const desc = Object.getOwnPropertyDescriptor(proto, prop)
   if (!desc?.get || !desc.set) return null
-  return { get: desc.get as () => string, set: desc.set as (value: string) => void }
+  return {
+    get: desc.get as TextAccessor['get'],
+    set: desc.set as TextAccessor['set'],
+    // Mirror the native flags so the shadow stays indistinguishable from the
+    // prototype accessor it hides (both are enumerable and configurable).
+    enumerable: desc.enumerable ?? true,
+    configurable: desc.configurable ?? true,
+  }
+}
+
+// Resolved once on first use, not at module scope: looking these up per write
+// would cost a descriptor allocation on every repaint (the hot path this module
+// exists to make cheap), but touching Node/HTMLElement at import time would
+// throw in the DOM-less environment the unit tests run in.
+let accessorsResolved = false
+let nativeTextContent: TextAccessor | null = null
+let nativeInnerText: TextAccessor | null = null
+
+function resolveAccessors(): void {
+  if (accessorsResolved) return
+  accessorsResolved = true
+  if (typeof Node === 'undefined' || typeof HTMLElement === 'undefined') return
+  nativeTextContent = nativeAccessor(Node.prototype, 'textContent')
+  nativeInnerText = nativeAccessor(HTMLElement.prototype, 'innerText')
 }
 
 /** Shadow a row's text accessors so identical writes leave the Text node alone. */
@@ -44,22 +80,26 @@ function guardRow(row: HTMLElement): void {
   if (GUARDED.has(row)) return
   GUARDED.add(row)
 
-  for (const prop of ['textContent', 'innerText'] as const) {
-    const base = describedTextSetter(prop)
-    if (!base) continue
+  const readCurrent = nativeTextContent?.get
+  if (!readCurrent) return
+
+  for (const [prop, native] of [
+    ['textContent', nativeTextContent],
+    ['innerText', nativeInnerText],
+  ] as const) {
+    if (!native) continue
     Object.defineProperty(row, prop, {
-      configurable: true,
-      enumerable: false,
+      configurable: native.configurable,
+      enumerable: native.enumerable,
       get(this: HTMLElement) {
-        return base.get.call(this)
+        return native.get.call(this)
       },
       set(this: HTMLElement, value: string) {
         // Compare against textContent for both props: after xterm writes
         // innerText for a blank row the node's textContent is that same string,
         // so this is the value that decides whether the node must be replaced.
-        const current = describedTextSetter('textContent')?.get.call(this)
-        if (current === value) return
-        base.set.call(this, value)
+        if (readCurrent.call(this) === value) return
+        native.set.call(this, value)
       },
     })
   }
@@ -67,9 +107,17 @@ function guardRow(row: HTMLElement): void {
 
 /**
  * Guard every row in `tree` and any row xterm adds later (rows are recreated on
- * resize and shuffled at the scroll boundaries). Returns a disposer.
+ * resize and shuffled at the scroll boundaries).
+ *
+ * The returned disposer stops adopting new rows but deliberately leaves the
+ * accessors on rows already guarded. The effect that owns this re-runs on font
+ * and session changes against the same live tree, and tearing the shadows down
+ * only to reinstall them would leave a window where a repaint could land
+ * unguarded. Rows are discarded with the terminal, so nothing outlives it.
  */
 export function keepA11yRowsStable(tree: HTMLElement): () => void {
+  resolveAccessors()
+
   const guardAll = () => {
     for (const child of Array.from(tree.children)) {
       if (child instanceof HTMLElement) guardRow(child)

--- a/src/client/utils/a11yRowStability.ts
+++ b/src/client/utils/a11yRowStability.ts
@@ -1,0 +1,87 @@
+/**
+ * Keep xterm's accessibility-tree row nodes alive across repaints so iOS text
+ * selection survives.
+ *
+ * On iOS the terminal canvas holds no selectable text, so we enable xterm's
+ * `screenReaderMode` and let native long-press select against the DOM mirror it
+ * builds. xterm's AccessibilityManager repaints that mirror by assigning
+ * `element.textContent` for every row in the refresh range, with no comparison
+ * against what the row already holds. Assigning textContent destroys the
+ * existing Text node and creates a new one even when the string is identical,
+ * and a Selection anchored to the old node collapses.
+ *
+ * RenderDebouncer makes it much worse: it coalesces pending refreshes into a
+ * single min/max span, so one genuinely-changed row repaints every row between
+ * it and any other dirty row. Measured against Claude Code in fullscreen, a
+ * single keystroke in the prompt box rewrote the whole viewport, and 97% of
+ * those rewrites wrote byte-identical text. Idle, it was 100% of them.
+ *
+ * We shadow `textContent`/`innerText` on each row element with a setter that
+ * drops no-op writes and delegates real ones. Only the text write is guarded:
+ * `aria-posinset` and `aria-setsize` are derived from `buffer.ydisp` and must
+ * still be reassigned on every pass, because a row's position changes on scroll
+ * even when its text does not.
+ *
+ * The real home for this is a dirty check inside xterm's AccessibilityManager;
+ * this is the same guard applied from outside, since the row elements are
+ * internal to xterm and the package ships only a minified build.
+ */
+
+const GUARDED = new WeakSet<HTMLElement>()
+
+function describedTextSetter(prop: 'textContent' | 'innerText'): {
+  get: () => string
+  set: (value: string) => void
+} | null {
+  const proto = prop === 'textContent' ? Node.prototype : HTMLElement.prototype
+  const desc = Object.getOwnPropertyDescriptor(proto, prop)
+  if (!desc?.get || !desc.set) return null
+  return { get: desc.get as () => string, set: desc.set as (value: string) => void }
+}
+
+/** Shadow a row's text accessors so identical writes leave the Text node alone. */
+function guardRow(row: HTMLElement): void {
+  if (GUARDED.has(row)) return
+  GUARDED.add(row)
+
+  for (const prop of ['textContent', 'innerText'] as const) {
+    const base = describedTextSetter(prop)
+    if (!base) continue
+    Object.defineProperty(row, prop, {
+      configurable: true,
+      enumerable: false,
+      get(this: HTMLElement) {
+        return base.get.call(this)
+      },
+      set(this: HTMLElement, value: string) {
+        // Compare against textContent for both props: after xterm writes
+        // innerText for a blank row the node's textContent is that same string,
+        // so this is the value that decides whether the node must be replaced.
+        const current = describedTextSetter('textContent')?.get.call(this)
+        if (current === value) return
+        base.set.call(this, value)
+      },
+    })
+  }
+}
+
+/**
+ * Guard every row in `tree` and any row xterm adds later (rows are recreated on
+ * resize and shuffled at the scroll boundaries). Returns a disposer.
+ */
+export function keepA11yRowsStable(tree: HTMLElement): () => void {
+  const guardAll = () => {
+    for (const child of Array.from(tree.children)) {
+      if (child instanceof HTMLElement) guardRow(child)
+    }
+  }
+
+  guardAll()
+
+  // Only childList on the tree itself: we react to rows being added, never to
+  // their contents, so arming a row cannot retrigger this observer.
+  const observer = new MutationObserver(guardAll)
+  observer.observe(tree, { childList: true })
+
+  return () => observer.disconnect()
+}

--- a/tests/e2e/ios-selection.spec.ts
+++ b/tests/e2e/ios-selection.spec.ts
@@ -1,0 +1,79 @@
+// E2E: on iOS the terminal canvas has no selectable text, so long-press selects
+// against xterm's accessibility-tree DOM mirror. xterm repaints that mirror by
+// assigning `element.textContent` unconditionally, which destroys the Text node
+// even when the string is identical and collapses any selection anchored to it.
+// Measured against Claude Code in fullscreen, 97-100% of those rewrites wrote
+// byte-identical text. keepA11yRowsStable() drops the no-op writes.
+//
+// The iOS code paths key off the user agent (isIOSDevice), so a desktop
+// viewport with an iPhone UA exercises them without the mobile drawer.
+import { test, expect } from '@playwright/test'
+
+test.use({
+  userAgent:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+  viewport: { width: 1280, height: 800 },
+})
+
+test('accessibility rows survive identical repaints without breaking updates', async ({
+  page,
+}) => {
+  await page.goto('/')
+  const card = page.getByTestId('session-card').first()
+  await expect(card).toBeVisible()
+  await card.click()
+  await expect(page.locator('.xterm')).toBeVisible()
+  // The tree is built lazily once screenReaderMode initialises.
+  await page.waitForSelector('.xterm-accessibility-tree > div', { timeout: 20000 })
+
+  const result = await page.evaluate(() => {
+    const tree = document.querySelector('.xterm-accessibility-tree')
+    if (!tree) return { error: 'no accessibility tree' }
+    const row = tree.firstElementChild as HTMLElement | null
+    if (!row) return { error: 'no rows' }
+
+    // Seed the row rather than relying on whatever the shell happened to
+    // print. This is a genuine change, so it must create a Text node.
+    const text = 'ALPHA selectable words here'
+    row.textContent = text
+    const node = row.firstChild as Text | null
+    if (!node) return { error: 'seed write was swallowed' }
+
+    // Anchor a real selection the way a long-press would.
+    const range = document.createRange()
+    range.setStart(node, 0)
+    range.setEnd(node, 5)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    const selectedBefore = selection?.toString() ?? ''
+
+    // Exactly what xterm's AccessibilityManager does on every refresh pass.
+    row.textContent = text
+
+    // posinset derives from buffer.ydisp, so it changes on scroll even when a
+    // row's text does not. The guard must not swallow those attribute writes.
+    row.setAttribute('aria-posinset', '4242')
+
+    const afterNoop = {
+      sameNode: row.firstChild === node,
+      stillAttached: node.isConnected,
+      selectedBefore,
+      selectedAfter: window.getSelection()?.toString() ?? '',
+      posinset: row.getAttribute('aria-posinset'),
+    }
+
+    // A row whose text genuinely changed must still repaint.
+    row.textContent = 'BRAVO different text'
+
+    return { ...afterNoop, changedText: row.textContent, error: undefined }
+  })
+
+  expect(result.error).toBeUndefined()
+  expect(result.sameNode).toBe(true)
+  expect(result.stillAttached).toBe(true)
+  expect(result.selectedBefore).toBe('ALPHA')
+  expect(result.selectedAfter).toBe('ALPHA')
+  expect(result.posinset).toBe('4242')
+  expect(result.changedText).toBe('BRAVO different text')
+})

--- a/tests/e2e/ios-selection.spec.ts
+++ b/tests/e2e/ios-selection.spec.ts
@@ -48,8 +48,13 @@ test('accessibility rows survive identical repaints without breaking updates', a
     selection?.addRange(range)
     const selectedBefore = selection?.toString() ?? ''
 
-    // Exactly what xterm's AccessibilityManager does on every refresh pass.
+    // Both writes AccessibilityManager makes, with the value unchanged.
+    // innerText is the load-bearing case: browsers already collapse an
+    // identical textContent write onto the existing node, but an identical
+    // innerText write replaces it unconditionally, so without the guard this
+    // is what destroys the selection anchor on xterm's blank rows.
     row.textContent = text
+    row.innerText = text
 
     // posinset derives from buffer.ydisp, so it changes on scroll even when a
     // row's text does not. The guard must not swallow those attribute writes.


### PR DESCRIPTION
Fixes janky native text selection in the terminal on iOS Safari, plus the tooling used to find and verify it.

## The bug

On iOS the terminal canvas holds no selectable text, so we enable xterm's `screenReaderMode` and let native long-press select against the DOM mirror it builds. A `Selection` is anchored to a specific `Text` node, so it dies the moment that node is replaced.

xterm's `AccessibilityManager._renderRows` repaints every row in the refresh range without comparing against what the row already holds. `RenderDebouncer` widens the blast radius: it coalesces pending refreshes into one min/max **span**, so a single genuinely-changed row drags every row between it and any other dirty row into the repaint.

Measured against Claude Code in fullscreen (alt-screen):

| scenario | row rewrites | rows that actually changed | wasted |
|---|---|---|---|
| idle | 120 / 6s | 0 of 30 | **100%** |
| typing one char in the prompt box | 270 / 10s | **1** of 30 | **97%** |

Typing at row 26 rewrote the header at row 1 nine times with byte-identical text. Observer-free, a held `Text` node came back `isConnected: false` and a live selection collapsed from `"ASCII"` to `""` within six seconds of an **idle** terminal.

## The fix

`src/client/utils/a11yRowStability.ts` shadows `textContent`/`innerText` on each row with a setter that drops no-op writes and delegates real ones.

Only the **text** write is guarded. `aria-posinset` and `aria-setsize` derive from `buffer.ydisp` and change on scroll even when a row's text does not, so a naive `if (unchanged) continue` would silently break screen-reader navigation while fixing selection. Shadowing the property gets that right by construction.

Applied from outside rather than patching xterm: the row elements are internal and the package ships only a minified `lib/`. Upstreaming a dirty check into `AccessibilityManager` remains the right long-term home — this also affects real VoiceOver users, not just our selection use case.

**After: 0 mutations per 6s, anchor node and live selection both survive.**

## Alignment was not the problem

My first hypothesis was that the a11y overlay drifts off the canvas grid. Disproven: max drift 0.016px over 80 columns, letter-spacing at −0.13px, nowhere near the ±2px clamp.

## Tooling included

- `scripts/ios-sim.sh` — runs agentboard isolated from the live instance (own tmux server, port, DB, log) and drives real touch gestures in the iOS Simulator via `idb`. Refuses to run if it detects it is about to drive the live tmux server.
- `scripts/ios-a11y-diag.mjs` — `align` and `churn` modes; produced every number above.

## Testing

- New e2e spec in `tests/e2e/ios-selection.spec.ts`, **verified non-vacuous**: it fails with the guard disabled and passes with it restored. This mattered — the first version asserted only on `textContent`, which browsers already collapse onto the existing node, so it passed with the fix removed. `innerText` (xterm's blank-row path) is the write that replaces the node unconditionally.
- Unit suite green, lint and typecheck clean.

## Known limitations

- **The end-to-end gesture is unconfirmed.** A synthetic `idb` long-press does not produce a selection in the simulator, before or after the fix, so the harness cannot discriminate "fix didn't work" from "synthetic long-press doesn't trigger iOS's selection recognizer". Needs a human finger on a device. What is proven is the DOM-level defect and its elimination.
- **Selections still die during streaming output.** When the transcript scrolls, every row genuinely changes, so the dirty check cannot help. Semantically unavoidable — the text really did move.
- **Separate unsolved obstacle in fullscreen:** the TUI has mouse tracking on, so touches are forwarded to the app as mouse events rather than starting a selection. Independent of this fix.
- **No unit test.** The repo has no DOM environment (client tests hand-stub `document`) and this fix is entirely about real `Text` node semantics, so coverage lives in the e2e suite. Adding happy-dom would close the gap but touches shared client-test setup with a history of cross-file state leaks.

Patch version bumped 0.4.7 → 0.4.8.
