### PR TITLE
fix(e2e): deflake ios-selection spec — read selection via Range, not Selection.toString()

### DIFF
--- a/tests/e2e/ios-selection.spec.ts
+++ b/tests/e2e/ios-selection.spec.ts
@@ -46,7 +46,17 @@ test('accessibility rows survive identical repaints without breaking updates', a
     const selection = window.getSelection()
     selection?.removeAllRanges()
     selection?.addRange(range)
-    const selectedBefore = selection?.toString() ?? ''
+
+    // Read the selection through its Range, not Selection.toString():
+    // Selection.toString() returns *rendered* text, which is '' while the
+    // a11y rows have no layout yet (seen on slow CI runners). Range.toString()
+    // is layout-independent and still collapses to '' if a repaint destroys
+    // the anchored Text node, which is the regression under test.
+    const readSelection = () => {
+      const sel = window.getSelection()
+      return sel && sel.rangeCount > 0 ? sel.getRangeAt(0).toString() : ''
+    }
+    const selectedBefore = readSelection()
 
     // Both writes AccessibilityManager makes, with the value unchanged.
     // innerText is the load-bearing case: browsers already collapse an
@@ -64,7 +74,7 @@ test('accessibility rows survive identical repaints without breaking updates', a
       sameNode: row.firstChild === node,
       stillAttached: node.isConnected,
       selectedBefore,
-      selectedAfter: window.getSelection()?.toString() ?? '',
+      selectedAfter: readSelection(),
       posinset: row.getAttribute('aria-posinset'),
     }
 


### PR DESCRIPTION
## Problem

Master CI failed on run [30755976779](https://github.com/gbasin/agentboard/actions/runs/30755976779) in `tests/e2e/ios-selection.spec.ts`: `selectedBefore` came back `""` instead of `"ALPHA"`. A re-run of the same commit passed, and the spec passes 15/15 locally — it's a flake, not a regression in the iOS selection fix (#185).

## Root cause

The test read the selection back with `Selection.toString()`, which returns the **rendered** text of the selection and depends on layout. On a slow CI runner the accessibility-tree rows can still have zero layout when the assertion runs, so it returns `""` even though the range is correctly anchored.

## Fix

Read through `Selection.getRangeAt(0).toString()` instead — `Range.toString()` is layout-independent (concatenates the text content in the range).

Regression sensitivity is preserved: verified in a throwaway spec that when an unguarded `innerText` write replaces the Text node (the bug #185 fixed), the live range collapses and the range read returns `""`, so the assertions still fail.

## Testing

- `bunx playwright test tests/e2e/ios-selection.spec.ts --repeat-each=15` → 15/15 pass
- `bun run lint && bun run typecheck && bun run test` → clean