### PR TITLE
fix(e2e): run the suite on a private tmux server so nothing leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,13 +68,6 @@ jobs:
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps chromium
 
-      - name: Setup tmux session
-        run: |
-          tmux new-session -d -s agentboard -n test
-          tmux send-keys -t agentboard:test 'echo "hello from CI"' Enter
-          sleep 1
-          tmux capture-pane -t agentboard:test -p
-
       - name: Build
         run: bun run build
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,31 @@
 import { defineConfig } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 const port = Number(process.env.E2E_PORT) || 4173
 const tmuxSession =
   process.env.E2E_TMUX_SESSION || `agentboard-e2e-${Date.now()}`
 
 process.env.E2E_TMUX_SESSION = tmuxSession
+
+// Run the whole suite against a private tmux server. The agentboard server
+// creates per-connection grouped sessions (`<base>-ws-<uuid>`) that only its
+// own dispose() or its next startup's pruner can reap; when Playwright
+// SIGKILLs the webServer they used to leak onto the user's live tmux server
+// (which also received the server-global set-clipboard write). With a private
+// socket, teardown just kill-servers it — nothing to enumerate, nothing shared.
+//
+// TMUX_TMPDIR is silently ignored unless the directory exists, and an
+// inherited $TMUX (suite run from inside a tmux session) overrides the socket
+// choice entirely — hence the mkdir and the delete. Both propagate to the
+// webServer, the test workers (paste.spec shells out to tmux), and teardown.
+const tmuxTmpDir =
+  process.env.E2E_TMUX_TMPDIR || join(tmpdir(), `abe2e-${Date.now()}`)
+process.env.E2E_TMUX_TMPDIR = tmuxTmpDir
+mkdirSync(tmuxTmpDir, { recursive: true })
+process.env.TMUX_TMPDIR = tmuxTmpDir
+delete process.env.TMUX
 
 export default defineConfig({
   testDir: 'tests/e2e',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -46,5 +46,6 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
   },
+  globalSetup: './tests/e2e/setup.ts',
   globalTeardown: './tests/e2e/teardown.ts',
 })

--- a/tests/e2e/setup.ts
+++ b/tests/e2e/setup.ts
@@ -1,0 +1,36 @@
+import { spawnSync } from 'node:child_process'
+
+// The specs need at least one visible session card. A fresh base session only
+// has the invisible bootstrap window (filtered from listings), and CI used to
+// paper over that with a workflow step that pre-created an `agentboard`
+// session on the default tmux server — which the suite no longer sees now
+// that it runs on a private one (TMUX_TMPDIR, see playwright.config.ts).
+// Create the visible window here instead, on whatever server the suite uses.
+export default async function setup() {
+  const session = process.env.E2E_TMUX_SESSION
+  if (!session) {
+    throw new Error('E2E_TMUX_SESSION is not set')
+  }
+
+  const created = spawnSync(
+    'tmux',
+    ['new-session', '-d', '-s', session, '-n', 'test'],
+    { encoding: 'utf-8' }
+  )
+  if (created.status === 0) {
+    return
+  }
+
+  // The session already exists (the webServer's ensureSession won the race);
+  // add the visible window to it.
+  const added = spawnSync(
+    'tmux',
+    ['new-window', '-t', `=${session}`, '-n', 'test'],
+    { encoding: 'utf-8' }
+  )
+  if (added.status !== 0) {
+    throw new Error(
+      `Failed to create test window in ${session}: ${created.stderr}${added.stderr}`
+    )
+  }
+}

--- a/tests/e2e/teardown.ts
+++ b/tests/e2e/teardown.ts
@@ -1,6 +1,25 @@
 import { spawnSync } from 'node:child_process'
+import { existsSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
 
 export default async function teardown() {
+  const dir = process.env.E2E_TMUX_TMPDIR
+  if (dir) {
+    // The suite ran on a private tmux server (see playwright.config.ts), so
+    // cleanup is one kill-server. Address it with an explicit -S socket path:
+    // unlike TMUX_TMPDIR (ignored if the dir vanished) or $TMUX (overrides the
+    // socket choice), -S can never resolve to the user's live tmux server.
+    const socket = join(dir, `tmux-${process.getuid?.() ?? 0}`, 'default')
+    if (existsSync(socket)) {
+      spawnSync('tmux', ['-S', socket, 'kill-server'], { stdio: 'ignore' })
+    }
+    rmSync(dir, { recursive: true, force: true })
+    return
+  }
+
+  // No private server (E2E_TMUX_TMPDIR unset): the run shared the inherited
+  // tmux server, so kill the base session and any grouped `-ws-` clones the
+  // agentboard server left behind if it was killed before its own cleanup.
   const session = process.env.E2E_TMUX_SESSION
   if (!session) {
     return
@@ -12,4 +31,17 @@ export default async function teardown() {
   }
 
   spawnSync('tmux', ['kill-session', '-t', session], { stdio: 'ignore' })
+
+  const list = spawnSync('tmux', ['list-sessions', '-F', '#{session_name}'], {
+    encoding: 'utf-8',
+  })
+  if (list.status !== 0 || !list.stdout) {
+    return
+  }
+  for (const line of list.stdout.split('\n')) {
+    const name = line.trim()
+    if (name.startsWith(`${session}-ws-`)) {
+      spawnSync('tmux', ['kill-session', '-t', name], { stdio: 'ignore' })
+    }
+  }
 }


### PR DESCRIPTION
## Problem

After running e2e locally, an orphaned `agentboard-e2e-<ts>-ws-<uuid>` grouped session was left on the live tmux server. Mechanism:

1. The agentboard server creates a per-connection grouped session (`<base>-ws-<uuid>`), cleaned up by `dispose()` on WebSocket close or by `pruneOrphanedWsSessions()` at next startup.
2. Playwright SIGKILLs the webServer at shutdown — a connection still open at that moment never runs `dispose()`. The tmux session lives on the tmux daemon, so it survives.
3. `globalTeardown` only killed the base `E2E_TMUX_SESSION`, and each run uses a fresh timestamped base name, so no later run's startup pruner ever matches old orphans.

The suite also mutated the live server's global `set-clipboard` option.

## Fix

**Private tmux server per run**: `playwright.config.ts` points `TMUX_TMPDIR` at a per-run directory (created eagerly — tmux silently ignores a missing dir — and with `$TMUX` deleted, since it overrides the socket choice when the suite runs from inside a tmux session). The env propagates to the webServer, the test workers (`paste.spec` shells out to tmux), and teardown.

**Teardown = one `kill-server`**, addressed via an explicit `-S <socket>` path so it can never resolve to the user's live server, then removes the directory. The no-private-server fallback path now also sweeps `<base>-ws-` clones.

**Hermetic card setup**: isolation exposed that the specs' session cards never came from the e2e base session (its only window is the invisible bootstrap window) — they came from an `agentboard` session a CI workflow step pre-created on the *default* socket, discovered as an external session; locally they raced `paste.spec`'s window. A new Playwright `globalSetup` creates the visible `test` window on whatever server the suite uses, and the workflow step is removed.

### Why not `destroy-unattached on`?

Considered and rejected: the proxy legitimately leaves the ws session unattached while its client visits derived external-session groups (`-x-` sessions), so tmux would reap it mid-connection.

## Testing

- Full e2e suite ×3 locally: 3/3 pass each run; live `tmux ls` identical before/after; private dirs removed.
- Crash simulation: base + orphaned `-ws-` clone on a private socket, teardown run standalone → server killed, dir removed, live server untouched.
- Fallback simulation (no `E2E_TMUX_TMPDIR`): base + clone on the shared server → both swept, other sessions untouched.
- `bun run lint && bun run typecheck && bun run test` → clean; all CI checks green including e2e.