### PR TITLE
fix(e2e): isolate the webServer's db, logs, and agent-log dirs per run

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,21 +29,24 @@ delete process.env.TMUX
 
 // The tmux server isn't the only shared state: without these, the e2e
 // webServer opens the user's live ~/.agentboard/agentboard.db and watches
-// their real Claude/Codex logs. It then rewrites each agent session's
+// their real Claude/Codex/Pi logs. It then rewrites each agent session's
 // current_window mapping against ITS tmux view — which contains none of the
 // user's windows — desyncing the live dashboard's status and last-message
 // display until every session's log happens to grow again. Point all of it
-// into the same throwaway directory teardown already removes.
+// into the same throwaway directory teardown already removes. Set via
+// process.env (like TMUX_TMPDIR above) so the webServer, the test workers,
+// and any future setup/teardown code all see the same isolated paths.
 const claudeDir = join(tmuxTmpDir, 'claude')
 const codexDir = join(tmuxTmpDir, 'codex')
+const piDir = join(tmuxTmpDir, 'pi')
 mkdirSync(claudeDir, { recursive: true })
 mkdirSync(codexDir, { recursive: true })
-const e2eDataEnv = [
-  `AGENTBOARD_DB_PATH=${tmuxTmpDir}/agentboard.db`,
-  `LOG_FILE=${tmuxTmpDir}/agentboard.log`,
-  `CLAUDE_CONFIG_DIR=${claudeDir}`,
-  `CODEX_HOME=${codexDir}`,
-].join(' ')
+mkdirSync(piDir, { recursive: true })
+process.env.AGENTBOARD_DB_PATH = `${tmuxTmpDir}/agentboard.db`
+process.env.LOG_FILE = `${tmuxTmpDir}/agentboard.log`
+process.env.CLAUDE_CONFIG_DIR = claudeDir
+process.env.CODEX_HOME = codexDir
+process.env.PI_HOME = piDir
 
 export default defineConfig({
   testDir: 'tests/e2e',
@@ -59,7 +62,7 @@ export default defineConfig({
     // AGENTBOARD_STATIC_DIR is pinned to the repo build: when e2e runs from a
     // shell inside a live agentboard session, the inherited env points at the
     // installed npm package's bundle and the tests would exercise stale code.
-    command: `[ -d dist/client ] || bun run build && PORT=${port} TMUX_SESSION=${tmuxSession} AGENTBOARD_STATIC_DIR=dist/client ${e2eDataEnv} bun src/server/index.ts`,
+    command: `[ -d dist/client ] || bun run build && PORT=${port} TMUX_SESSION=${tmuxSession} AGENTBOARD_STATIC_DIR=dist/client bun src/server/index.ts`,
     url: `http://localhost:${port}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,6 +27,24 @@ mkdirSync(tmuxTmpDir, { recursive: true })
 process.env.TMUX_TMPDIR = tmuxTmpDir
 delete process.env.TMUX
 
+// The tmux server isn't the only shared state: without these, the e2e
+// webServer opens the user's live ~/.agentboard/agentboard.db and watches
+// their real Claude/Codex logs. It then rewrites each agent session's
+// current_window mapping against ITS tmux view — which contains none of the
+// user's windows — desyncing the live dashboard's status and last-message
+// display until every session's log happens to grow again. Point all of it
+// into the same throwaway directory teardown already removes.
+const claudeDir = join(tmuxTmpDir, 'claude')
+const codexDir = join(tmuxTmpDir, 'codex')
+mkdirSync(claudeDir, { recursive: true })
+mkdirSync(codexDir, { recursive: true })
+const e2eDataEnv = [
+  `AGENTBOARD_DB_PATH=${tmuxTmpDir}/agentboard.db`,
+  `LOG_FILE=${tmuxTmpDir}/agentboard.log`,
+  `CLAUDE_CONFIG_DIR=${claudeDir}`,
+  `CODEX_HOME=${codexDir}`,
+].join(' ')
+
 export default defineConfig({
   testDir: 'tests/e2e',
   timeout: 30000,
@@ -41,7 +59,7 @@ export default defineConfig({
     // AGENTBOARD_STATIC_DIR is pinned to the repo build: when e2e runs from a
     // shell inside a live agentboard session, the inherited env points at the
     // installed npm package's bundle and the tests would exercise stale code.
-    command: `[ -d dist/client ] || bun run build && PORT=${port} TMUX_SESSION=${tmuxSession} AGENTBOARD_STATIC_DIR=dist/client bun src/server/index.ts`,
+    command: `[ -d dist/client ] || bun run build && PORT=${port} TMUX_SESSION=${tmuxSession} AGENTBOARD_STATIC_DIR=dist/client ${e2eDataEnv} bun src/server/index.ts`,
     url: `http://localhost:${port}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120000,


### PR DESCRIPTION
## Problem

Follow-up to #187, found the hard way: after today's e2e runs, live dashboard sessions desynced from their log files (empty `current_window`, stale last-user-message) until each session's log grew again.

The private tmux server didn't cover **data**. The e2e webServer still opened the live `~/.agentboard/agentboard.db` (no `AGENTBOARD_DB_PATH` set) and watched the real `~/.claude/projects` / `~/.codex/sessions` logs. It saw the user's active session logs grow, tried to match them against **its own** tmux windows (an e2e session containing none of the user's windows), and rewrote `current_window` mappings in the shared db — clobbering the live server's associations and consuming the log-size deltas its rematching keys on.

## Fix

Point `AGENTBOARD_DB_PATH`, `LOG_FILE`, `CLAUDE_CONFIG_DIR`, and `CODEX_HOME` into the same per-run private directory as the tmux socket — teardown already removes it.

## Testing

- Manual server boot with the four overrides: `agentboard.db` + `agentboard.log` created inside the private dir; live db row count unchanged.
- Full e2e suite passes (3/3); live db row count unchanged before/after.
- `bun run lint && bun run typecheck` clean.