### PR TITLE
fix: stop unbounded session loads from starving the event loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,5 @@ test-results
 systemd/agentboard.service
 # Nightshift plan artifacts (keep out of version control)
 .nightshift-plan
-/.cachebro
 /.agentcache
 .claude/

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -28,6 +28,28 @@ export type NewAgentSessionRecord = Omit<
   AgentSessionRecord,
   'id' | 'wakeStartedAt'
 > & { wakeStartedAt?: string | null }
+
+/** Identity fields for every tracked log, cheap enough to load in full. */
+export interface KnownSessionKey {
+  sessionId: string
+  logFilePath: string
+  projectPath: string | null
+  slug: string | null
+  agentType: AgentType | null
+  isCodexExec: boolean
+}
+
+// last_user_message is a UI preview; unbounded values (giant pastes, tool
+// dumps) bloated real-world databases into the hundreds of MB and made every
+// full-table read a multi-second event-loop stall.
+export const MAX_LAST_USER_MESSAGE_LENGTH = 8192
+
+function clampLastUserMessage(value: string | null): string | null {
+  if (value && value.length > MAX_LAST_USER_MESSAGE_LENGTH) {
+    return value.slice(0, MAX_LAST_USER_MESSAGE_LENGTH)
+  }
+  return value
+}
 export type ClaimCurrentWindowPatch = Partial<
   Pick<
     AgentSessionRecord,
@@ -60,6 +82,8 @@ export interface SessionDatabase {
   getActiveSessions: () => AgentSessionRecord[]
   getHibernatingSessions: () => AgentSessionRecord[]
   getHistorySessions: (options?: { maxAgeHours?: number }) => AgentSessionRecord[]
+  /** All session identity keys without large TEXT columns — safe to load per poll. */
+  getKnownSessionKeys: () => KnownSessionKey[]
   orphanSession: (
     sessionId: string,
     options?: { hibernate?: boolean }
@@ -182,6 +206,9 @@ export function initDatabase(options: { path?: string } = {}): SessionDatabase {
   const selectHistoryRecent = db.prepare(
     'SELECT * FROM agent_sessions WHERE current_window IS NULL AND is_pinned = 0 AND last_activity_at > $cutoff ORDER BY last_activity_at DESC, session_id'
   )
+  const selectKnownSessionKeys = db.prepare(
+    'SELECT session_id, log_file_path, project_path, slug, agent_type, is_codex_exec FROM agent_sessions'
+  )
   const selectByDisplayName = db.prepare(
     'SELECT 1 FROM agent_sessions WHERE display_name = $displayName LIMIT 1'
   )
@@ -232,7 +259,7 @@ export function initDatabase(options: { path?: string } = {}): SessionDatabase {
         $displayName: session.displayName,
         $createdAt: session.createdAt,
         $lastActivityAt: session.lastActivityAt,
-        $lastUserMessage: session.lastUserMessage,
+        $lastUserMessage: clampLastUserMessage(session.lastUserMessage),
         $currentWindow: session.currentWindow,
         $isPinned: session.isPinned ? 1 : 0,
         $lastResumeError: session.lastResumeError,
@@ -288,6 +315,8 @@ export function initDatabase(options: { path?: string } = {}): SessionDatabase {
         // Normalize boolean fields to 0/1 for SQLite
         if (key === 'isPinned' || key === 'isCodexExec') {
           params[`$${field}`] = value ? 1 : 0
+        } else if (key === 'lastUserMessage') {
+          params[`$${field}`] = clampLastUserMessage(value as string | null)
         } else {
           params[`$${field}`] = value as string | number | null
         }
@@ -365,6 +394,17 @@ export function initDatabase(options: { path?: string } = {}): SessionDatabase {
       }
       const rows = selectHistory.all() as Record<string, unknown>[]
       return rows.map(mapRow)
+    },
+    getKnownSessionKeys: () => {
+      const rows = selectKnownSessionKeys.all() as Record<string, unknown>[]
+      return rows.map((row) => ({
+        sessionId: row.session_id as string,
+        logFilePath: row.log_file_path as string,
+        projectPath: (row.project_path as string | null) ?? null,
+        slug: (row.slug as string | null) ?? null,
+        agentType: (row.agent_type as AgentType | null) ?? null,
+        isCodexExec: Boolean(row.is_codex_exec),
+      }))
     },
     orphanSession: (sessionId, options) => {
       const hibernate = options?.hibernate ?? true

--- a/src/server/logMatchWorkerClient.ts
+++ b/src/server/logMatchWorkerClient.ts
@@ -74,6 +74,12 @@ export class LogMatchWorkerClient {
       const timeoutId = setTimeout(() => {
         this.pending.delete(id)
         reject(new Error('Log match worker timed out'))
+        // A stalled worker keeps grinding its message queue and would swallow
+        // every subsequent request too, so fail anything queued behind this
+        // one and start fresh. The old worker is abandoned, not terminated —
+        // terminate() segfaults in compiled Bun binaries (see dispose()).
+        this.failAll(new Error('Log match worker restarted after stall'))
+        this.restartWorker()
       }, timeoutMs)
 
       this.pending.set(id, { resolve, reject, timeoutId })

--- a/src/server/logPoller.ts
+++ b/src/server/logPoller.ts
@@ -24,6 +24,16 @@ import type {
 const MIN_INTERVAL_MS = 2000
 const DEFAULT_INTERVAL_MS = 5000
 const DEFAULT_MAX_LOGS = 25
+// Poll cycles only need history sessions with recent activity: entry routing in
+// processMatchResponse resolves via getSessionByLogPath, and duplicate-insert
+// protection comes from knownSessions (loaded in full via getKnownSessionKeys).
+// Unbounded history loads dragged the entire table — including every stored
+// last_user_message — through the main thread on each cycle.
+const HISTORY_SNAPSHOT_MAX_AGE_HOURS = 72
+// The worker only inspects lastUserMessage to decide whether to re-extract it
+// from the log (presence + isToolNotificationText, both prefix-safe), so a
+// short prefix is enough — full texts made each postMessage clone ~100+ MB.
+const SNAPSHOT_MESSAGE_MAX_LENGTH = 2048
 const STARTUP_LAST_MESSAGE_BACKFILL_MAX = 100
 const MIN_LOG_TOKENS_FOR_INSERT = 1
 const REMATCH_COOLDOWN_MS = 60 * 1000 // 1 minute between re-match attempts
@@ -46,6 +56,13 @@ interface SessionRecord {
   wakeStartedAt: string | null
   lastKnownLogSize: number | null
   isCodexExec: boolean
+}
+
+function toSnapshotMessage(message: string | null): string | null {
+  if (message && message.length > SNAPSHOT_MESSAGE_MAX_LENGTH) {
+    return message.slice(0, SNAPSHOT_MESSAGE_MAX_LENGTH)
+  }
+  return message
 }
 
 // Fields that applyLogEntryToExistingRecord may update
@@ -336,7 +353,7 @@ export class LogPoller {
         logFilePath: session.logFilePath,
         currentWindow: session.currentWindow,
         lastActivityAt: session.lastActivityAt,
-        lastUserMessage: session.lastUserMessage,
+        lastUserMessage: toSnapshotMessage(session.lastUserMessage),
         lastKnownLogSize: null, // Force re-check for orphan matching
       }))
 
@@ -520,26 +537,19 @@ export class LogPoller {
       const sessionRecords = [
         ...this.db.getActiveSessions(),
         ...this.db.getHibernatingSessions(),
-        ...this.db.getHistorySessions(),
+        ...this.db.getHistorySessions({
+          maxAgeHours: HISTORY_SNAPSHOT_MAX_AGE_HOURS,
+        }),
       ]
       const sessions: SessionSnapshot[] = sessionRecords.map((session) => ({
         sessionId: session.sessionId,
         logFilePath: session.logFilePath,
         currentWindow: session.currentWindow,
         lastActivityAt: session.lastActivityAt,
-        lastUserMessage: session.lastUserMessage,
+        lastUserMessage: toSnapshotMessage(session.lastUserMessage),
         lastKnownLogSize: session.lastKnownLogSize,
       }))
-      const knownSessions: KnownSession[] = sessionRecords
-        .filter((session) => session.logFilePath)
-        .map((session) => ({
-          logFilePath: session.logFilePath,
-          sessionId: session.sessionId,
-          projectPath: session.projectPath ?? null,
-          slug: session.slug ?? null,
-          agentType: session.agentType ?? null,
-          isCodexExec: session.isCodexExec,
-        }))
+      const knownSessions: KnownSession[] = this.db.getKnownSessionKeys()
 
       const response = await this.matchWorker.poll({
         windows,
@@ -942,7 +952,9 @@ export class LogPoller {
       const sessionRecords = [
         ...this.db.getActiveSessions(),
         ...this.db.getHibernatingSessions(),
-        ...this.db.getHistorySessions(),
+        ...this.db.getHistorySessions({
+          maxAgeHours: HISTORY_SNAPSHOT_MAX_AGE_HOURS,
+        }),
       ]
       let shouldBackfillLastMessage = false
       if (this.startupLastMessageBackfillPending) {
@@ -960,19 +972,10 @@ export class LogPoller {
         logFilePath: session.logFilePath,
         currentWindow: session.currentWindow,
         lastActivityAt: session.lastActivityAt,
-        lastUserMessage: session.lastUserMessage,
+        lastUserMessage: toSnapshotMessage(session.lastUserMessage),
         lastKnownLogSize: session.lastKnownLogSize,
       }))
-      const knownSessions: KnownSession[] = sessionRecords
-        .filter((session) => session.logFilePath)
-        .map((session) => ({
-          logFilePath: session.logFilePath,
-          sessionId: session.sessionId,
-          projectPath: session.projectPath ?? null,
-          slug: session.slug ?? null,
-          agentType: session.agentType ?? null,
-          isCodexExec: session.isCodexExec,
-        }))
+      const knownSessions: KnownSession[] = this.db.getKnownSessionKeys()
 
       const lastMessageCandidates: LastMessageCandidate[] = []
       if (this.startupLastMessageBackfillPending) {


### PR DESCRIPTION
## Problem

Every poll cycle loaded ALL history sessions via `SELECT *` — including 147MB of stored `last_user_message` text in real-world databases — then structured-cloned the whole payload to the match worker. Under memory pressure this starved the event loop for minutes at a time, leaving the HTTP server accepting connections but never responding.

## Fix

- Bound poll-cycle history loads to 72h of activity; duplicate-insert protection now comes from `getKnownSessionKeys()`, a projection query that skips large TEXT columns entirely (worker only checks presence + `isToolNotificationText`, prefix-safe)
- Clamp `last_user_message` to 8KB on insert/update so the table cannot regrow unbounded
- Restart the match worker on poll timeout so a stalled worker stops swallowing queued requests

Also rides along: drop the stale `/.cachebro` gitignore entry (tool renamed to `.agentcache`; no references remain).

## Testing

`bun run lint && bun run typecheck && bun run test` clean after rebase onto master.