### PR TITLE
fix: recover missing tmux sockets without replacing server

### DIFF
--- a/launchd/README.md
+++ b/launchd/README.md
@@ -95,6 +95,14 @@ if tmux has-session -t "=$SESSION" 2>/dev/null; then
   exit 0
 fi
 
+# The server is reachable but only the managed base session is missing.
+# Restart Agentboard so ensureSession() recreates it; no socket repair signal
+# is needed.
+if tmux list-sessions >/dev/null 2>&1; then
+  launchctl kickstart -k "gui/$(id -u)/com.agentboard"
+  exit $?
+fi
+
 if read -r pid < "$PID_FILE" 2>/dev/null &&
    [[ "$pid" =~ ^[0-9]+$ ]] &&
    kill -0 "$pid" 2>/dev/null &&
@@ -104,6 +112,10 @@ if read -r pid < "$PID_FILE" 2>/dev/null &&
   if tmux has-session -t "=$SESSION" 2>/dev/null; then
     remember_server
     exit 0
+  fi
+  if tmux list-sessions >/dev/null 2>&1; then
+    launchctl kickstart -k "gui/$(id -u)/com.agentboard"
+    exit $?
   fi
   echo "Live tmux server $pid did not recreate its socket; refusing to replace it" >&2
   exit 1
@@ -150,3 +162,4 @@ Note: if you `tmux kill-session -t agentboard` while agentboard is loaded, the w
 - The wrapper script `cd`s into the repo directory before `bun run start`, matching the Linux systemd setup.
 - Override the log path via the `LOG_FILE` env var (respected by agentboard and the rotate script).
 - Override the tmux session name via `TMUX_SESSION` (respected by agentboard and the watchdog).
+- Set a distinct `AGENTBOARD_TMUX_PID_FILE` for each Agentboard instance that uses a separate tmux socket.

--- a/launchd/README.md
+++ b/launchd/README.md
@@ -77,8 +77,39 @@ cat > ~/.agentboard/bin/tmux-agentboard-watchdog.sh << 'EOF'
 #!/bin/bash
 export PATH="$(dirname "$(command -v tmux)"):/usr/local/bin:/usr/bin:/bin"
 SESSION="${TMUX_SESSION:-agentboard}"
-tmux has-session -t "$SESSION" 2>/dev/null || \
-  launchctl kickstart -k "gui/$(id -u)/com.agentboard"
+STATE_DIR="${AGENTBOARD_STATE_DIR:-$HOME/.agentboard}"
+PID_FILE="${AGENTBOARD_TMUX_PID_FILE:-$STATE_DIR/tmux-server.pid}"
+
+remember_server() {
+  local pid temp
+  pid="$(tmux display-message -p -t "=$SESSION" '#{pid}')" || return 1
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  mkdir -p "$STATE_DIR"
+  temp="$PID_FILE.$$.tmp"
+  (umask 077; printf '%s\n' "$pid" > "$temp")
+  mv "$temp" "$PID_FILE"
+}
+
+if tmux has-session -t "=$SESSION" 2>/dev/null; then
+  remember_server
+  exit 0
+fi
+
+if read -r pid < "$PID_FILE" 2>/dev/null &&
+   [[ "$pid" =~ ^[0-9]+$ ]] &&
+   kill -0 "$pid" 2>/dev/null &&
+   [[ "$(basename "$(ps -p "$pid" -o comm= 2>/dev/null)")" == tmux ]]; then
+  kill -USR1 "$pid"
+  sleep 0.2
+  if tmux has-session -t "=$SESSION" 2>/dev/null; then
+    remember_server
+    exit 0
+  fi
+  echo "Live tmux server $pid did not recreate its socket; refusing to replace it" >&2
+  exit 1
+fi
+
+launchctl kickstart -k "gui/$(id -u)/com.agentboard"
 EOF
 chmod +x ~/.agentboard/bin/tmux-agentboard-watchdog.sh
 ```
@@ -104,7 +135,12 @@ EOF
 launchctl load -w ~/Library/LaunchAgents/com.agentboard.tmux-watchdog.plist
 ```
 
-The watchdog checks `tmux has-session -t agentboard` every 30s. If the session is gone (server crashed, or session killed), it runs `launchctl kickstart -k gui/$(id -u)/com.agentboard` which triggers agentboard's startup path. `ensureSession()` recreates the base session; Hibernating sessions stay dormant and can be woken manually from the UI.
+The watchdog records the tmux server PID while the session is healthy. If the
+socket file disappears while that server is still alive, it sends `SIGUSR1` so
+tmux recreates the socket. It restarts Agentboard only when the recorded server
+is no longer running. This prevents a replacement tmux server from orphaning
+live panes behind an unlinked socket. `ensureSession()` applies the same
+fail-closed recovery during normal Agentboard refreshes.
 
 Note: if you `tmux kill-session -t agentboard` while agentboard is loaded, the watchdog will restore it within 30s. To stop cleanly, `launchctl unload ~/Library/LaunchAgents/com.agentboard.plist` first.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -44,6 +44,7 @@ mkdirSync(codexDir, { recursive: true })
 mkdirSync(piDir, { recursive: true })
 process.env.AGENTBOARD_DB_PATH = `${tmuxTmpDir}/agentboard.db`
 process.env.LOG_FILE = `${tmuxTmpDir}/agentboard.log`
+process.env.AGENTBOARD_TMUX_PID_FILE = `${tmuxTmpDir}/tmux-server.pid`
 process.env.CLAUDE_CONFIG_DIR = claudeDir
 process.env.CODEX_HOME = codexDir
 process.env.PI_HOME = piDir

--- a/src/server/SessionManager.ts
+++ b/src/server/SessionManager.ts
@@ -38,6 +38,9 @@ type TmuxRunner = (args: string[]) => string
 type NowFn = () => number
 type RecoverTmuxSocket = () => boolean
 type RememberTmuxServerPid = (pid: number) => void
+const TMUX_RECOVERY_SETTLE_MS = 200
+const TMUX_RECOVERY_SIGNAL_INTERVAL_MS = 30_000
+let lastTmuxRecoverySignal: { pid: number; sentAt: number } | null = null
 type GroupLookupResult =
   | { reliable: true; sessionName: string | null }
   | { reliable: false; sessionName: null }
@@ -157,7 +160,7 @@ export class SessionManager {
         throw error
       }
 
-      if (this.recoverTmuxSocket()) {
+      if (isTmuxConnectionError(error) && this.recoverTmuxSocket()) {
         try {
           this.runTmux(['has-session', '-t', `=${this.sessionName}`])
           this.configureSession()
@@ -911,8 +914,21 @@ function recoverPersistedTmuxSocket(): boolean {
     return false
   }
 
+  const now = Date.now()
+  if (
+    lastTmuxRecoverySignal?.pid === pid &&
+    now - lastTmuxRecoverySignal.sentAt < TMUX_RECOVERY_SIGNAL_INTERVAL_MS
+  ) {
+    return true
+  }
+
   try {
     process.kill(pid, 'SIGUSR1')
+    lastTmuxRecoverySignal = { pid, sentAt: now }
+    // tmux recreates a removed socket asynchronously after SIGUSR1. Give it
+    // the same short settle window used by the launchd watchdog before the
+    // caller probes the socket again.
+    Bun.sleepSync(TMUX_RECOVERY_SETTLE_MS)
     return true
   } catch {
     return false
@@ -952,15 +968,13 @@ function getTmuxCommand(args: string[]): string {
   return args[0] === '-u' ? args[1] ?? 'command' : args[0] ?? 'command'
 }
 
-function isTmuxSessionAbsentError(error: unknown): boolean {
+function isTmuxConnectionError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false
   }
 
   const message = error.message.toLowerCase()
   return (
-    message.includes("can't find session") ||
-    message.includes('session not found') ||
     message.includes('failed to connect to server') ||
     message.includes('no server running') ||
     (
@@ -970,6 +984,19 @@ function isTmuxSessionAbsentError(error: unknown): boolean {
         message.includes('connection refused')
       )
     )
+  )
+}
+
+function isTmuxSessionAbsentError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+
+  const message = error.message.toLowerCase()
+  return (
+    message.includes("can't find session") ||
+    message.includes('session not found') ||
+    isTmuxConnectionError(error)
   )
 }
 

--- a/src/server/SessionManager.ts
+++ b/src/server/SessionManager.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import path from 'node:path'
 import { inferAgentType, normalizePaneStartCommand } from './agentDetection'
 import { config } from './config'
 import { resolveExternalDisplayName } from './displayName'
@@ -34,6 +35,8 @@ interface WindowInfo {
 
 type TmuxRunner = (args: string[]) => string
 type NowFn = () => number
+type RecoverTmuxSocket = () => boolean
+type RememberTmuxServerPid = (pid: number) => void
 type GroupLookupResult =
   | { reliable: true; sessionName: string | null }
   | { reliable: false; sessionName: null }
@@ -95,6 +98,8 @@ export class SessionManager {
   private now: NowFn
   private displayNameExists: (name: string, excludeSessionId?: string) => boolean
   private mouseMode: boolean
+  private recoverTmuxSocket: RecoverTmuxSocket
+  private rememberTmuxServerPid: RememberTmuxServerPid
 
   constructor(
     sessionName = config.tmuxSession,
@@ -104,12 +109,16 @@ export class SessionManager {
       now,
       displayNameExists,
       mouseMode = true,
+      recoverTmuxSocket: recoverTmuxSocketOverride,
+      rememberTmuxServerPid: rememberTmuxServerPidOverride,
     }: {
       runTmux?: TmuxRunner
       capturePaneContent?: CapturePane
       now?: NowFn
       displayNameExists?: (name: string, excludeSessionId?: string) => boolean
       mouseMode?: boolean
+      recoverTmuxSocket?: RecoverTmuxSocket
+      rememberTmuxServerPid?: RememberTmuxServerPid
     } = {}
   ) {
     this.sessionName = sessionName
@@ -118,6 +127,14 @@ export class SessionManager {
     this.now = now ?? Date.now
     this.displayNameExists = displayNameExists ?? (() => false)
     this.mouseMode = mouseMode
+    // A custom runner normally represents an isolated unit-test tmux model.
+    // Do not let those tests inspect or signal the machine's real tmux server.
+    this.recoverTmuxSocket =
+      recoverTmuxSocketOverride ??
+      (runTmuxOverride ? () => false : recoverPersistedTmuxSocket)
+    this.rememberTmuxServerPid =
+      rememberTmuxServerPidOverride ??
+      (runTmuxOverride ? () => {} : persistTmuxServerPid)
   }
 
   ensureSession(): EnsureSessionResult {
@@ -135,6 +152,44 @@ export class SessionManager {
       if (error instanceof TmuxTimeoutError) {
         throw error
       }
+      if (!isTmuxSessionAbsentError(error)) {
+        throw error
+      }
+
+      if (this.recoverTmuxSocket()) {
+        try {
+          this.runTmux(['has-session', '-t', `=${this.sessionName}`])
+          this.configureSession()
+          this.recordTmuxServerPid()
+          return { canPruneWsSessions }
+        } catch (retryError) {
+          if (retryError instanceof TmuxTimeoutError) {
+            throw retryError
+          }
+          if (!isTmuxSessionAbsentError(retryError)) {
+            throw retryError
+          }
+
+          // The session itself may have been removed while other sessions on
+          // the same server survived. Prove that the recovered server is
+          // reachable before allowing new-session to run. Otherwise a missing
+          // socket would make tmux start a second server and orphan live panes.
+          try {
+            this.runParsedTmux(['list-sessions', '-F', '#{session_name}'])
+          } catch (probeError) {
+            if (probeError instanceof TmuxTimeoutError) {
+              throw probeError
+            }
+            if (isTmuxSessionAbsentError(probeError)) {
+              throw new Error(
+                'A live tmux server did not recreate its socket; refusing to start a replacement server'
+              )
+            }
+            throw probeError
+          }
+        }
+      }
+
       const groupLookup = this.findSessionInGroup()
       if (groupLookup.sessionName) {
         this.runTmux([
@@ -157,7 +212,28 @@ export class SessionManager {
       }
     }
     this.configureSession()
+    this.recordTmuxServerPid()
     return { canPruneWsSessions }
+  }
+
+  private recordTmuxServerPid(): void {
+    try {
+      const rawPid = this.runParsedTmux([
+        'display-message',
+        '-p',
+        '-t',
+        `=${this.sessionName}`,
+        '#{pid}',
+      ]).trim()
+      const pid = Number.parseInt(rawPid, 10)
+      if (Number.isSafeInteger(pid) && pid > 1) {
+        this.rememberTmuxServerPid(pid)
+      }
+    } catch (error) {
+      logger.warn('tmux_server_pid_record_failed', {
+        message: error instanceof Error ? error.message : String(error),
+      })
+    }
   }
 
   private findSessionInGroup(): GroupLookupResult {
@@ -768,6 +844,63 @@ function runTmux(args: string[]): string {
   }
 
   return result.stdout.toString()
+}
+
+function persistTmuxServerPid(pid: number): void {
+  const pidFile = config.tmuxServerPidFile
+  const directory = path.dirname(pidFile)
+  const temporaryFile = `${pidFile}.${process.pid}.tmp`
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 })
+
+  if (readPersistedTmuxServerPid(pidFile) === pid) {
+    return
+  }
+
+  fs.writeFileSync(temporaryFile, `${pid}\n`, { mode: 0o600 })
+  fs.renameSync(temporaryFile, pidFile)
+}
+
+function recoverPersistedTmuxSocket(): boolean {
+  const pid = readPersistedTmuxServerPid(config.tmuxServerPidFile)
+  if (pid === null || !isTmuxServerProcess(pid)) {
+    return false
+  }
+
+  try {
+    process.kill(pid, 'SIGUSR1')
+    return true
+  } catch {
+    return false
+  }
+}
+
+function readPersistedTmuxServerPid(pidFile: string): number | null {
+  try {
+    const pid = Number.parseInt(fs.readFileSync(pidFile, 'utf8').trim(), 10)
+    return Number.isSafeInteger(pid) && pid > 1 ? pid : null
+  } catch {
+    return null
+  }
+}
+
+function isTmuxServerProcess(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+  } catch {
+    return false
+  }
+
+  const result = Bun.spawnSync(['ps', '-p', String(pid), '-o', 'comm='], {
+    stdout: 'pipe',
+    stderr: 'ignore',
+    timeout: config.tmuxTimeoutMs,
+  })
+  if (result.exitCode !== 0) {
+    return false
+  }
+
+  const command = path.basename(result.stdout.toString().trim())
+  return command === 'tmux' || command.startsWith('tmux:')
 }
 
 function getTmuxCommand(args: string[]): string {

--- a/src/server/__tests__/sessionManager.test.ts
+++ b/src/server/__tests__/sessionManager.test.ts
@@ -2008,6 +2008,31 @@ describe('SessionManager', () => {
     expect(rememberedPids).toEqual([4242])
   })
 
+  test('ensureSession does not signal socket recovery when only the session is missing', () => {
+    const sessionName = 'agentboard-session-missing'
+    const calls: string[][] = []
+    let recoveryAttempts = 0
+    const manager = new SessionManager(sessionName, {
+      runTmux: (args) => {
+        const normalized = normalizeParsedTmuxArgs(args)
+        calls.push(normalized)
+        if (normalized[0] === 'has-session') {
+          throw new Error(`can't find session: ${sessionName}`)
+        }
+        return ''
+      },
+      capturePaneContent: () => makePaneCapture(''),
+      recoverTmuxSocket: () => {
+        recoveryAttempts += 1
+        return true
+      },
+    })
+
+    expect(manager.ensureSession()).toEqual({ canPruneWsSessions: true })
+    expect(recoveryAttempts).toBe(0)
+    expect(calls.some((call) => call[0] === 'new-session')).toBe(true)
+  })
+
   test('ensureSession refuses a replacement when live-server socket recovery fails', () => {
     const calls: string[][] = []
     const manager = new SessionManager('agentboard-recovery-failed', {

--- a/src/server/__tests__/sessionManager.test.ts
+++ b/src/server/__tests__/sessionManager.test.ts
@@ -1976,6 +1976,56 @@ describe('SessionManager', () => {
     expect(sessions.find((session) => session.name === 'alpha')).toBeTruthy()
   })
 
+  test('ensureSession recovers a missing socket before creating a replacement server', () => {
+    const sessionName = 'agentboard-recover-socket'
+    let socketReachable = false
+    const calls: string[][] = []
+    const rememberedPids: number[] = []
+    const runTmux = (args: string[]) => {
+      const normalized = normalizeParsedTmuxArgs(args)
+      calls.push(normalized)
+      if (normalized[0] === 'has-session') {
+        if (!socketReachable) throw new Error('no server running')
+        return ''
+      }
+      if (normalized[0] === 'display-message') return '4242\n'
+      return ''
+    }
+
+    const manager = new SessionManager(sessionName, {
+      runTmux,
+      capturePaneContent: () => makePaneCapture(''),
+      recoverTmuxSocket: () => {
+        socketReachable = true
+        return true
+      },
+      rememberTmuxServerPid: (pid) => rememberedPids.push(pid),
+    })
+
+    expect(manager.ensureSession()).toEqual({ canPruneWsSessions: true })
+    expect(calls.filter((call) => call[0] === 'has-session')).toHaveLength(2)
+    expect(calls.some((call) => call[0] === 'new-session')).toBe(false)
+    expect(rememberedPids).toEqual([4242])
+  })
+
+  test('ensureSession refuses a replacement when live-server socket recovery fails', () => {
+    const calls: string[][] = []
+    const manager = new SessionManager('agentboard-recovery-failed', {
+      runTmux: (args) => {
+        const normalized = normalizeParsedTmuxArgs(args)
+        calls.push(normalized)
+        throw new Error('no server running')
+      },
+      capturePaneContent: () => makePaneCapture(''),
+      recoverTmuxSocket: () => true,
+    })
+
+    expect(() => manager.ensureSession()).toThrow(
+      'A live tmux server did not recreate its socket; refusing to start a replacement server'
+    )
+    expect(calls.some((call) => call[0] === 'new-session')).toBe(false)
+  })
+
   test('ensureSession does not rejoin unrelated sessions with matching prefixes', () => {
     const sessionName = 'agentboard-prefix'
     const unrelatedSession = `${sessionName}-work`

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -82,8 +82,12 @@ const logLevelRaw = process.env.LOG_LEVEL?.toLowerCase()
 const logLevel = ['debug', 'info', 'warn', 'error'].includes(logLevelRaw || '')
   ? (logLevelRaw as 'debug' | 'info' | 'warn' | 'error')
   : 'info'
-const defaultLogFile = path.join(homeDir, '.agentboard', 'agentboard.log')
+const defaultDataDir = path.join(homeDir, '.agentboard')
+const defaultLogFile = path.join(defaultDataDir, 'agentboard.log')
 const logFile = process.env.LOG_FILE ?? defaultLogFile
+const tmuxServerPidFile =
+  process.env.AGENTBOARD_TMUX_PID_FILE ||
+  path.join(defaultDataDir, 'tmux-server.pid')
 
 const claudeConfigDir =
   process.env.CLAUDE_CONFIG_DIR || path.join(homeDir, '.claude')
@@ -212,6 +216,7 @@ export const config = {
   skipMatchingPatterns,
   logLevel,
   logFile,
+  tmuxServerPidFile,
   remoteHosts,
   remotePollMs,
   remoteTimeoutMs,


### PR DESCRIPTION
## What changed

- Persist the tmux server PID and ask a surviving server to recreate a missing socket with SIGUSR1.
- Refuse to bootstrap a replacement when the prior server is still alive but unreachable.
- Signal only for socket/connection failures, allow tmux a settle window, and rate-limit retries.
- Harden the launchd watchdog and document the recovery behavior.
- Isolate the recovery PID file in E2E runs.
- Bump the patch version to 0.4.12.

## Why

A missing tmux socket made Agentboard treat a live server as dead. The watchdog restarted Agentboard, which created a new server at the same socket path and hid every pane owned by the original server.

## Impact

Agentboard now reconnects to the existing server and preserves live panes and unsent terminal input instead of silently orphaning them.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test` (751 unit tests plus isolated integration suites)
- `bun run build`
- `bun run test:e2e` (3 passed with private tmux, DB, logs, and PID file)
- independent read-only Claude review; addressed E2E PID cross-contamination, socket settle timing, unnecessary signals, and retry spam
- isolated missing-socket reproduction from the original PR confirmed the recovered server PID was unchanged