### PR TITLE
feat: add global terminal colors setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/__tests__/renderComponents.test.tsx
+++ b/src/client/__tests__/renderComponents.test.tsx
@@ -456,6 +456,7 @@ describe('component rendering', () => {
       <SettingsModal isOpen onClose={() => {}} />
     )
     expect(html).toContain('Settings')
+    expect(html).toContain('Terminal Colors')
   })
 
   test('renders controls widgets', () => {

--- a/src/client/__tests__/settingsModal.test.tsx
+++ b/src/client/__tests__/settingsModal.test.tsx
@@ -72,6 +72,63 @@ afterEach(() => {
 })
 
 describe('SettingsModal', () => {
+  test('keeps terminal colors disabled until the initial setting loads', async () => {
+    const originalFetch = globalThis.fetch
+    let resolveTerminalColors!: (response: Response) => void
+    const terminalColorsResponse = new Promise<Response>((resolve) => {
+      resolveTerminalColors = resolve
+    })
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === '/api/settings/terminal-colors') {
+        return terminalColorsResponse
+      }
+      const payload = url.includes('history-max-age-hours')
+        ? { hours: 24 }
+        : { enabled: true }
+      return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    let renderer!: TestRenderer.ReactTestRenderer
+    try {
+      await act(async () => {
+        renderer = TestRenderer.create(
+          <SettingsModal isOpen onClose={() => {}} />
+        )
+        await Promise.resolve()
+      })
+
+      const findColorSwitch = () => {
+        const colorSwitch = renderer.root
+          .findAllByType(Switch)
+          .find((component) => component.props.ariaLabel === 'Enable terminal colors')
+        if (!colorSwitch) throw new Error('Expected terminal colors switch')
+        return colorSwitch
+      }
+
+      expect(findColorSwitch().props.disabled).toBe(true)
+
+      await act(async () => {
+        resolveTerminalColors(new Response(JSON.stringify({ enabled: false }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }))
+        await terminalColorsResponse
+        await Promise.resolve()
+      })
+
+      expect(findColorSwitch().props.checked).toBe(false)
+      expect(findColorSwitch().props.disabled).toBe(false)
+    } finally {
+      renderer?.unmount()
+      globalThis.fetch = originalFetch
+    }
+  })
+
   test('loads and updates the global terminal colors setting', async () => {
     const originalFetch = globalThis.fetch
     const requests: Array<{ url: string; method: string; body: string | null }> = []

--- a/src/client/__tests__/settingsModal.test.tsx
+++ b/src/client/__tests__/settingsModal.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import TestRenderer, { act } from 'react-test-renderer'
 import SettingsModal from '../components/SettingsModal'
+import { Switch } from '../components/Switch'
 import {
   DEFAULT_PRESETS,
   DEFAULT_PROJECT_DIR,
@@ -71,6 +72,59 @@ afterEach(() => {
 })
 
 describe('SettingsModal', () => {
+  test('loads and updates the global terminal colors setting', async () => {
+    const originalFetch = globalThis.fetch
+    const requests: Array<{ url: string; method: string; body: string | null }> = []
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+      requests.push({
+        url,
+        method,
+        body: typeof init?.body === 'string' ? init.body : null,
+      })
+      const payload = url.includes('history-max-age-hours')
+        ? { hours: 24 }
+        : { enabled: true }
+      return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    let renderer!: TestRenderer.ReactTestRenderer
+    try {
+      await act(async () => {
+        renderer = TestRenderer.create(
+          <SettingsModal isOpen onClose={() => {}} />
+        )
+        await Promise.resolve()
+      })
+
+      const colorSwitch = renderer.root
+        .findAllByType(Switch)
+        .find((component) => component.props.ariaLabel === 'Enable terminal colors')
+      if (!colorSwitch) {
+        throw new Error('Expected terminal colors switch')
+      }
+      expect(colorSwitch.props.checked).toBe(true)
+
+      await act(async () => {
+        colorSwitch.props.onCheckedChange(false)
+        await Promise.resolve()
+      })
+
+      expect(requests).toContainEqual({
+        url: '/api/settings/terminal-colors',
+        method: 'PUT',
+        body: JSON.stringify({ enabled: false }),
+      })
+    } finally {
+      renderer?.unmount()
+      globalThis.fetch = originalFetch
+    }
+  })
+
   test('submits trimmed values and falls back to defaults', () => {
     let closed = 0
     let renderer!: TestRenderer.ReactTestRenderer

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -117,6 +117,8 @@ export default function SettingsModal({
   // Server-side settings (fetched from API)
   const [tmuxMouseMode, setTmuxMouseMode] = useState(true)
   const [tmuxMouseModeLoading, setTmuxMouseModeLoading] = useState(false)
+  const [terminalColors, setTerminalColors] = useState(true)
+  const [terminalColorsLoading, setTerminalColorsLoading] = useState(false)
   const [preferWindowName, setPreferWindowName] = useState(false)
   const [preferWindowNameLoading, setPreferWindowNameLoading] = useState(false)
   const [historyMaxAgeHours, setHistoryMaxAgeHours] = useState(24)
@@ -162,6 +164,10 @@ export default function SettingsModal({
       fetch('/api/settings/tmux-mouse-mode')
         .then((res) => res.json())
         .then((data: { enabled: boolean }) => setTmuxMouseMode(data.enabled))
+        .catch(() => {})
+      fetch('/api/settings/terminal-colors')
+        .then((res) => res.json())
+        .then((data: { enabled: boolean }) => setTerminalColors(data.enabled))
         .catch(() => {})
       fetch('/api/settings/history-max-age-hours')
         .then((res) => res.json())
@@ -336,6 +342,21 @@ export default function SettingsModal({
       })
       .catch(() => setPreferWindowName(!enabled)) // Revert on error
       .finally(() => setPreferWindowNameLoading(false))
+  }
+
+  const handleTerminalColorsChange = (enabled: boolean) => {
+    setTerminalColorsLoading(true)
+    setTerminalColors(enabled)
+    fetch('/api/settings/terminal-colors', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled }),
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      })
+      .catch(() => setTerminalColors(!enabled))
+      .finally(() => setTerminalColorsLoading(false))
   }
 
   const handleHistoryMaxAgeHoursChange = (hours: number) => {
@@ -736,6 +757,22 @@ export default function SettingsModal({
                 checked={tmuxMouseMode}
                 onCheckedChange={handleTmuxMouseModeChange}
                 disabled={tmuxMouseModeLoading}
+              />
+            </div>
+
+            <div className="mt-4 flex items-center justify-between gap-4">
+              <div>
+                <div className="text-sm text-primary">Terminal Colors</div>
+                <div className="text-[10px] text-muted">
+                  Preserve ANSI colors and remove NO_COLOR for newly started sessions.
+                  Restart running agents after changing this setting.
+                </div>
+              </div>
+              <Switch
+                checked={terminalColors}
+                onCheckedChange={handleTerminalColorsChange}
+                disabled={terminalColorsLoading}
+                ariaLabel="Enable terminal colors"
               />
             </div>
 

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -118,7 +118,7 @@ export default function SettingsModal({
   const [tmuxMouseMode, setTmuxMouseMode] = useState(true)
   const [tmuxMouseModeLoading, setTmuxMouseModeLoading] = useState(false)
   const [terminalColors, setTerminalColors] = useState(true)
-  const [terminalColorsLoading, setTerminalColorsLoading] = useState(false)
+  const [terminalColorsLoading, setTerminalColorsLoading] = useState(true)
   const [preferWindowName, setPreferWindowName] = useState(false)
   const [preferWindowNameLoading, setPreferWindowNameLoading] = useState(false)
   const [historyMaxAgeHours, setHistoryMaxAgeHours] = useState(24)
@@ -130,8 +130,10 @@ export default function SettingsModal({
   const [newCommand, setNewCommand] = useState('')
   const [newAgentType, setNewAgentType] = useState<'claude' | 'codex' | ''>('')
   const reenableTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const terminalColorsLoadIdRef = useRef(0)
 
   useEffect(() => {
+    const terminalColorsLoadId = ++terminalColorsLoadIdRef.current
     if (reenableTimeoutRef.current) {
       clearTimeout(reenableTimeoutRef.current)
       reenableTimeoutRef.current = null
@@ -165,10 +167,23 @@ export default function SettingsModal({
         .then((res) => res.json())
         .then((data: { enabled: boolean }) => setTmuxMouseMode(data.enabled))
         .catch(() => {})
+      setTerminalColorsLoading(true)
       fetch('/api/settings/terminal-colors')
-        .then((res) => res.json())
-        .then((data: { enabled: boolean }) => setTerminalColors(data.enabled))
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`)
+          return res.json()
+        })
+        .then((data: { enabled: boolean }) => {
+          if (terminalColorsLoadIdRef.current === terminalColorsLoadId) {
+            setTerminalColors(data.enabled)
+          }
+        })
         .catch(() => {})
+        .finally(() => {
+          if (terminalColorsLoadIdRef.current === terminalColorsLoadId) {
+            setTerminalColorsLoading(false)
+          }
+        })
       fetch('/api/settings/history-max-age-hours')
         .then((res) => res.json())
         .then((data: { hours: number }) => setHistoryMaxAgeHours(data.hours))

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -764,8 +764,8 @@ export default function SettingsModal({
               <div>
                 <div className="text-sm text-primary">Terminal Colors</div>
                 <div className="text-[10px] text-muted">
-                  Preserve ANSI colors for terminal output. Applies to agents started after
-                  changing this setting.
+                  Preserve ANSI colors for terminal output. Hibernate then Wake running agents
+                  after changing this setting.
                 </div>
               </div>
               <Switch

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -764,8 +764,8 @@ export default function SettingsModal({
               <div>
                 <div className="text-sm text-primary">Terminal Colors</div>
                 <div className="text-[10px] text-muted">
-                  Preserve ANSI colors and remove NO_COLOR for newly started sessions.
-                  Restart running agents after changing this setting.
+                  Preserve ANSI colors for terminal output. Applies to agents started after
+                  changing this setting.
                 </div>
               </div>
               <Switch

--- a/src/client/components/Switch.tsx
+++ b/src/client/components/Switch.tsx
@@ -6,6 +6,7 @@ interface SwitchProps {
   onCheckedChange: (checked: boolean) => void
   disabled?: boolean
   className?: string
+  ariaLabel?: string
 }
 
 /**
@@ -17,12 +18,14 @@ export function Switch({
   onCheckedChange,
   disabled,
   className,
+  ariaLabel,
 }: SwitchProps) {
   return (
     <BaseSwitch.Root
       checked={checked}
       onCheckedChange={onCheckedChange}
       disabled={disabled}
+      aria-label={ariaLabel}
       className={cn(
         'group relative inline-flex h-6 w-10 shrink-0 cursor-pointer items-center rounded-full transition-colors',
         'bg-border data-[checked]:bg-accent',

--- a/src/server/SessionManager.ts
+++ b/src/server/SessionManager.ts
@@ -85,6 +85,7 @@ const TMUX_MUTATION_COMMANDS = new Set([
   'new-window',
   'kill-window',
   'rename-window',
+  'set-environment',
   'set-option',
 ])
 
@@ -95,6 +96,7 @@ export class SessionManager {
   private now: NowFn
   private displayNameExists: (name: string, excludeSessionId?: string) => boolean
   private mouseMode: boolean
+  private terminalColorsEnabled: boolean
 
   constructor(
     sessionName = config.tmuxSession,
@@ -104,12 +106,14 @@ export class SessionManager {
       now,
       displayNameExists,
       mouseMode = true,
+      terminalColorsEnabled = config.terminalColorsEnabled ?? true,
     }: {
       runTmux?: TmuxRunner
       capturePaneContent?: CapturePane
       now?: NowFn
       displayNameExists?: (name: string, excludeSessionId?: string) => boolean
       mouseMode?: boolean
+      terminalColorsEnabled?: boolean
     } = {}
   ) {
     this.sessionName = sessionName
@@ -118,6 +122,7 @@ export class SessionManager {
     this.now = now ?? Date.now
     this.displayNameExists = displayNameExists ?? (() => false)
     this.mouseMode = mouseMode
+    this.terminalColorsEnabled = terminalColorsEnabled
   }
 
   ensureSession(): EnsureSessionResult {
@@ -209,6 +214,7 @@ export class SessionManager {
     // Note: PtyTerminalProxy copies this setting onto grouped client sessions.
     const mouseValue = this.mouseMode ? 'on' : 'off'
     this.applyMouseMode(this.sessionName, mouseValue)
+    this.applyTerminalColors(this.sessionName, this.terminalColorsEnabled)
   }
 
   setMouseMode(enabled: boolean): void {
@@ -280,6 +286,32 @@ export class SessionManager {
 
   private applyMouseMode(target: string, mouseValue: string): void {
     this.runTmux(['set-option', '-t', target, 'mouse', mouseValue])
+  }
+
+  setTerminalColors(enabled: boolean): void {
+    try {
+      this.applyTerminalColors(this.sessionName, enabled)
+    } catch (error) {
+      if (error instanceof TmuxTimeoutError) {
+        throw error
+      }
+      if (!isTmuxSessionAbsentError(error)) {
+        throw error
+      }
+      // Session doesn't exist yet; configureSession applies the value when it
+      // is created.
+    }
+    this.terminalColorsEnabled = enabled
+  }
+
+  private applyTerminalColors(target: string, enabled: boolean): void {
+    if (enabled) {
+      // -r marks NO_COLOR for removal from future pane processes even when it
+      // exists in tmux's global environment.
+      this.runTmux(['set-environment', '-r', '-t', target, 'NO_COLOR'])
+      return
+    }
+    this.runTmux(['set-environment', '-t', target, 'NO_COLOR', '1'])
   }
 
   private rollbackMouseMode(

--- a/src/server/SessionManager.ts
+++ b/src/server/SessionManager.ts
@@ -548,12 +548,19 @@ export class SessionManager {
     // mouse features work in the browser terminal. tmux `-e` sets the pane env
     // (tmux >= 3.0); the launched command inherits it. Harmless for non-Claude commands.
     const noFlickerEnv = config.claudeNoFlicker ? ['-e', 'CLAUDE_CODE_NO_FLICKER=1'] : []
+    // Apply the color preference to the pane creation itself. In the missing-session
+    // path the agent starts before configureSession() can update the session environment.
+    const terminalColorEnv = [
+      '-e',
+      `NO_COLOR=${this.terminalColorsEnabled ? '' : '1'}`,
+    ]
 
     if (!sessionExisted) {
       // Create session + window in one step to avoid orphan shell window
       this.runTmux([
         'new-session', '-d',
         ...noFlickerEnv,
+        ...terminalColorEnv,
         '-s', this.sessionName,
         '-n', finalName,
         '-c', resolvedPath,
@@ -565,6 +572,7 @@ export class SessionManager {
       this.runTmux([
         'new-window',
         ...noFlickerEnv,
+        ...terminalColorEnv,
         '-t', `${this.sessionName}:${nextIndex}`,
         '-n', finalName,
         '-c', resolvedPath,

--- a/src/server/__tests__/config.test.ts
+++ b/src/server/__tests__/config.test.ts
@@ -60,6 +60,7 @@ async function loadConfig(tag: string) {
     pruneWsSessions: boolean
     terminalMode: string
     terminalMonitorTargets: boolean
+    terminalColorsEnabled: boolean
     tlsCert: string
     tlsKey: string
     logPollIntervalMs: number
@@ -105,6 +106,7 @@ describe('config', () => {
     expect(config.pruneWsSessions).toBe(true)
     expect(config.terminalMode).toBe('pty')
     expect(config.terminalMonitorTargets).toBe(true)
+    expect(config.terminalColorsEnabled).toBe(true)
     expect(config.tlsCert).toBe('')
     expect(config.tlsKey).toBe('')
     expect(config.logPollIntervalMs).toBe(5000)

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -64,6 +64,7 @@ const defaultConfig = {
   pruneWsSessions: true,
   terminalMode: 'pty',
   terminalMonitorTargets: true,
+  terminalColorsEnabled: true,
   tlsCert: '',
   tlsKey: '',
   rgThreads: 1,
@@ -142,6 +143,7 @@ let sessionManagerState: {
   killWindow: (tmuxWindow: string) => void
   renameWindow: (tmuxWindow: string, newName: string) => void
   setMouseMode: (enabled: boolean) => void
+  setTerminalColors: (enabled: boolean) => void
   ensureSession: () => { canPruneWsSessions: boolean }
 }
 
@@ -169,6 +171,10 @@ class SessionManagerMock {
 
   setMouseMode(enabled: boolean) {
     sessionManagerState.setMouseMode(enabled)
+  }
+
+  setTerminalColors(enabled: boolean) {
+    sessionManagerState.setTerminalColors(enabled)
   }
 
   ensureSession() {
@@ -635,6 +641,7 @@ beforeEach(() => {
     killWindow: () => {},
     renameWindow: () => {},
     setMouseMode: () => {},
+    setTerminalColors: () => {},
     ensureSession: () => ({ canPruneWsSessions: true }),
   }
 
@@ -2914,6 +2921,7 @@ describe('server message handlers', () => {
     expect(attached.switchTargets).toEqual(['agentboard'])
     expect(captureTarget).toBe(groupedTarget)
     expect(captureArgs[0]).toBe('capture-pane')
+    expect(captureArgs).toContain('-e')
     expect(captureOptions?.timeout).toBe(configState.tmuxTimeoutMs)
     const historyIndex = sent.findIndex(
       (message) =>
@@ -4772,6 +4780,113 @@ describe('server fetch handlers', () => {
     expect(await response.json()).toEqual({
       error: 'Unable to persist tmux mouse mode',
     })
+    expect(dbState.setAppSettingCalls).toEqual([])
+  })
+
+  test('terminal colors setting applies globally and persists', async () => {
+    const appliedValues: boolean[] = []
+    sessionManagerState.setTerminalColors = (enabled: boolean) => {
+      appliedValues.push(enabled)
+    }
+
+    const { serveOptions } = await loadIndex()
+    const fetchHandler = serveOptions.fetch
+    if (!fetchHandler) {
+      throw new Error('Fetch handler not configured')
+    }
+
+    const putResponse = await fetchHandler.call(
+      {} as Bun.Server<unknown>,
+      new Request('http://localhost/api/settings/terminal-colors', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: false }),
+      }),
+      {} as Bun.Server<unknown>
+    )
+
+    if (!putResponse) {
+      throw new Error('Expected response for terminal colors request')
+    }
+
+    expect(putResponse.status).toBe(200)
+    expect(await putResponse.json()).toEqual({ enabled: false })
+    expect(appliedValues).toEqual([false])
+    expect(configState.terminalColorsEnabled).toBe(false)
+    expect(dbState.setAppSettingCalls).toEqual([
+      { key: 'terminal_colors_enabled', value: 'false' },
+    ])
+
+    const getResponse = await fetchHandler.call(
+      {} as Bun.Server<unknown>,
+      new Request('http://localhost/api/settings/terminal-colors'),
+      {} as Bun.Server<unknown>
+    )
+    if (!getResponse) {
+      throw new Error('Expected response for terminal colors request')
+    }
+    expect(await getResponse.json()).toEqual({ enabled: false })
+  })
+
+  test('terminal colors persistence failure rolls back runtime state', async () => {
+    dbState.setAppSettingError = new Error('db unavailable')
+    const appliedValues: boolean[] = []
+    sessionManagerState.setTerminalColors = (enabled: boolean) => {
+      appliedValues.push(enabled)
+    }
+
+    const { serveOptions } = await loadIndex()
+    const fetchHandler = serveOptions.fetch
+    if (!fetchHandler) {
+      throw new Error('Fetch handler not configured')
+    }
+
+    const response = await fetchHandler.call(
+      {} as Bun.Server<unknown>,
+      new Request('http://localhost/api/settings/terminal-colors', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: false }),
+      }),
+      {} as Bun.Server<unknown>
+    )
+
+    if (!response) {
+      throw new Error('Expected response for terminal colors request')
+    }
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toEqual({
+      error: 'Unable to persist terminal colors',
+    })
+    expect(appliedValues).toEqual([false, true])
+    expect(configState.terminalColorsEnabled).toBe(true)
+    expect(dbState.setAppSettingCalls).toEqual([])
+  })
+
+  test('terminal colors rejects non-boolean values', async () => {
+    const { serveOptions } = await loadIndex()
+    const fetchHandler = serveOptions.fetch
+    if (!fetchHandler) {
+      throw new Error('Fetch handler not configured')
+    }
+
+    const response = await fetchHandler.call(
+      {} as Bun.Server<unknown>,
+      new Request('http://localhost/api/settings/terminal-colors', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: 'yes' }),
+      }),
+      {} as Bun.Server<unknown>
+    )
+
+    if (!response) {
+      throw new Error('Expected response for terminal colors request')
+    }
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'enabled must be a boolean' })
     expect(dbState.setAppSettingCalls).toEqual([])
   })
 

--- a/src/server/__tests__/sessionManager.test.ts
+++ b/src/server/__tests__/sessionManager.test.ts
@@ -1531,6 +1531,39 @@ describe('SessionManager', () => {
     fs.rmSync(tempDir, { recursive: true, force: true })
   })
 
+  test('createWindow applies terminal colors before the first agent starts', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentboard-'))
+
+    try {
+      for (const { enabled, expected } of [
+        { enabled: true, expected: 'NO_COLOR=' },
+        { enabled: false, expected: 'NO_COLOR=1' },
+      ]) {
+        const sessionName = `agentboard-first-colors-${enabled}`
+        const runner = createTmuxRunner([], 0)
+        const manager = new SessionManager(sessionName, {
+          runTmux: runner.runTmux,
+          capturePaneContent: () => makePaneCapture(''),
+          now: () => 1700000000000,
+          terminalColorsEnabled: enabled,
+        })
+
+        manager.createWindow(tempDir, `colors-${enabled}`, 'claude')
+
+        const newSessionCall = runner.calls.find(
+          (call) => getTmuxCommand(call) === 'new-session'
+        )
+        if (!newSessionCall) throw new Error('expected a new-session call')
+        expect(newSessionCall).toContain(expected)
+        expect(newSessionCall.indexOf(expected)).toBeLessThan(
+          newSessionCall.indexOf('claude')
+        )
+      }
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
   test('createWindow injects CLAUDE_CODE_NO_FLICKER=1 via tmux -e (fullscreen default)', () => {
     const sessionName = 'agentboard-noflicker'
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agentboard-'))

--- a/src/server/__tests__/sessionManager.test.ts
+++ b/src/server/__tests__/sessionManager.test.ts
@@ -264,6 +264,10 @@ function createTmuxRunner(sessions: SessionState[], baseIndex = 0) {
       return ''
     }
 
+    if (command === 'set-environment') {
+      return ''
+    }
+
     throw new Error(`Unhandled tmux command: ${args.join(' ')}`)
   }
 
@@ -864,7 +868,7 @@ describe('SessionManager', () => {
         ].join('\n')
       }
 
-      if (command === 'set-option') {
+      if (command === 'set-option' || command === 'set-environment') {
         return ''
       }
 
@@ -1699,6 +1703,41 @@ describe('SessionManager', () => {
     expect(mouseSetCalls.some((call) => call.includes('other-session'))).toBe(
       false
     )
+  })
+
+  test('terminal color setting controls NO_COLOR for future pane processes', () => {
+    const sessionName = 'agentboard-terminal-colors'
+    const runner = createTmuxRunner(
+      [{ name: sessionName, windows: [] }],
+      1
+    )
+
+    const manager = new SessionManager(sessionName, {
+      runTmux: runner.runTmux,
+      capturePaneContent: () => null,
+      terminalColorsEnabled: true,
+    })
+
+    manager.listWindows()
+
+    expect(runner.calls).toContainEqual([
+      'set-environment',
+      '-r',
+      '-t',
+      sessionName,
+      'NO_COLOR',
+    ])
+
+    runner.calls.length = 0
+    manager.setTerminalColors(false)
+
+    expect(runner.calls).toEqual([[
+      'set-environment',
+      '-t',
+      sessionName,
+      'NO_COLOR',
+      '1',
+    ]])
   })
 
   test('setMouseMode rethrows non-timeout base session failures', () => {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -180,6 +180,9 @@ export const config = {
   // process under tmux `automatic-rename on`. Enable when each window has a stable,
   // user-chosen name (e.g. one window per project in a shared session).
   preferWindowName: process.env.AGENTBOARD_PREFER_WINDOW_NAME === 'true',
+  // Preserve ANSI terminal colors by default. The persisted server setting can
+  // override this at startup, including ambient NO_COLOR inherited by Agentboard.
+  terminalColorsEnabled: true,
   // Launch agentboard-created windows with Claude Code fullscreen ("no-flicker")
   // rendering enabled, so its mouse features (click-to-expand, click-to-position
   // cursor, wheel scroll) work in the browser terminal. Set

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -509,9 +509,19 @@ if (storedPreferWindowName !== null) {
   config.preferWindowName = storedPreferWindowName === 'true'
 }
 
+// Read the global terminal color setting from DB. Enabled by default so an
+// ambient NO_COLOR on the Agentboard process does not flatten every managed
+// terminal. Once saved from the UI, the persisted value wins.
+const TERMINAL_COLORS_ENABLED_KEY = 'terminal_colors_enabled'
+const storedTerminalColorsEnabled = db.getAppSetting(TERMINAL_COLORS_ENABLED_KEY)
+if (storedTerminalColorsEnabled !== null) {
+  config.terminalColorsEnabled = storedTerminalColorsEnabled === 'true'
+}
+
 const sessionManager = new SessionManager(undefined, {
   displayNameExists: (name, excludeSessionId) => db.displayNameExists(name, excludeSessionId),
   mouseMode: initialMouseMode,
+  terminalColorsEnabled: config.terminalColorsEnabled,
 })
 // Ensure the base tmux session exists so listing/orphan logic has a real
 // session to read from. SessionManager creates it with a placeholder window
@@ -1650,6 +1660,57 @@ app.put('/api/settings/tmux-mouse-mode', async (c) => {
       })
     }
     return c.json({ error: 'Unable to persist tmux mouse mode' }, 500)
+  }
+
+  return c.json({ enabled: body.enabled })
+})
+
+// Terminal ANSI color setting
+app.get('/api/settings/terminal-colors', (c) => {
+  return c.json({ enabled: config.terminalColorsEnabled })
+})
+
+app.put('/api/settings/terminal-colors', async (c) => {
+  let body: { enabled?: unknown }
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json({ error: 'Invalid request body' }, 400)
+  }
+
+  if (typeof body.enabled !== 'boolean') {
+    return c.json({ error: 'enabled must be a boolean' }, 400)
+  }
+
+  const previousValue = config.terminalColorsEnabled
+  try {
+    sessionManager.setTerminalColors(body.enabled)
+  } catch (error) {
+    if (error instanceof TmuxTimeoutError) {
+      return c.json({ error: 'Timed out applying terminal colors' }, 504)
+    }
+    logger.warn('terminal_colors_update_failed', {
+      message: error instanceof Error ? error.message : String(error),
+    })
+    return c.json({ error: 'Unable to apply terminal colors' }, 500)
+  }
+
+  config.terminalColorsEnabled = body.enabled
+  try {
+    db.setAppSetting(TERMINAL_COLORS_ENABLED_KEY, String(body.enabled))
+  } catch (error) {
+    config.terminalColorsEnabled = previousValue
+    logger.warn('terminal_colors_persist_failed', {
+      message: error instanceof Error ? error.message : String(error),
+    })
+    try {
+      sessionManager.setTerminalColors(previousValue)
+    } catch (rollbackError) {
+      logger.warn('terminal_colors_rollback_failed', {
+        message: rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+      })
+    }
+    return c.json({ error: 'Unable to persist terminal colors' }, 500)
   }
 
   return c.json({ enabled: body.enabled })
@@ -4161,7 +4222,8 @@ function captureTmuxHistory(target: string): string | null {
   try {
     // Capture only the visible pane so initial attach paints the current view
     // immediately instead of replaying the entire scrollback buffer.
-    const result = Bun.spawnSync(['tmux', 'capture-pane', '-t', target, '-p', '-J'], {
+    const colorArgs = config.terminalColorsEnabled ? ['-e'] : []
+    const result = Bun.spawnSync(['tmux', 'capture-pane', '-t', target, '-p', '-J', ...colorArgs], {
       stdout: 'pipe',
       stderr: 'pipe',
       timeout: config.tmuxTimeoutMs,
@@ -4229,7 +4291,10 @@ async function runRemoteSsh(host: string, remoteCmd: string): Promise<{ exitCode
 
 async function captureTmuxHistoryRemote(target: string, host: string): Promise<string | null> {
   try {
-    const result = await runRemoteTmux(host, ['capture-pane', '-t', target, '-p', '-J'])
+    const colorArgs = config.terminalColorsEnabled ? ['-e'] : []
+    const result = await runRemoteTmux(host, [
+      'capture-pane', '-t', target, '-p', '-J', ...colorArgs,
+    ])
     if (result.exitCode !== 0) return null
     const output = result.stdout ?? ''
     if (output.trim().length === 0) return null


### PR DESCRIPTION
## Summary

- add a persisted global Terminal Colors switch in Settings
- preserve ANSI escape sequences in local and remote tmux pane snapshots
- control NO_COLOR for newly launched local managed sessions
- tell users to Hibernate then Wake running agents after changing the setting

## Validation

- bun run lint
- bun run typecheck
- bun run test
- bun run build
