### PR TITLE
fix: stop leaking launch env (NODE_ENV, npm_*) into tmux panes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/server/SessionManager.ts
+++ b/src/server/SessionManager.ts
@@ -7,6 +7,7 @@ import { generateSessionName } from './nameGenerator'
 import { logger } from './logger'
 import { resolveProjectPath } from './paths'
 import { TmuxTimeoutError } from './tmuxTimeout'
+import { isLeakedLaunchEnvVar, sanitizedTmuxEnv } from './tmuxEnv'
 import {
   BOOTSTRAP_WINDOW_COMMAND,
   BOOTSTRAP_WINDOW_NAME,
@@ -158,6 +159,46 @@ export class SessionManager {
     }
     this.configureSession()
     return { canPruneWsSessions }
+  }
+
+  // One-time repair for a tmux server daemon that an older agentboard booted
+  // with its launch environment (see tmuxEnv.ts): unset the leaked vars from
+  // the daemon's global environment so future panes are clean. Guarded on the
+  // AGENTBOARD_STATIC_DIR fingerprint — the daemon may be the user's own
+  // shared server, and a NODE_ENV they set deliberately must survive; only a
+  // daemon whose global env carries our launcher's fingerprint gets scrubbed.
+  // Call once at startup, not per refresh tick (each unset is a synchronous
+  // tmux spawn). Existing panes keep their env; only new windows benefit.
+  scrubLeakedGlobalEnvironment(): string[] {
+    let output: string
+    try {
+      output = this.runTmux(['show-environment', '-g'])
+    } catch {
+      return []
+    }
+    const leaked: string[] = []
+    let fingerprint = false
+    for (const line of splitTmuxLines(output)) {
+      // Removed-var markers start with '-'; values containing '=' are split
+      // on the first one.
+      if (!line || line.startsWith('-')) continue
+      const eq = line.indexOf('=')
+      if (eq <= 0) continue
+      const name = line.slice(0, eq)
+      if (name === 'AGENTBOARD_STATIC_DIR') fingerprint = true
+      if (isLeakedLaunchEnvVar(name)) leaked.push(name)
+    }
+    if (!fingerprint) return []
+    const scrubbed: string[] = []
+    for (const name of leaked) {
+      try {
+        this.runTmux(['set-environment', '-g', '-u', name])
+        scrubbed.push(name)
+      } catch {
+        // Best-effort: a failed unset just leaves that var for next startup.
+      }
+    }
+    return scrubbed
   }
 
   private findSessionInGroup(): GroupLookupResult {
@@ -757,6 +798,10 @@ function runTmux(args: string[]): string {
     stdout: 'pipe',
     stderr: 'pipe',
     timeout,
+    // If this call boots the tmux server daemon (new-session with no server
+    // running), the daemon keeps this environment as its global environment
+    // forever and every future pane inherits it — so hand it a sanitized one.
+    env: sanitizedTmuxEnv(),
   })
   if (result.signalCode === 'SIGTERM' || result.exitCode === null) {
     throw new TmuxTimeoutError(command, timeout)

--- a/src/server/__tests__/integration.test.ts
+++ b/src/server/__tests__/integration.test.ts
@@ -3,7 +3,11 @@ import fs from 'node:fs'
 import net from 'node:net'
 import path from 'node:path'
 import os from 'node:os'
-import { canBindLocalhost, isTmuxAvailable } from './testEnvironment'
+import {
+  canBindLocalhost,
+  createTmuxTmpDir,
+  isTmuxAvailable,
+} from './testEnvironment'
 
 const tmuxAvailable = isTmuxAvailable()
 const localhostBindable = canBindLocalhost()
@@ -27,8 +31,15 @@ if (!tmuxAvailable || !localhostBindable) {
     )
     let serverProcess: ReturnType<typeof Bun.spawn> | null = null
     let port = 0
+    // Private tmux server for this test. Without this, the spawned server
+    // inherits $TMUX (when the test process runs inside tmux) and every tmux
+    // call — session creation, kills, and the startup env scrub — lands on
+    // the user's LIVE tmux server. createTmuxTmpDir also deletes
+    // process.env.TMUX for the same reason.
+    let tmuxTmpDir: string | null = null
 
     beforeAll(async () => {
+      tmuxTmpDir = createTmuxTmpDir()
       port = await getFreePort()
 
       serverProcess = Bun.spawn(['bun', 'src/server/index.ts'], {
@@ -41,6 +52,7 @@ if (!tmuxAvailable || !localhostBindable) {
           AGENTBOARD_LOG_POLL_MS: '0',
           AGENTBOARD_DB_PATH: dbPath,
           AGENTBOARD_PASTE_IMAGE_MAX_BYTES: '1024',
+          TMUX_TMPDIR: tmuxTmpDir,
         },
         stdout: 'pipe',
         stderr: 'pipe',
@@ -66,9 +78,29 @@ if (!tmuxAvailable || !localhostBindable) {
         Bun.spawnSync(['tmux', 'kill-session', '-t', sessionName], {
           stdout: 'ignore',
           stderr: 'ignore',
+          env: {
+            ...process.env,
+            ...(tmuxTmpDir ? { TMUX_TMPDIR: tmuxTmpDir } : {}),
+          },
         })
       } catch {
         // ignore cleanup errors
+      }
+      if (tmuxTmpDir) {
+        try {
+          Bun.spawnSync(['tmux', 'kill-server'], {
+            stdout: 'ignore',
+            stderr: 'ignore',
+            env: { ...process.env, TMUX_TMPDIR: tmuxTmpDir },
+          })
+        } catch {
+          // ignore cleanup errors
+        }
+        try {
+          fs.rmSync(tmuxTmpDir, { recursive: true, force: true })
+        } catch {
+          // ignore cleanup errors
+        }
       }
       try {
         fs.unlinkSync(dbPath)

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -143,6 +143,7 @@ let sessionManagerState: {
   renameWindow: (tmuxWindow: string, newName: string) => void
   setMouseMode: (enabled: boolean) => void
   ensureSession: () => { canPruneWsSessions: boolean }
+  scrubLeakedGlobalEnvironment: () => string[]
 }
 
 class SessionManagerMock {
@@ -173,6 +174,10 @@ class SessionManagerMock {
 
   ensureSession() {
     return sessionManagerState.ensureSession()
+  }
+
+  scrubLeakedGlobalEnvironment() {
+    return sessionManagerState.scrubLeakedGlobalEnvironment()
   }
 }
 
@@ -636,6 +641,7 @@ beforeEach(() => {
     renameWindow: () => {},
     setMouseMode: () => {},
     ensureSession: () => ({ canPruneWsSessions: true }),
+    scrubLeakedGlobalEnvironment: () => [],
   }
 
   spawnSyncImpl = () =>

--- a/src/server/__tests__/tmuxEnv.test.ts
+++ b/src/server/__tests__/tmuxEnv.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from 'bun:test'
+import { SessionManager } from '../SessionManager'
+import { isLeakedLaunchEnvVar, sanitizedTmuxEnv } from '../tmuxEnv'
+
+describe('isLeakedLaunchEnvVar', () => {
+  test('flags the launch-chain vars', () => {
+    expect(isLeakedLaunchEnvVar('NODE_ENV')).toBe(true)
+    expect(isLeakedLaunchEnvVar('AGENTBOARD_STATIC_DIR')).toBe(true)
+    expect(isLeakedLaunchEnvVar('npm_config_cache')).toBe(true)
+    expect(isLeakedLaunchEnvVar('npm_lifecycle_script')).toBe(true)
+    expect(isLeakedLaunchEnvVar('npm_execpath')).toBe(true)
+  })
+
+  test('leaves ordinary env vars alone', () => {
+    expect(isLeakedLaunchEnvVar('PATH')).toBe(false)
+    expect(isLeakedLaunchEnvVar('HOME')).toBe(false)
+    expect(isLeakedLaunchEnvVar('SSH_AUTH_SOCK')).toBe(false)
+    expect(isLeakedLaunchEnvVar('TERM')).toBe(false)
+    // Other AGENTBOARD_* config vars are deliberately not stripped.
+    expect(isLeakedLaunchEnvVar('AGENTBOARD_DB_PATH')).toBe(false)
+    expect(isLeakedLaunchEnvVar('NODE_OPTIONS')).toBe(false)
+    expect(isLeakedLaunchEnvVar('NPM_TOKEN')).toBe(false)
+  })
+})
+
+describe('sanitizedTmuxEnv', () => {
+  test('strips leaked vars and keeps the rest', () => {
+    const env = sanitizedTmuxEnv({
+      PATH: '/usr/bin',
+      HOME: '/Users/x',
+      SSH_AUTH_SOCK: '/tmp/agent.sock',
+      NODE_ENV: 'production',
+      AGENTBOARD_STATIC_DIR: '/npx/dist/client',
+      npm_config_cache: '/Users/x/.npm',
+      npm_execpath: '/opt/npm-cli.js',
+    })
+    expect(env).toEqual({
+      PATH: '/usr/bin',
+      HOME: '/Users/x',
+      SSH_AUTH_SOCK: '/tmp/agent.sock',
+    })
+  })
+
+  test('drops undefined values', () => {
+    expect(sanitizedTmuxEnv({ FOO: undefined, BAR: 'x' })).toEqual({ BAR: 'x' })
+  })
+
+  test('defaults to process.env', () => {
+    const env = sanitizedTmuxEnv()
+    expect(env.NODE_ENV).toBeUndefined()
+    expect(env.AGENTBOARD_STATIC_DIR).toBeUndefined()
+    expect(Object.keys(env).some((k) => k.startsWith('npm_'))).toBe(false)
+  })
+})
+
+describe('SessionManager.scrubLeakedGlobalEnvironment', () => {
+  function managerWithGlobalEnv(
+    lines: string[],
+    calls: string[][]
+  ): SessionManager {
+    return new SessionManager('agentboard', {
+      runTmux: (args: string[]) => {
+        calls.push(args)
+        if (args[0] === 'show-environment') {
+          return lines.join('\n')
+        }
+        return ''
+      },
+    })
+  }
+
+  test('scrubs leaked vars when the agentboard fingerprint is present', () => {
+    const calls: string[][] = []
+    const manager = managerWithGlobalEnv(
+      [
+        'AGENTBOARD_STATIC_DIR=/npx/dist/client',
+        'NODE_ENV=production',
+        'npm_config_cache=/Users/x/.npm',
+        'npm_execpath=/opt/npm-cli.js',
+        'PATH=/usr/bin',
+        'SSH_AUTH_SOCK=/tmp/agent.sock',
+      ],
+      calls
+    )
+    const scrubbed = manager.scrubLeakedGlobalEnvironment()
+    expect(scrubbed.sort()).toEqual([
+      'AGENTBOARD_STATIC_DIR',
+      'NODE_ENV',
+      'npm_config_cache',
+      'npm_execpath',
+    ])
+    const unsets = calls.filter((args) => args[0] === 'set-environment')
+    expect(unsets).toEqual(
+      scrubbed.map((name) => ['set-environment', '-g', '-u', name])
+    )
+    // PATH and SSH_AUTH_SOCK must never be touched.
+    expect(unsets.some((args) => args.includes('PATH'))).toBe(false)
+    expect(unsets.some((args) => args.includes('SSH_AUTH_SOCK'))).toBe(false)
+  })
+
+  test('does nothing without the fingerprint, even if NODE_ENV is set', () => {
+    // The daemon may be the user's own shared tmux server; a NODE_ENV they
+    // exported deliberately must survive.
+    const calls: string[][] = []
+    const manager = managerWithGlobalEnv(
+      ['NODE_ENV=staging', 'PATH=/usr/bin'],
+      calls
+    )
+    expect(manager.scrubLeakedGlobalEnvironment()).toEqual([])
+    expect(calls.filter((args) => args[0] === 'set-environment')).toEqual([])
+  })
+
+  test('ignores removed-var markers', () => {
+    const calls: string[][] = []
+    const manager = managerWithGlobalEnv(
+      ['AGENTBOARD_STATIC_DIR=/x', '-NODE_ENV', 'npm_config_yes=true'],
+      calls
+    )
+    expect(manager.scrubLeakedGlobalEnvironment().sort()).toEqual([
+      'AGENTBOARD_STATIC_DIR',
+      'npm_config_yes',
+    ])
+  })
+
+  test('returns empty when show-environment fails (no tmux server)', () => {
+    const manager = new SessionManager('agentboard', {
+      runTmux: () => {
+        throw new Error('no server running')
+      },
+    })
+    expect(manager.scrubLeakedGlobalEnvironment()).toEqual([])
+  })
+
+  test('a failed unset skips that var but continues', () => {
+    const calls: string[][] = []
+    const manager = new SessionManager('agentboard', {
+      runTmux: (args: string[]) => {
+        calls.push(args)
+        if (args[0] === 'show-environment') {
+          return ['AGENTBOARD_STATIC_DIR=/x', 'NODE_ENV=production'].join('\n')
+        }
+        if (args[0] === 'set-environment' && args[3] === 'AGENTBOARD_STATIC_DIR') {
+          throw new Error('boom')
+        }
+        return ''
+      },
+    })
+    expect(manager.scrubLeakedGlobalEnvironment()).toEqual(['NODE_ENV'])
+  })
+})

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -518,6 +518,13 @@ const sessionManager = new SessionManager(undefined, {
 // (filtered out of listings) when missing.
 try {
   const ensureResult = sessionManager.ensureSession()
+  // One-time: if an older agentboard booted the tmux daemon with leaked
+  // launch env (NODE_ENV=production etc.), scrub it so new windows are clean.
+  // Startup only — never per refresh tick (each unset is a tmux spawn).
+  const scrubbedEnvVars = sessionManager.scrubLeakedGlobalEnvironment()
+  if (scrubbedEnvVars.length > 0) {
+    logger.info('tmux_global_env_scrubbed', { vars: scrubbedEnvVars })
+  }
   if (ensureResult.canPruneWsSessions) {
     pruneOrphanedWsSessions()
   } else {

--- a/src/server/terminal/PtyTerminalProxy.ts
+++ b/src/server/terminal/PtyTerminalProxy.ts
@@ -6,6 +6,7 @@ import {
 import { TerminalProxyError, TerminalState } from './types'
 import { resolveGroupedSessionSwitchTarget } from './groupedSessionTarget'
 import { buildTmuxFormat, splitTmuxFields } from '../tmuxFormat'
+import { sanitizedTmuxEnv } from '../tmuxEnv'
 
 const CLIENT_TTY_FORMAT = buildTmuxFormat([
   '#{client_tty}',
@@ -518,7 +519,7 @@ class PtyTerminalProxy extends TerminalProxyBase {
         ['tmux', ...this.clientFeatureArgs(), 'attach', '-t', this.options.sessionName],
         {
           env: {
-            ...process.env,
+            ...sanitizedTmuxEnv(),
             TERM: 'xterm-256color',
           },
           terminal: {

--- a/src/server/terminal/TerminalProxyBase.ts
+++ b/src/server/terminal/TerminalProxyBase.ts
@@ -2,6 +2,7 @@ import { config } from '../config'
 import { logger } from '../logger'
 import { withTmuxUtf8Flag } from '../tmuxFormat'
 import { TmuxTimeoutError } from '../tmuxTimeout'
+import { sanitizedTmuxEnv } from '../tmuxEnv'
 import type {
   ITerminalProxy,
   SpawnFn,
@@ -141,6 +142,9 @@ abstract class TerminalProxyBase implements ITerminalProxy {
       stdout: 'pipe',
       stderr: 'pipe',
       timeout: timeoutMs,
+      // Keep leaked launch env (NODE_ENV, npm_*, …) out of any tmux server
+      // daemon this client might boot — see tmuxEnv.ts.
+      env: sanitizedTmuxEnv(),
       ...(options.stdin !== undefined ? { stdin: Buffer.from(options.stdin) } : {}),
     })
 

--- a/src/server/tmuxEnv.ts
+++ b/src/server/tmuxEnv.ts
@@ -1,0 +1,36 @@
+// Env hygiene for spawned tmux clients.
+//
+// agentboard's launch chain injects env vars the user never exported:
+// bin/agentboard forces NODE_ENV=production (the compiled binary's logger
+// needs it), npx adds the npm_* family, and the launcher adds
+// AGENTBOARD_STATIC_DIR. If a tmux client we spawn is the one that boots the
+// tmux server daemon, the daemon captures that environment as its global
+// environment permanently — and every pane created afterwards (i.e. every
+// agent shell) inherits it. An ambient NODE_ENV=production breaks test
+// runners and React's dev-only `act`, npm_* confuses nested package-manager
+// runs, and a leaked AGENTBOARD_STATIC_DIR makes locally-started dev servers
+// silently serve the published client bundle.
+//
+// Stripping these from every tmux client we spawn keeps a daemon we boot as
+// clean as one the user boots from their own terminal. Vars the user really
+// exports still reach panes: interactive pane shells re-source dotfiles, and
+// everything outside this denylist passes through untouched.
+
+export function isLeakedLaunchEnvVar(name: string): boolean {
+  return (
+    name === 'NODE_ENV' ||
+    name === 'AGENTBOARD_STATIC_DIR' ||
+    name.startsWith('npm_')
+  )
+}
+
+export function sanitizedTmuxEnv(
+  source: Record<string, string | undefined> = process.env
+): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined || isLeakedLaunchEnvVar(key)) continue
+    env[key] = value
+  }
+  return env
+}


### PR DESCRIPTION
Agentboard's launch chain injects `NODE_ENV=production` (forced by `bin/agentboard` for the compiled binary's logger), the `npm_*` family (from npx), and `AGENTBOARD_STATIC_DIR`. When the server's tmux client is the one that boots the tmux daemon, the daemon keeps that environment as its global environment forever — and every pane created afterwards (i.e. every agent shell) inherits it.

Downstream symptoms: an ambient `NODE_ENV=production` breaks vitest / React's dev-only `act()` inside agent sessions (eichler papercuts #404/#420), `npm_*` confuses nested package-manager runs, and a leaked `AGENTBOARD_STATIC_DIR` makes locally-started dev servers silently serve the published client bundle (see the e2e prod-datadir incident).

## Changes

- **`src/server/tmuxEnv.ts`** — `sanitizedTmuxEnv()` strips the denylist (`NODE_ENV`, `npm_*`, `AGENTBOARD_STATIC_DIR`) from the env handed to every tmux client spawn (`SessionManager.runTmux`, `TerminalProxyBase.runTmux`, the pty attach). A daemon agentboard boots is now born clean; everything else passes through untouched (`SSH_AUTH_SOCK`, `PATH`, user exports).
- **`SessionManager.scrubLeakedGlobalEnvironment()`** — one-time startup repair for daemons an older agentboard already polluted: unsets the leaked vars from the tmux global environment. Guarded on the `AGENTBOARD_STATIC_DIR` fingerprint so a user's own deliberately-set variables on a shared daemon survive. Runs at startup only, never on refresh ticks (each unset is a synchronous tmux spawn).
- **`integration.test.ts` isolation fix** — the file spawned its real server with `{...process.env}` and no private tmux socket; with `$TMUX` set (any agent shell on an agentboard-managed machine) every tmux call — including the new startup scrub — landed on the user's live tmux server. Now uses `createTmuxTmpDir` like its `*.integration.test.ts` siblings.
- Version bump to 0.4.9.

## Verification

- Unit tests for the denylist, the scrub, the fingerprint guard, and failure tolerance (`tmuxEnv.test.ts`).
- End-to-end on an isolated tmux server: a server launched with a fully polluted environment boots a daemon whose global env and panes are clean, while the server itself keeps `NODE_ENV=production` for pino; startup repair scrubs a fingerprinted polluted daemon (24 vars) without disturbing its windows; a daemon with a user's own `NODE_ENV` and no fingerprint is left untouched.
- `integration.test.ts` run from a `$TMUX` shell creates no sessions on the live server and leaves its global environment byte-identical.

Known limitation: panes that already exist keep their environment (a live process's env can't be changed); they clear when their windows are recreated.

https://claude.ai/code/session_019qWzB9aJWjRBbPg1fPdmge