### PR TITLE
fix: improve mobile terminal controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/__tests__/terminal.test.tsx
+++ b/src/client/__tests__/terminal.test.tsx
@@ -501,6 +501,21 @@ describe('Terminal', () => {
     })
 
     const openButton = renderer.root.findByProps({ 'aria-label': 'Open session menu' })
+    expect(String(openButton.props.className)).toContain('size-[44px]')
+
+    const mobileStatus = renderer.root.findAllByType('span').find((span) =>
+      span.props.children === 'Working' &&
+      String(span.props.className ?? '').includes('md:hidden')
+    )
+    expect(mobileStatus).toBeDefined()
+    expect(String(mobileStatus?.props.className)).toContain('text-[10px]')
+
+    const mobileKillButton = renderer.root
+      .findAllByProps({ 'aria-label': 'Kill session' })
+      .find((button) => String(button.props.className ?? '').includes('md:hidden'))
+    expect(mobileKillButton).toBeDefined()
+    expect(String(mobileKillButton?.props.className)).toContain('size-[44px]')
+
     act(() => {
       openButton.props.onClick()
     })
@@ -528,6 +543,7 @@ describe('Terminal', () => {
     if (!switchButton) {
       throw new Error('Expected session switcher button')
     }
+    expect(String(switchButton.props.className)).toContain('h-[44px]')
 
     act(() => {
       switchButton.props.onClick()

--- a/src/client/__tests__/terminalControls.test.tsx
+++ b/src/client/__tests__/terminalControls.test.tsx
@@ -46,6 +46,32 @@ function findPasteButton(renderer: TestRenderer.ReactTestRenderer) {
 }
 
 describe('TerminalControls', () => {
+  test('renders the mobile key deck as one scrollable row of 44px targets', () => {
+    const renderer = TestRenderer.create(
+      <TerminalControls
+        onSendKey={() => {}}
+        sessions={[{ id: 'session-1', name: 'alpha', status: 'working' }]}
+        currentSessionId="session-1"
+        onSelectSession={() => {}}
+      />
+    )
+
+    const keyDeck = renderer.root.findAllByType('div').find((element) =>
+      String(element.props.className ?? '').includes('grid-flow-col')
+    )
+    expect(keyDeck).toBeDefined()
+    expect(String(keyDeck?.props.className)).toContain('auto-cols-[44px]')
+    expect(String(keyDeck?.props.className)).toContain('overflow-x-auto')
+
+    const keyButtons = renderer.root.findAllByType('button').filter((button) =>
+      String(button.props.className ?? '').includes('terminal-key')
+    )
+    expect(keyButtons).toHaveLength(9)
+    expect(keyButtons.every((button) =>
+      String(button.props.className).includes('size-[44px]')
+    )).toBe(true)
+  })
+
   test('ctrl toggle modifies keys and resets', () => {
     globalAny.navigator = { vibrate: () => true } as unknown as Navigator
 
@@ -110,6 +136,9 @@ describe('TerminalControls', () => {
       )
 
     expect(sessionButtons).toHaveLength(2)
+    expect(sessionButtons.every((button) =>
+      String(button.props.className).includes('h-[44px]')
+    )).toBe(true)
 
     act(() => {
       sessionButtons[1]?.props.onClick()

--- a/src/client/components/DPad.tsx
+++ b/src/client/components/DPad.tsx
@@ -256,7 +256,7 @@ export default function DPad({
         className={`
           terminal-key
           flex items-center justify-center
-          h-11 min-w-[2.75rem] px-2.5
+          size-[44px] p-0
           text-sm font-medium
           bg-surface border border-border rounded-md
           active:bg-hover active:scale-95

--- a/src/client/components/NumPad.tsx
+++ b/src/client/components/NumPad.tsx
@@ -205,7 +205,7 @@ export default function NumPad({
         className={`
           terminal-key
           flex items-center justify-center
-          h-11 min-w-[2.75rem] px-2.5
+          size-[44px] p-0
           text-sm font-medium
           bg-surface border border-border rounded-md
           active:bg-hover active:scale-95

--- a/src/client/components/Terminal.tsx
+++ b/src/client/components/Terminal.tsx
@@ -1130,11 +1130,11 @@ export default function Terminal({
       data-testid="terminal-panel"
     >
       {/* Mobile header - always show on mobile for drawer access */}
-      <div className={`flex h-10 shrink-0 items-center justify-between border-b border-border bg-elevated px-3 ${session || hibernatingSession ? '' : 'md:hidden'}`}>
-        <div className="flex items-center gap-3 min-w-0">
+      <div className={`flex min-h-[52px] shrink-0 items-center justify-between border-b border-border bg-elevated px-[6px] md:h-10 md:min-h-0 md:px-3 ${session || hibernatingSession ? '' : 'md:hidden'}`}>
+        <div className="flex min-w-0 items-center gap-[7px] md:gap-3">
           <button
             onClick={() => setIsDrawerOpen(true)}
-            className="flex h-7 w-7 items-center justify-center rounded bg-surface border border-border text-secondary hover:bg-hover hover:text-primary active:scale-95 transition-all md:hidden shrink-0"
+            className="flex size-[44px] shrink-0 items-center justify-center rounded border border-border bg-surface text-secondary transition-all hover:bg-hover hover:text-primary active:scale-95 md:hidden"
             aria-label="Open session menu"
           >
             <Menu01Icon width={16} height={16} />
@@ -1161,7 +1161,7 @@ export default function Terminal({
             </button>
           )}
           {session ? (
-            <div className="flex items-baseline gap-3 min-w-0">
+            <div className="flex min-w-[72px] flex-col items-start gap-px leading-none md:min-w-0 md:flex-row md:items-baseline md:gap-3 md:leading-normal">
               {isRenaming ? (
                 <input
                   ref={renameInputRef}
@@ -1170,23 +1170,26 @@ export default function Terminal({
                   onChange={(e) => setRenameValue(e.target.value)}
                   onBlur={handleRenameSubmit}
                   onKeyDown={handleRenameKeyDown}
-                  className="w-full max-w-[200px] rounded border border-border bg-surface px-2 py-0.5 text-sm font-medium text-primary outline-none focus:border-accent"
+                  className="w-full max-w-[112px] rounded border border-border bg-surface px-2 py-0.5 text-sm font-medium text-primary outline-none focus:border-accent md:max-w-[200px]"
                 />
               ) : (
-                <span className="text-sm font-medium text-primary truncate">
+                <span className="max-w-[112px] truncate text-sm font-medium text-primary md:max-w-none">
                   {session.agentSessionName || session.name}
                 </span>
               )}
-              <span className={`text-xs shrink-0 ${statusClass[session.status]}`}>
+              <span className={`shrink-0 text-[10px] md:hidden ${connectionStatus !== 'connected' ? 'text-approval' : statusClass[session.status]}`}>
+                {connectionStatus !== 'connected' ? connectionStatus : statusText[session.status]}
+              </span>
+              <span className={`hidden shrink-0 text-xs md:inline ${statusClass[session.status]}`}>
                 {statusText[session.status]}
               </span>
             </div>
           ) : hibernatingSession ? (
-            <div className="flex items-baseline gap-2 min-w-0">
-              <span className="text-sm font-medium text-primary truncate">
+            <div className="flex min-w-0 flex-col items-start gap-px leading-none md:flex-row md:items-baseline md:gap-2 md:leading-normal">
+              <span className="max-w-[112px] truncate text-sm font-medium text-primary md:max-w-none">
                 {hibernatingDisplayName}
               </span>
-              <span className="rounded-full bg-blue-500/15 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-blue-400">
+              <span className="text-[10px] font-medium text-blue-400 md:rounded-full md:bg-blue-500/15 md:px-1.5 md:py-0.5 md:uppercase md:tracking-wide">
                 Hibernating
               </span>
             </div>
@@ -1197,9 +1200,9 @@ export default function Terminal({
           )}
         </div>
 
-        <div className="flex items-center gap-1.5 shrink-0">
+        <div className="flex shrink-0 items-center gap-[4px] md:gap-1.5">
           {connectionStatus !== 'connected' && (
-            <span className="text-xs text-approval">
+            <span className="hidden text-xs text-approval md:inline">
               {connectionStatus}
             </span>
           )}
@@ -1207,7 +1210,7 @@ export default function Terminal({
           {/* New session button - mobile only (desktop has it in header) */}
           <button
             onClick={onNewSession}
-            className="flex h-7 w-7 items-center justify-center rounded bg-accent text-white hover:bg-accent/90 active:scale-95 transition-all md:hidden"
+            className="flex size-[44px] items-center justify-center rounded bg-accent text-white transition-all hover:bg-accent/90 active:scale-95 md:hidden"
             title={`New session (${modDisplay}N)`}
             aria-label="New session"
           >
@@ -1218,7 +1221,7 @@ export default function Terminal({
           {session && canControl && (
             <button
               onClick={() => setShowEndConfirm(true)}
-              className="flex md:hidden h-7 w-7 items-center justify-center rounded bg-danger/10 border border-danger/30 text-danger hover:bg-danger/20 active:scale-95 transition-all"
+              className="flex size-[44px] items-center justify-center rounded border border-danger/30 bg-danger/10 text-danger transition-all hover:bg-danger/20 active:scale-95 md:hidden"
               title={`Kill session (${modDisplay}X)`}
               aria-label="Kill session"
             >
@@ -1228,7 +1231,7 @@ export default function Terminal({
           {canHibernate && (
             <button
               onClick={handleHibernateSession}
-              className="flex md:hidden h-7 w-7 items-center justify-center rounded border border-border text-secondary hover:bg-hover hover:text-primary active:scale-95 transition-all"
+              className="hidden size-[44px] items-center justify-center rounded border border-border text-secondary transition-all hover:bg-hover hover:text-primary active:scale-95 min-[360px]:flex md:hidden"
               title="Hibernate session"
               aria-label="Hibernate session"
             >
@@ -1238,7 +1241,7 @@ export default function Terminal({
           {hibernatingSession && (
             <button
               onClick={() => onResumeSession(hibernatingSession.sessionId)}
-              className="btn btn-primary h-7 px-2 text-xs md:hidden"
+              className="btn btn-primary h-[44px] px-3 text-xs md:hidden"
             >
               Wake
             </button>
@@ -1249,7 +1252,7 @@ export default function Terminal({
             <div className="relative md:hidden" ref={moreMenuRef}>
               <button
                 onClick={() => setShowMoreMenu(!showMoreMenu)}
-                className="flex h-7 w-7 items-center justify-center rounded bg-surface border border-border text-secondary hover:bg-hover hover:text-primary active:scale-95 transition-all"
+                className="flex size-[44px] items-center justify-center rounded border border-border bg-surface text-secondary transition-all hover:bg-hover hover:text-primary active:scale-95"
                 title="More options"
                 aria-label="More options"
               >
@@ -1261,7 +1264,7 @@ export default function Terminal({
                   {canControl && (
                     <button
                       onClick={handleStartRename}
-                      className="w-full px-3 py-2 text-left text-sm text-secondary hover:bg-hover hover:text-primary flex items-center gap-2"
+                      className="flex min-h-[44px] w-full items-center gap-2 px-3 py-2 text-left text-sm text-secondary hover:bg-hover hover:text-primary"
                     >
                       <Edit05Icon width={14} height={14} />
                       Rename
@@ -1270,7 +1273,7 @@ export default function Terminal({
                   {canHibernate && (
                     <button
                       onClick={handleHibernateSession}
-                      className="w-full px-3 py-2 text-left text-sm text-secondary hover:bg-hover hover:text-primary flex items-center gap-2"
+                      className="flex min-h-[44px] w-full items-center gap-2 px-3 py-2 text-left text-sm text-secondary hover:bg-hover hover:text-primary"
                     >
                       <Moon01Icon width={14} height={14} />
                       Hibernate
@@ -1281,7 +1284,7 @@ export default function Terminal({
                       onOpenSettings()
                       setShowMoreMenu(false)
                     }}
-                    className="w-full px-3 py-2 text-left text-sm text-secondary hover:bg-hover hover:text-primary flex items-center gap-2"
+                    className="flex min-h-[44px] w-full items-center gap-2 px-3 py-2 text-left text-sm text-secondary hover:bg-hover hover:text-primary"
                   >
                     <Settings01Icon width={14} height={14} />
                     Settings
@@ -1300,7 +1303,7 @@ export default function Terminal({
           {/* Right fade indicator */}
           <div className="absolute right-0 top-0 bottom-0 w-4 bg-gradient-to-l from-elevated to-transparent z-10 pointer-events-none" />
           <div
-            className="flex items-center gap-1.5 pl-5 pr-3 py-1.5 overflow-x-auto scrollbar-none scroll-smooth snap-x snap-mandatory"
+            className="flex items-center gap-[6px] overflow-x-auto px-[8px] py-[5px] scrollbar-none scroll-smooth snap-x snap-mandatory"
             style={{ WebkitOverflowScrolling: 'touch' }}
           >
             {sessions.map((s, index) => {
@@ -1316,7 +1319,7 @@ export default function Terminal({
                   type="button"
                   className={`
                     flex items-center justify-center shrink-0 snap-start
-                    h-8 ${mobileTabsUseNames ? 'min-w-[2rem] px-2.5 max-w-[8rem] truncate' : 'w-8'}
+                    h-[44px] ${mobileTabsUseNames ? 'min-w-[44px] px-2.5 max-w-[8rem] truncate' : 'w-[44px]'}
                     text-sm font-extrabold rounded-lg
                     active:scale-95 transition-all duration-75
                     select-none touch-manipulation

--- a/src/client/components/TerminalControls.tsx
+++ b/src/client/components/TerminalControls.tsx
@@ -442,17 +442,17 @@ export default function TerminalControls({
   return (
     <div
       ref={controlsRef}
-      className={`terminal-controls flex flex-col gap-1.5 px-2 py-2.5 bg-elevated border-t border-border ${isIOSDevice() ? '' : 'md:hidden'}`}
+      className={`terminal-controls flex flex-col gap-[6px] border-t border-border bg-elevated p-[6px] ${isIOSDevice() ? '' : 'md:hidden'}`}
     >
       {/* Session switcher row */}
       {showSessionRow && (
-        <div className="relative -mx-2">
+        <div className="relative -mx-[6px]">
           {/* Left fade indicator */}
           <div className="absolute left-0 top-0 bottom-0 w-3 bg-gradient-to-r from-elevated to-transparent z-10 pointer-events-none" />
           {/* Right fade indicator */}
           <div className="absolute right-0 top-0 bottom-0 w-3 bg-gradient-to-l from-elevated to-transparent z-10 pointer-events-none" />
           <div
-            className="flex items-center gap-1.5 px-3 overflow-x-auto scrollbar-none scroll-smooth snap-x snap-mandatory"
+            className="flex items-center gap-[6px] overflow-x-auto px-[6px] scrollbar-none scroll-smooth snap-x snap-mandatory"
             style={{ WebkitOverflowScrolling: 'touch' }}
           >
             {sessions.map((session, index) => {
@@ -463,7 +463,7 @@ export default function TerminalControls({
                   type="button"
                   className={`
                     terminal-key flex items-center justify-center gap-1.5 shrink-0 snap-start
-                    h-8 min-w-[3rem] px-2.5 text-xs font-medium rounded-md
+                    h-[44px] min-w-[44px] px-2.5 text-xs font-medium rounded-md
                     active:scale-95 transition-transform duration-75
                     select-none touch-manipulation
                     ${isActive
@@ -481,14 +481,14 @@ export default function TerminalControls({
         </div>
       )}
       {/* Key row */}
-      <div className="flex flex-wrap items-center gap-1.5">
+      <div className="grid grid-flow-col auto-cols-[44px] items-center gap-[4px] overflow-x-auto scrollbar-none">
         {/* Ctrl toggle */}
         <button
           type="button"
           className={`
             terminal-key
             flex items-center justify-center
-            h-11 min-w-[2.75rem] px-2.5
+            size-[44px] p-0
             text-sm font-medium
             rounded-md
             active:scale-95
@@ -514,7 +514,7 @@ export default function TerminalControls({
             className={`
               terminal-key
               flex items-center justify-center
-              h-11 min-w-[2.75rem] px-2.5
+              size-[44px] p-0
               text-sm font-medium
               bg-surface border border-border rounded-md
               active:bg-hover active:scale-95
@@ -558,7 +558,7 @@ export default function TerminalControls({
             className={`
               terminal-key
               flex items-center justify-center
-              h-11 min-w-[2.75rem] px-2.5
+              size-[44px] p-0
               text-sm font-medium
               bg-surface border border-border rounded-md
               active:bg-hover active:scale-95
@@ -583,7 +583,7 @@ export default function TerminalControls({
           className={`
             terminal-key
             flex items-center justify-center
-            h-11 min-w-[2.75rem] px-2.5
+            size-[44px] p-0
             text-sm font-medium
             bg-surface border border-border rounded-md
             active:bg-hover active:scale-95
@@ -606,7 +606,7 @@ export default function TerminalControls({
           className={`
             terminal-key
             flex items-center justify-center
-            h-11 min-w-[2.75rem] px-2.5
+            size-[44px] p-0
             text-sm font-medium
             bg-surface border border-border rounded-md
             active:bg-hover active:scale-95


### PR DESCRIPTION
## Summary

- move the session status beneath the session name on mobile
- enlarge mobile header actions, session tabs, and terminal controls to 44px touch targets
- keep terminal controls in one horizontally scrollable row on narrow screens
- hide the direct Hibernate action below 360px while retaining it in the More menu
- bump the patch version to 0.4.10

Closes #193

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run build`
- full pre-commit test suite
- browser QA at 440x956 and 320x700

No live tmux or running Agentboard instance was used during implementation or QA.