### PR TITLE
fix: block input during session switches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/__tests__/useTerminal.test.tsx
+++ b/src/client/__tests__/useTerminal.test.tsx
@@ -504,6 +504,10 @@ describe('useTerminal', () => {
     }
 
     act(() => {
+      listeners[0]?.({ type: 'terminal-ready', sessionId: 'session-1' })
+    })
+
+    act(() => {
       terminal.emitData('ls')
     })
 
@@ -703,6 +707,7 @@ describe('useTerminal', () => {
     } as unknown as Navigator
 
     const sendCalls: Array<Record<string, unknown>> = []
+    const listeners: Array<(message: ServerMessage) => void> = []
     const { container } = createContainerMock()
 
     let renderer!: TestRenderer.ReactTestRenderer
@@ -713,7 +718,10 @@ describe('useTerminal', () => {
           sessionId="session-1"
           tmuxTarget="agentboard:@1"
           sendMessage={(message) => sendCalls.push(message)}
-          subscribe={() => () => {}}
+          subscribe={(listener) => {
+            listeners.push(listener)
+            return () => {}
+          }}
           theme={{ background: '#000' }}
           fontSize={12}
         />,
@@ -725,18 +733,61 @@ describe('useTerminal', () => {
       await Promise.resolve()
     })
 
+    const terminal = TerminalMock.instances[0]
+    if (!terminal) throw new Error('Expected terminal instance')
+
+    act(() => {
+      listeners.forEach((listener) => listener({
+        type: 'terminal-ready',
+        sessionId: 'session-1',
+      }))
+      terminal.emitData('before-switch')
+    })
+
     await act(async () => {
       renderer.update(
         <TerminalHarness
           sessionId="session-2"
           tmuxTarget="agentboard:@2"
           sendMessage={(message) => sendCalls.push(message)}
-          subscribe={() => () => {}}
+          subscribe={(listener) => {
+            listeners.push(listener)
+            return () => {}
+          }}
           theme={{ background: '#000' }}
           fontSize={12}
         />
       )
       await Promise.resolve()
+    })
+
+    act(() => {
+      terminal.emitData('during-switch')
+    })
+
+    expect(sendCalls).not.toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-1',
+      data: 'during-switch',
+    })
+    expect(sendCalls).not.toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-2',
+      data: 'during-switch',
+    })
+
+    act(() => {
+      listeners.forEach((listener) => listener({
+        type: 'terminal-ready',
+        sessionId: 'session-2',
+      }))
+      terminal.emitData('after-ready')
+    })
+
+    expect(sendCalls).toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-2',
+      data: 'after-ready',
     })
 
     expect(sendCalls).toContainEqual({
@@ -755,7 +806,6 @@ describe('useTerminal', () => {
       renderer.unmount()
     })
 
-    const terminal = TerminalMock.instances[0]
     const webglAddon = WebglAddonMock.instances[0]
 
     expect(terminal?.disposed).toBe(true)
@@ -2605,6 +2655,7 @@ describe('useTerminal', () => {
     }) as typeof fetch
 
     const sendCalls: Array<Record<string, unknown>> = []
+    const listeners: Array<(message: ServerMessage) => void> = []
     const { container, dispatchEvent } = createContainerMock()
 
     let renderer!: TestRenderer.ReactTestRenderer
@@ -2616,7 +2667,10 @@ describe('useTerminal', () => {
           tmuxTarget="agentboard:@1"
           agentType="claude"
           sendMessage={(message) => sendCalls.push(message)}
-          subscribe={() => () => {}}
+          subscribe={(listener) => {
+            listeners.push(listener)
+            return () => {}
+          }}
           theme={{ background: '#000' }}
           fontSize={12}
         />,
@@ -2632,7 +2686,10 @@ describe('useTerminal', () => {
           tmuxTarget="agentboard:@2"
           agentType="codex"
           sendMessage={(message) => sendCalls.push(message)}
-          subscribe={() => () => {}}
+          subscribe={(listener) => {
+            listeners.push(listener)
+            return () => {}
+          }}
           theme={{ background: '#000' }}
           fontSize={12}
         />,
@@ -2642,6 +2699,13 @@ describe('useTerminal', () => {
 
     const terminal = TerminalMock.instances[0]
     if (!terminal) throw new Error('Expected terminal instance')
+
+    act(() => {
+      listeners.forEach((listener) => listener({
+        type: 'terminal-ready',
+        sessionId: 'session-2',
+      }))
+    })
 
     terminal.emitKey({ key: 'v', type: 'keydown', metaKey: true, ctrlKey: false })
 

--- a/src/client/components/Terminal.tsx
+++ b/src/client/components/Terminal.tsx
@@ -165,6 +165,7 @@ export default function Terminal({
     appMouseRef,
     setTmuxCopyMode,
     isSwitching,
+    isInputReady,
     pendingClipboardOffer,
     copyPendingClipboardOffer,
     dismissPendingClipboardOffer,
@@ -1001,17 +1002,17 @@ export default function Terminal({
 
   const handleSendKey = useCallback(
     (key: string) => {
-      if (!session || isReadOnly) return
+      if (!session || isReadOnly || !isInputReady) return
       sendMessage({ type: 'terminal-input', sessionId: session.id, data: key })
     },
-    [session, isReadOnly, sendMessage]
+    [session, isReadOnly, isInputReady, sendMessage]
   )
 
   // Deliver pasted text as a single bracketed paste (server routes it through
   // tmux paste-buffer -p) so multi-line content isn't auto-submitted line-by-line.
   const handlePasteText = useCallback(
     (text: string) => {
-      if (!session || isReadOnly) return
+      if (!session || isReadOnly || !isInputReady) return
       // Exit tmux copy-mode first: a paste-buffer into a pane still in copy-mode
       // is swallowed by the copy-mode key table instead of reaching the program.
       if (inTmuxCopyModeRef.current) {
@@ -1020,7 +1021,7 @@ export default function Terminal({
       }
       sendMessage({ type: 'terminal-paste', sessionId: session.id, data: text })
     },
-    [session, isReadOnly, sendMessage, inTmuxCopyModeRef, setTmuxCopyMode]
+    [session, isReadOnly, isInputReady, sendMessage, inTmuxCopyModeRef, setTmuxCopyMode]
   )
 
   const handleRefocus = useCallback(() => {
@@ -1035,7 +1036,7 @@ export default function Terminal({
 
   // Enter text mode: exit copy-mode and focus input (for keyboard button)
   const handleEnterTextMode = useCallback(() => {
-    if (!session || isReadOnly) return
+    if (!session || isReadOnly || !isInputReady) return
     if (inTmuxCopyModeRef.current) {
       sendMessage({ type: 'tmux-cancel-copy-mode', sessionId: session.id })
       setTmuxCopyMode(false)
@@ -1047,7 +1048,7 @@ export default function Terminal({
       textarea.removeAttribute('disabled')
       textarea.focus()
     }
-  }, [session, isReadOnly, sendMessage, containerRef, inTmuxCopyModeRef, setTmuxCopyMode])
+  }, [session, isReadOnly, isInputReady, sendMessage, containerRef, inTmuxCopyModeRef, setTmuxCopyMode])
 
   const isKeyboardVisible = useCallback(() => {
     if (typeof document === 'undefined') return false
@@ -1142,8 +1143,9 @@ export default function Terminal({
           {/* Kill session button - desktop only, left of session name */}
           {session && canControl && (
             <button
+              disabled={isSwitching}
               onClick={() => setShowEndConfirm(true)}
-              className="hidden md:flex h-7 w-7 items-center justify-center rounded bg-danger/10 border border-danger/30 text-danger hover:bg-danger/20 active:scale-95 transition-all shrink-0"
+              className="hidden md:flex h-7 w-7 items-center justify-center rounded bg-danger/10 border border-danger/30 text-danger hover:bg-danger/20 active:scale-95 transition-all shrink-0 disabled:cursor-not-allowed disabled:opacity-40"
               title={`Kill session (${modDisplay}X)`}
               aria-label="Kill session"
             >
@@ -1220,8 +1222,9 @@ export default function Terminal({
           {/* Kill session button - mobile only (desktop has it on left) */}
           {session && canControl && (
             <button
+              disabled={isSwitching}
               onClick={() => setShowEndConfirm(true)}
-              className="flex size-[44px] items-center justify-center rounded border border-danger/30 bg-danger/10 text-danger transition-all hover:bg-danger/20 active:scale-95 md:hidden"
+              className="flex size-[44px] items-center justify-center rounded border border-danger/30 bg-danger/10 text-danger transition-all hover:bg-danger/20 active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 md:hidden"
               title={`Kill session (${modDisplay}X)`}
               aria-label="Kill session"
             >
@@ -1350,7 +1353,11 @@ export default function Terminal({
           style={{ backgroundColor: terminalTheme.background }}
         />
         {isSwitching && session && (
-          <div className="absolute top-2 left-2 z-50 flex items-center gap-1.5 rounded-lg bg-black/60 px-2.5 py-1.5 text-xs text-white/90 shadow-lg backdrop-blur-md">
+          <div
+            role="status"
+            aria-live="polite"
+            className="absolute top-2 left-2 z-50 flex items-center gap-1.5 rounded-lg bg-black/60 px-2.5 py-1.5 text-xs text-white/90 shadow-lg backdrop-blur-md"
+          >
             <svg className="h-3 w-3 animate-spin" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
               <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
               <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
@@ -1490,7 +1497,7 @@ export default function Terminal({
         <TerminalControls
           onSendKey={handleSendKey}
           onPasteText={handlePasteText}
-          disabled={connectionStatus !== 'connected' || isReadOnly}
+          disabled={connectionStatus !== 'connected' || isReadOnly || !isInputReady}
           sessions={sessions.map(s => ({ id: s.id, name: s.name, status: s.status }))}
           currentSessionId={session.id}
           agentType={session.agentType}

--- a/src/client/hooks/useTerminal.ts
+++ b/src/client/hooks/useTerminal.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, useState } from 'react'
+import { useEffect, useRef, useCallback, useLayoutEffect, useState } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebglAddon } from '@xterm/addon-webgl'
@@ -359,6 +359,12 @@ export function useTerminal({
 
   // Track the currently attached session to prevent race conditions
   const attachedSessionRef = useRef<string | null>(null)
+  // During a session transition, input is allowed only after the server
+  // acknowledges the same attachment. Initial mount retains the existing
+  // startup behavior; every later selection/reconnect revokes readiness first.
+  const readySessionRef = useRef<string | null>(
+    sessionId && allowAttach && connectionStatus === 'connected' ? sessionId : null
+  )
   const attachedTargetRef = useRef<string | null>(null)
   const attachedConnectionEpochRef = useRef<number>(-1)
   const focusAfterAttachSessionRef = useRef<string | null>(null)
@@ -484,7 +490,7 @@ export function useTerminal({
 
   // Request tmux copy-mode status from server (debounced)
   const requestCopyModeCheck = useCallback(() => {
-    const attached = attachedSessionRef.current
+    const attached = readySessionRef.current
     if (!attached) return
 
     // Debounce: clear existing timer and set a new one
@@ -504,7 +510,7 @@ export function useTerminal({
 
     fitAddon.fit()
 
-    const attached = attachedSessionRef.current
+    const attached = readySessionRef.current
     if (attached) {
       sendMessageRef.current({
         type: 'terminal-resize',
@@ -750,7 +756,11 @@ export function useTerminal({
     // is still the attached one, so a mid-paste session switch can't deliver to
     // the wrong (or a no-longer-viewed) session.
     const sendInputIfStillAttached = (expected: string, data: string | null) => {
-      if (data && attachedSessionRef.current === expected) {
+      if (
+        data &&
+        attachedSessionRef.current === expected &&
+        readySessionRef.current === expected
+      ) {
         sendMessageRef.current({ type: 'terminal-input', sessionId: expected, data })
       }
     }
@@ -775,7 +785,7 @@ export function useTerminal({
       // Excluded on iOS: no Finder/osascript, and Ctrl+V with hardware keyboard
       // should not trigger desktop image paste behavior.
       if (getIsMac() && !isiOS && event.ctrlKey && !event.metaKey && event.key.toLowerCase() === 'v' && event.type === 'keydown') {
-        const attached = attachedSessionRef.current
+        const attached = readySessionRef.current
         if (attached) {
           if (inTmuxCopyModeRef.current) {
             sendMessageRef.current({ type: 'tmux-cancel-copy-mode', sessionId: attached })
@@ -820,7 +830,7 @@ export function useTerminal({
         })
         void (async () => {
           try {
-            const attached = attachedSessionRef.current
+            const attached = readySessionRef.current
             if (!attached) return
 
             // Wait for the paste event to deliver text (up to 100ms timeout).
@@ -871,7 +881,10 @@ export function useTerminal({
               // pastes to auto-submit on the first newline. Guard on the live
               // ref (like sendInputIfStillAttached) so a session switch during
               // the async clipboard read doesn't paste into the wrong session.
-              if (attachedSessionRef.current === attached) {
+              if (
+                attachedSessionRef.current === attached &&
+                readySessionRef.current === attached
+              ) {
                 // Exit tmux copy-mode first (as onData does for typed input):
                 // paste-buffer into a pane still in copy-mode is swallowed by
                 // the copy-mode key table instead of reaching the program.
@@ -901,7 +914,7 @@ export function useTerminal({
 
       // Ctrl+Backspace: delete word backward (browser eats this otherwise)
       if (event.ctrlKey && event.key === 'Backspace' && event.type === 'keydown') {
-        const attached = attachedSessionRef.current
+        const attached = readySessionRef.current
         if (attached) {
           sendMessageRef.current({ type: 'terminal-input', sessionId: attached, data: '\x17' })
         }
@@ -930,7 +943,7 @@ export function useTerminal({
 
     // Handle input - only send to attached session
     terminal.onData((data) => {
-      const attached = attachedSessionRef.current
+      const attached = readySessionRef.current
       if (attached) {
         // When in copy-mode, filter out mouse sequences so clicks don't exit copy-mode
         // This prevents accidental copy-mode exit when clicking in scrollback (Safari desktop)
@@ -956,7 +969,7 @@ export function useTerminal({
     // Forward wheel events to tmux for scrollback (like Blink terminal)
     // This enters tmux copy-mode instead of using xterm.js local scrollback
     terminal.attachCustomWheelEventHandler((ev) => {
-      const attached = attachedSessionRef.current
+      const attached = readySessionRef.current
       if (!attached) return true // Let xterm handle it
 
       // Don't intercept wheel over HTML inputs (like Claude Code's text box)
@@ -1090,7 +1103,7 @@ export function useTerminal({
       terminal.options.letterSpacing = letterSpacing
       fitAddon.fit()
       // Notify server of new dimensions
-      const attached = attachedSessionRef.current
+      const attached = readySessionRef.current
       if (attached) {
         sendMessageRef.current({
           type: 'terminal-resize',
@@ -1141,7 +1154,26 @@ export function useTerminal({
     }
   }, [useWebGL])
 
-  // Handle session changes and websocket reconnects - attach/detach
+  // Revoke input synchronously when selection or connection intent changes.
+  // The full attach routine remains passive because xterm is initialized in a
+  // passive effect, but this layout effect closes the old-pane input window
+  // before the browser can deliver another user event.
+  useLayoutEffect(() => {
+    if (
+      readySessionRef.current !== sessionId ||
+      !allowAttach ||
+      connectionStatus !== 'connected' ||
+      (attachedConnectionEpochRef.current >= 0 &&
+        attachedConnectionEpochRef.current !== connectionEpoch)
+    ) {
+      readySessionRef.current = null
+      if (sessionId && allowAttach && connectionStatus === 'connected') {
+        setIsSwitching(true)
+      }
+    }
+  }, [sessionId, allowAttach, connectionStatus, connectionEpoch])
+
+  // Handle session changes and websocket reconnects - attach/detach.
   useEffect(() => {
     const terminal = terminalRef.current
     if (!terminal) return
@@ -1150,6 +1182,7 @@ export function useTerminal({
     const prevTarget = attachedTargetRef.current
 
     if (!allowAttach) {
+      readySessionRef.current = null
       if (attachDebounceRef.current !== null) {
         window.clearTimeout(attachDebounceRef.current)
         attachDebounceRef.current = null
@@ -1171,6 +1204,7 @@ export function useTerminal({
     // Reattach when websocket comes back: server-side ws.currentSessionId is
     // cleared on disconnect, so input is ignored until a fresh terminal-attach.
     if (connectionStatus !== 'connected') {
+      readySessionRef.current = null
       if (attachDebounceRef.current !== null) {
         window.clearTimeout(attachDebounceRef.current)
         attachDebounceRef.current = null
@@ -1192,6 +1226,7 @@ export function useTerminal({
 
     // Detach from previous session first
     if (prevAttached && prevAttached !== sessionId) {
+      readySessionRef.current = null
       // Capture terminal snapshot before detach for instant restore on switch-back
       try {
         const serialized = serializeAddonRef.current?.serialize()
@@ -1245,6 +1280,9 @@ export function useTerminal({
       }
       needsResetRef.current = true
       setIsSwitching(true)
+      if (prevAttached !== null) {
+        readySessionRef.current = null
+      }
 
       // Instantly show cached snapshot for the target session (if available)
       const cached = snapshotCache.get(sessionId)
@@ -1344,6 +1382,7 @@ export function useTerminal({
       attachedTargetRef.current = null
       attachedConnectionEpochRef.current = -1
       focusAfterAttachSessionRef.current = null
+      readySessionRef.current = null
     }
 
     // Cancel pending debounced attach on effect re-run or unmount
@@ -1489,6 +1528,7 @@ export function useTerminal({
         attachedSession &&
         message.sessionId === attachedSession
       ) {
+        readySessionRef.current = message.sessionId
         // If output is buffered but unflushed, flush now so reset+write
         // stay atomic (avoids blank flash from resetting before flush fires).
         // If no output arrived at all (empty pane or server dedup), reset
@@ -1534,6 +1574,7 @@ export function useTerminal({
         attachedSession &&
         (!message.sessionId || message.sessionId === attachedSession)
       ) {
+        readySessionRef.current = null
         needsResetRef.current = false
         setIsSwitching(false)
       }
@@ -1724,6 +1765,12 @@ export function useTerminal({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  const isInputReady =
+    !!sessionId &&
+    allowAttach &&
+    connectionStatus === 'connected' &&
+    readySessionRef.current === sessionId
+
   return {
     containerRef,
     terminalRef,
@@ -1734,6 +1781,7 @@ export function useTerminal({
     appMouseRef,
     setTmuxCopyMode,
     isSwitching,
+    isInputReady,
     pendingClipboardOffer,
     copyPendingClipboardOffer,
     dismissPendingClipboardOffer,

--- a/src/client/hooks/useTerminal.ts
+++ b/src/client/hooks/useTerminal.ts
@@ -510,7 +510,7 @@ export function useTerminal({
 
     fitAddon.fit()
 
-    const attached = readySessionRef.current
+    const attached = attachedSessionRef.current
     if (attached) {
       sendMessageRef.current({
         type: 'terminal-resize',
@@ -1103,7 +1103,7 @@ export function useTerminal({
       terminal.options.letterSpacing = letterSpacing
       fitAddon.fit()
       // Notify server of new dimensions
-      const attached = readySessionRef.current
+      const attached = attachedSessionRef.current
       if (attached) {
         sendMessageRef.current({
           type: 'terminal-resize',


### PR DESCRIPTION
Fixes #192.

## Summary
- revoke terminal input readiness synchronously when session selection or connection intent changes
- restore input only after the matching `terminal-ready` acknowledgement
- disable terminal controls and header kill actions during switching
- preserve resize synchronization while input is blocked
- bump the patch version to 0.4.11

## Verification
- browser-tested against a separate Agentboard instance and private tmux socket with a forced 1.1s switch delay
- confirmed input typed during the transition reached neither pane
- confirmed input resumed on the selected pane after `terminal-ready`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- independent read-only Claude review; addressed its confirmed resize regression finding