### PR TITLE
fix: preserve unicode terminal input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -63,7 +63,7 @@ export default defineConfig({
     // AGENTBOARD_STATIC_DIR is pinned to the repo build: when e2e runs from a
     // shell inside a live agentboard session, the inherited env points at the
     // installed npm package's bundle and the tests would exercise stale code.
-    command: `[ -d dist/client ] || bun run build && PORT=${port} TMUX_SESSION=${tmuxSession} AGENTBOARD_STATIC_DIR=dist/client bun src/server/index.ts`,
+    command: `[ -d dist/client ] || bun run build && LC_ALL=C LANG=C PORT=${port} TMUX_SESSION=${tmuxSession} AGENTBOARD_STATIC_DIR=dist/client bun src/server/index.ts`,
     url: `http://localhost:${port}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120000,

--- a/src/server/__tests__/isolated/terminalProxy.test.ts
+++ b/src/server/__tests__/isolated/terminalProxy.test.ts
@@ -24,7 +24,7 @@ function createSpawnHarness({ tmuxVersion = 'tmux 3.4' } = {}) {
     args: string[]
     options?: Parameters<typeof Bun.spawnSync>[1]
   }> = []
-  const writes: string[] = []
+  const writes: Array<string | Uint8Array> = []
   const resizes: Array<{ cols: number; rows: number }> = []
   let closed = false
   let killed = false
@@ -40,8 +40,16 @@ function createSpawnHarness({ tmuxVersion = 'tmux 3.4' } = {}) {
   })
 
   const terminal = {
-    write: (data: string) => {
-      writes.push(data)
+    write: (data: string | BufferSource) => {
+      if (typeof data === 'string') {
+        writes.push(data)
+        return
+      }
+      const view =
+        data instanceof ArrayBuffer
+          ? new Uint8Array(data)
+          : new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+      writes.push(view.slice())
     },
     resize: (cols: number, rows: number) => {
       resizes.push({ cols, rows })
@@ -320,6 +328,7 @@ describe('TerminalProxy', () => {
     )
     expect(harness.spawnCalls[0]?.args).toEqual([
       'tmux',
+      '-u',
       '-T',
       'sync',
       'attach',
@@ -352,6 +361,7 @@ describe('TerminalProxy', () => {
 
       expect(harness.spawnCalls[0]?.args).toEqual([
         'tmux',
+        '-u',
         'attach',
         '-t',
         'agentboard-ws-abc',
@@ -381,6 +391,7 @@ describe('TerminalProxy', () => {
 
     expect(harness.spawnCalls[0]?.args).toEqual([
       'tmux',
+      '-u',
       'attach',
       '-t',
       'agentboard-ws-abc',
@@ -906,7 +917,16 @@ describe('TerminalProxy', () => {
     proxy.resize(120, 40)
     await proxy.dispose()
 
-    expect(harness.writes).toEqual(['ls'])
+    expect(harness.spawnCalls[0]?.args).toEqual([
+      'tmux',
+      '-u',
+      '-T',
+      'sync',
+      'attach',
+      '-t',
+      'agentboard-ws-abc',
+    ])
+    expect(harness.writes).toEqual([new TextEncoder().encode('ls')])
     expect(harness.resizes).toEqual([{ cols: 120, rows: 40 }])
     expect(harness.wasClosed()).toBe(true)
     expect(harness.wasKilled()).toBe(true)
@@ -914,6 +934,26 @@ describe('TerminalProxy', () => {
       args: ['tmux', 'kill-session', '-t', 'agentboard-ws-abc'],
       options: expect.objectContaining({ timeout: 15000 }),
     })
+  })
+
+  test('writes terminal input as explicit UTF-8 bytes', async () => {
+    const harness = createSpawnHarness()
+    const proxy = new TerminalProxy({
+      connectionId: 'unicode',
+      sessionName: 'agentboard-ws-unicode',
+      baseSession: 'agentboard',
+      onData: () => {},
+      spawn: harness.spawn,
+      spawnSync: harness.spawnSync,
+      wait: async () => {},
+    })
+
+    await proxy.start()
+    proxy.write('áéíñü-你好-🚀')
+
+    expect(harness.writes).toEqual([
+      new TextEncoder().encode('áéíñü-你好-🚀'),
+    ])
   })
 
   test('disposes the grouped session when tmux attach spawn fails', async () => {

--- a/src/server/__tests__/sshTerminalProxy.test.ts
+++ b/src/server/__tests__/sshTerminalProxy.test.ts
@@ -15,7 +15,7 @@ function createSshHarness(options?: {
     mode: 'terminal' | 'pipe'
     stdin?: string
   }> = []
-  const terminalWrites: string[] = []
+  const terminalWrites: Array<string | Uint8Array> = []
   let killed = false
   let terminalClosed = false
   let exitResolver: ((code: number) => void) | null = null
@@ -51,8 +51,16 @@ function createSshHarness(options?: {
       // Terminal mode — used by doStartCore for SSH attach
       return {
         terminal: {
-          write: (data: string) => {
-            terminalWrites.push(data)
+          write: (data: string | BufferSource) => {
+            if (typeof data === 'string') {
+              terminalWrites.push(data)
+              return
+            }
+            const view =
+              data instanceof ArrayBuffer
+                ? new Uint8Array(data)
+                : new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+            terminalWrites.push(view.slice())
           },
           resize: () => {},
           close: () => {
@@ -160,6 +168,12 @@ describe('SshTerminalProxy', () => {
     expect(attachArgs).toContain('ssh')
     expect(attachArgs).toContain('-tt')
     expect(attachArgs).toContain('remote-host')
+    expect(attachArgs.at(-1)).toContain('tmux -u')
+
+    proxy.write('áéíñü-你好-🚀')
+    expect(harness.terminalWrites).toEqual([
+      new TextEncoder().encode('áéíñü-你好-🚀'),
+    ])
 
     await proxy.dispose()
   })
@@ -527,7 +541,7 @@ describe('SshTerminalProxy sync terminal feature', () => {
       spawnPipeOverride: versionAnswers({ createVersion: '3.4' }),
     })
     const attachCmd = await startAndGetAttachCmd(harness)
-    expect(attachCmd).toContain('tmux -T sync new-session -A')
+    expect(attachCmd).toContain('tmux -u -T sync new-session -A')
     // The create round-trip supplied the version; no separate -V probe.
     const probeCalls = harness.spawnCalls.filter(
       (c) => c.mode === 'pipe' && (c.args[c.args.length - 1] ?? '') === 'tmux -V'
@@ -540,7 +554,7 @@ describe('SshTerminalProxy sync terminal feature', () => {
       spawnPipeOverride: versionAnswers({ createVersion: '3.1c' }),
     })
     const attachCmd = await startAndGetAttachCmd(harness)
-    expect(attachCmd).toContain('tmux new-session -A')
+    expect(attachCmd).toContain('tmux -u new-session -A')
     expect(attachCmd).not.toContain('-T sync')
   })
 
@@ -549,7 +563,7 @@ describe('SshTerminalProxy sync terminal feature', () => {
       spawnPipeOverride: versionAnswers({ createDuplicate: true, probeVersion: '3.4' }),
     })
     const attachCmd = await startAndGetAttachCmd(harness)
-    expect(attachCmd).toContain('tmux -T sync new-session -A')
+    expect(attachCmd).toContain('tmux -u -T sync new-session -A')
   })
 
   test('degrades to a plain attach when the fallback probe fails', async () => {
@@ -557,7 +571,7 @@ describe('SshTerminalProxy sync terminal feature', () => {
       spawnPipeOverride: versionAnswers({ createDuplicate: true, probeFails: true }),
     })
     const attachCmd = await startAndGetAttachCmd(harness)
-    expect(attachCmd).toContain('tmux new-session -A')
+    expect(attachCmd).toContain('tmux -u new-session -A')
     expect(attachCmd).not.toContain('-T sync')
   })
 
@@ -569,7 +583,7 @@ describe('SshTerminalProxy sync terminal feature', () => {
         spawnPipeOverride: versionAnswers({ createVersion: '3.4' }),
       })
       const attachCmd = await startAndGetAttachCmd(harness)
-      expect(attachCmd).toContain('tmux new-session -A')
+      expect(attachCmd).toContain('tmux -u new-session -A')
       expect(attachCmd).not.toContain('-T sync')
     } finally {
       if (saved === undefined) {

--- a/src/server/terminal/PtyTerminalProxy.ts
+++ b/src/server/terminal/PtyTerminalProxy.ts
@@ -5,7 +5,11 @@ import {
 } from './TerminalProxyBase'
 import { TerminalProxyError, TerminalState } from './types'
 import { resolveGroupedSessionSwitchTarget } from './groupedSessionTarget'
-import { buildTmuxFormat, splitTmuxFields } from '../tmuxFormat'
+import {
+  buildTmuxFormat,
+  splitTmuxFields,
+  withTmuxUtf8Flag,
+} from '../tmuxFormat'
 import { sanitizedTmuxEnv } from '../tmuxEnv'
 
 const CLIENT_TTY_FORMAT = buildTmuxFormat([
@@ -39,6 +43,7 @@ interface TmuxTargetIdentity {
 class PtyTerminalProxy extends TerminalProxyBase {
   private process: ReturnType<typeof Bun.spawn> | null = null
   private decoder = new TextDecoder()
+  private encoder = new TextEncoder()
   private cols = 80
   private rows = 24
   private clientTty: string | null = null
@@ -318,7 +323,7 @@ class PtyTerminalProxy extends TerminalProxyBase {
   }
 
   write(data: string): void {
-    this.process?.terminal?.write(data)
+    this.process?.terminal?.write(this.encoder.encode(data))
   }
 
   paste(data: string): void {
@@ -515,8 +520,18 @@ class PtyTerminalProxy extends TerminalProxyBase {
 
     let proc: ReturnType<typeof Bun.spawn>
     try {
+      // Agentboard's browser PTY is UTF-8 even when a service manager gives
+      // the server a C locale. Force tmux's client to render UTF-8 output.
       proc = this.spawn(
-        ['tmux', ...this.clientFeatureArgs(), 'attach', '-t', this.options.sessionName],
+        [
+          'tmux',
+          ...withTmuxUtf8Flag([
+            ...this.clientFeatureArgs(),
+            'attach',
+            '-t',
+            this.options.sessionName,
+          ]),
+        ],
         {
           env: {
             ...sanitizedTmuxEnv(),

--- a/src/server/terminal/SshTerminalProxy.ts
+++ b/src/server/terminal/SshTerminalProxy.ts
@@ -18,6 +18,7 @@ class SshTerminalProxy extends TerminalProxyBase {
 
   private process: ReturnType<typeof Bun.spawn> | null = null
   private decoder = new TextDecoder()
+  private encoder = new TextEncoder()
   private cols = 80
   private rows = 24
   private clientTty: string | null = null
@@ -44,7 +45,7 @@ class SshTerminalProxy extends TerminalProxyBase {
   }
 
   write(data: string): void {
-    this.process?.terminal?.write(data)
+    this.process?.terminal?.write(this.encoder.encode(data))
   }
 
   paste(data: string): void {
@@ -308,10 +309,18 @@ class SshTerminalProxy extends TerminalProxyBase {
       )
     }
 
-    // Pass the remote tmux attach command as a single string to SSH.
+    // Pass the remote tmux attach command as a single string to SSH. Force
+    // UTF-8 because the remote login may inherit a non-UTF-8 service locale.
     const featureArgs = await this.clientFeatureArgs(remoteVersion)
-    const attachCmd = ['tmux', ...featureArgs, 'new-session', '-A', '-s']
-      .join(' ') + ` ${shellQuote(this.options.sessionName)}`
+    const attachCmd = [
+      'tmux',
+      ...withTmuxUtf8Flag([
+        ...featureArgs,
+        'new-session',
+        '-A',
+        '-s',
+      ]),
+    ].join(' ') + ` ${shellQuote(this.options.sessionName)}`
     const spawnArgs = [
       'ssh',
       '-tt',

--- a/tests/e2e/fixtures/paste-repl.py
+++ b/tests/e2e/fixtures/paste-repl.py
@@ -62,6 +62,7 @@ def main() -> None:
                     byte = bytes([byte_value])
                     if byte in (b"\r", b"\n"):
                         os.write(1, b"SUBMITTED:" + render(buf) + b"\r\n")
+                        os.write(1, b"INPUT_HEX:" + buf.hex().encode() + b"\r\n")
                         buf = b""
                     elif byte == b"\x03":  # Ctrl-C exits
                         raise KeyboardInterrupt

--- a/tests/e2e/paste.spec.ts
+++ b/tests/e2e/paste.spec.ts
@@ -9,6 +9,9 @@ import { test, expect } from '@playwright/test'
 
 const WINDOW_NAME = 'paste-repl'
 const REPL_PATH = fileURLToPath(new URL('./fixtures/paste-repl.py', import.meta.url))
+const UNICODE_INPUT = 'áéíñü-你好-🚀'
+const UNICODE_HEX =
+  'c3a1c3a9c3adc3b1c3bc2de4bda0e5a5bd2df09f9a80'
 
 function tmux(args: string[]): { status: number | null; stdout: string } {
   const result = spawnSync('tmux', args, { encoding: 'utf-8' })
@@ -98,6 +101,13 @@ test('multi-line text paste is held for editing, not auto-submitted', async ({ p
     await page.locator('.xterm-helper-textarea').focus()
     await page.keyboard.press('Enter')
     await waitForPaneText(target, 'SUBMITTED:e2e_alpha|e2e_beta')
+
+    // IME and predictive keyboards commit characters through the browser's
+    // text-input path. Verify they reach the pane as exact UTF-8 bytes.
+    await page.locator('.xterm-helper-textarea').focus()
+    await page.keyboard.insertText(UNICODE_INPUT)
+    await page.keyboard.press('Enter')
+    await waitForPaneText(target, `INPUT_HEX:${UNICODE_HEX}`)
   } finally {
     tmux(['kill-window', '-t', target])
   }


### PR DESCRIPTION
Closes #191

## Summary
- encode interactive PTY and SSH terminal input as explicit UTF-8 bytes
- force tmux attach clients to render UTF-8 under non-UTF-8 service locales
- exercise typed accented Latin, CJK, and emoji input under a forced C locale and assert exact pane bytes
- bump the patch version to 0.4.13

## Verification
- bun run lint
- bun run typecheck
- bun run test
- CI=1 E2E_PORT=43196 bunx playwright test --reporter=line
- isolated mobile browser verification at 430x932
- read-only Claude Code review: ship, no blockers