### PR TITLE
fix: preserve unicode terminal snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/server/SessionManager.ts
+++ b/src/server/SessionManager.ts
@@ -1091,7 +1091,13 @@ function capturePaneWithDimensions(tmuxWindow: string): PaneCapture | null {
     // Use -J to unwrap lines and only capture visible content (no scrollback)
     // This prevents false positives from scrollback buffer changes on window focus
     const result = Bun.spawnSync(
-      ['tmux', 'capture-pane', '-t', tmuxWindow, '-p', '-J'],
+      ['tmux', ...withTmuxUtf8Flag([
+        'capture-pane',
+        '-t',
+        tmuxWindow,
+        '-p',
+        '-J',
+      ])],
       {
         stdout: 'pipe',
         stderr: 'pipe',

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -2870,12 +2870,14 @@ describe('server message handlers', () => {
     let captureTarget = ''
     let captureArgs: string[] = []
     let captureOptions: Parameters<typeof Bun.spawnSync>[1] | undefined
+    let captureUsesUtf8 = false
     let copyModeTarget = ''
     spawnSyncImpl = ((...args: Parameters<typeof Bun.spawnSync>) => {
       const command = Array.isArray(args[0]) ? args[0] : [String(args[0])]
       const tmuxArgs = getTmuxArgs(command as string[])
       if (tmuxArgs[0] === 'capture-pane') {
         captureArgs = tmuxArgs
+        captureUsesUtf8 = command[1] === '-u'
         captureTarget = tmuxArgs[2] ?? ''
         captureOptions = args[1]
       }
@@ -2893,7 +2895,7 @@ describe('server message handlers', () => {
         exitCode: 0,
         stdout:
           tmuxArgs[0] === 'capture-pane'
-            ? Buffer.from('visible pane line\n')
+            ? Buffer.from('visible pane 你好 🚀\n')
             : Buffer.from(''),
         stderr: Buffer.from(''),
       } as ReturnType<typeof Bun.spawnSync>
@@ -2920,12 +2922,13 @@ describe('server message handlers', () => {
     expect(attached.switchTargets).toEqual(['agentboard'])
     expect(captureTarget).toBe(groupedTarget)
     expect(captureArgs[0]).toBe('capture-pane')
+    expect(captureUsesUtf8).toBe(true)
     expect(captureOptions?.timeout).toBe(configState.tmuxTimeoutMs)
     const historyIndex = sent.findIndex(
       (message) =>
         message.type === 'terminal-output' &&
         message.sessionId === baseSession.id &&
-        message.data === 'visible pane line\n'
+        message.data === 'visible pane 你好 🚀\n'
     )
     expect(historyIndex).toBeGreaterThanOrEqual(0)
     expect(ws.data.currentTmuxTarget).toBe(groupedTarget)
@@ -2961,7 +2964,7 @@ describe('server message handlers', () => {
     let captureTimeout: number | undefined
     spawnSyncImpl = ((...args: Parameters<typeof Bun.spawnSync>) => {
       const command = Array.isArray(args[0]) ? args[0] : [String(args[0])]
-      if (command[0] === 'tmux' && command[1] === 'capture-pane') {
+      if (getTmuxArgs(command as string[])[0] === 'capture-pane') {
         captureTimeout = args[1]?.timeout
         return {
           exitCode: null,
@@ -5782,7 +5785,7 @@ describe('server startup side effects', () => {
 
     spawnSyncImpl = ((...args: Parameters<typeof Bun.spawnSync>) => {
       const command = Array.isArray(args[0]) ? args[0] : [String(args[0])]
-      if (command[0] === 'tmux' && command[1] === 'capture-pane') {
+      if (getTmuxArgs(command as string[])[0] === 'capture-pane') {
         syncCapturePaneCalls.push(command as string[])
       }
       return {
@@ -5797,7 +5800,7 @@ describe('server startup side effects', () => {
         exited: Promise.resolve(0),
         stdout: new ReadableStream({
           start(controller) {
-            if (cmd[0] === 'tmux' && cmd[1] === 'capture-pane') {
+            if (getTmuxArgs(cmd as string[])[0] === 'capture-pane') {
               controller.enqueue(new TextEncoder().encode(''))
             }
             controller.close()

--- a/src/server/__tests__/logMatchWorker.test.ts
+++ b/src/server/__tests__/logMatchWorker.test.ts
@@ -164,7 +164,8 @@ beforeEach(async () => {
   })
 
   bunAny.spawnSync = ((args: string[]) => {
-    if (args[0] === 'tmux' && args[1] === 'capture-pane') {
+    const tmuxSubcommand = args[1] === '-u' ? args[2] : args[1]
+    if (args[0] === 'tmux' && tmuxSubcommand === 'capture-pane') {
       const targetIndex = args.indexOf('-t')
       const target = targetIndex >= 0 ? args[targetIndex + 1] : ''
       const output = tmuxOutputs.get(target ?? '') ?? ''

--- a/src/server/__tests__/logMatcher.test.ts
+++ b/src/server/__tests__/logMatcher.test.ts
@@ -20,6 +20,7 @@ import {
   hasMessageInValidUserContext,
   isToolNotificationText,
   extractLastEntryTimestamp,
+  captureTerminalScrollback,
 } from '../logMatcher'
 
 const bunAny = Bun as typeof Bun & {
@@ -30,6 +31,7 @@ const originalSpawn = bunAny.spawn
 const originalSpawnSync = bunAny.spawnSync
 
 const tmuxOutputs = new Map<string, string>()
+const commandCalls: string[][] = []
 
 function setTmuxOutput(target: string, content: string) {
   tmuxOutputs.set(target, content)
@@ -128,7 +130,9 @@ function runRg(args: string[]) {
 }
 
 function runCommand(args: string[]) {
-  if (args[0] === 'tmux' && args[1] === 'capture-pane') {
+  commandCalls.push(args)
+  const tmuxSubcommand = args[1] === '-u' ? args[2] : args[1]
+  if (args[0] === 'tmux' && tmuxSubcommand === 'capture-pane') {
     const targetIndex = args.indexOf('-t')
     const target = targetIndex >= 0 ? args[targetIndex + 1] : ''
     const output = tmuxOutputs.get(target ?? '') ?? ''
@@ -181,6 +185,7 @@ function buildUserLogEntry(message: string): string {
 }
 
 beforeEach(() => {
+  commandCalls.length = 0
   bunAny.spawn = ((args: string[]) => {
     const result = runCommand(args)
     return {
@@ -204,6 +209,20 @@ afterEach(() => {
 })
 
 describe('logMatcher', () => {
+  test('captures tmux scrollback through a UTF-8 client', () => {
+    setTmuxOutput('agentboard:1', '你好 🚀')
+
+    expect(captureTerminalScrollback('agentboard:1', 20)).toEqual({
+      ok: true,
+      content: '你好 🚀',
+    })
+    expect(commandCalls[0]?.slice(0, 3)).toEqual([
+      'tmux',
+      '-u',
+      'capture-pane',
+    ])
+  })
+
   test('normalizeText strips ANSI and control characters', () => {
     const input = '\u001b[31mHello\u001b[0m\u0007\nWorld'
     expect(normalizeText(input)).toBe('hello world')

--- a/src/server/__tests__/logPoller.test.ts
+++ b/src/server/__tests__/logPoller.test.ts
@@ -170,7 +170,8 @@ beforeEach(async () => {
   process.env.PI_HOME = path.join(tempRoot, 'pi')
 
   bunAny.spawnSync = ((args: string[]) => {
-    if (args[0] === 'tmux' && args[1] === 'capture-pane') {
+    const tmuxSubcommand = args[1] === '-u' ? args[2] : args[1]
+    if (args[0] === 'tmux' && tmuxSubcommand === 'capture-pane') {
       const targetIndex = args.indexOf('-t')
       const target = targetIndex >= 0 ? args[targetIndex + 1] : ''
       const output = tmuxOutputs.get(target ?? '') ?? ''

--- a/src/server/__tests__/sessionManager.test.ts
+++ b/src/server/__tests__/sessionManager.test.ts
@@ -1266,7 +1266,11 @@ describe('SessionManager', () => {
 
     const originalPrefixes = config.discoverPrefixes
     config.discoverPrefixes = []
+    const capturedCommands: string[][] = []
     bunAny.spawnSync = (args) => {
+      if (Array.isArray(args)) {
+        capturedCommands.push(args as string[])
+      }
       const command = Array.isArray(args) ? getTmuxCommand(args.slice(1)) : ''
       if (command === 'display-message') {
         return {
@@ -1290,6 +1294,11 @@ describe('SessionManager', () => {
 
       const sessions = manager.listWindows()
       expect(sessions[0]?.status).toBe('waiting')
+      expect(
+        capturedCommands.some(
+          (args) => args[0] === 'tmux' && args[1] === '-u' && args[2] === 'capture-pane'
+        )
+      ).toBe(true)
     } finally {
       bunAny.spawnSync = originalSpawnSync
       config.discoverPrefixes = originalPrefixes

--- a/src/server/__tests__/sessionRefreshWorker.test.ts
+++ b/src/server/__tests__/sessionRefreshWorker.test.ts
@@ -172,6 +172,7 @@ describe('sessionRefreshWorker', () => {
       joinTmuxFields(['agentboard', '1', 'alpha', '/Users/test/project', '100', '1700000000', '"claude --dangerously-skip-permissions"', '80', '24']),
     ].join('\n')
 
+    let captureCommand: string[] | undefined
     bunAny.spawnSync = ((args: string[]) => {
       if (getTmuxSubcommand(args) === 'list-windows') {
         return {
@@ -181,6 +182,7 @@ describe('sessionRefreshWorker', () => {
         } as ReturnType<typeof Bun.spawnSync>
       }
       if (getTmuxSubcommand(args) === 'capture-pane') {
+        captureCommand = args
         return {
           exitCode: 0,
           stdout: Buffer.from('ready'),
@@ -208,6 +210,7 @@ describe('sessionRefreshWorker', () => {
 
     expect(response.sessions).toHaveLength(1)
     expect(response.sessions[0]?.command).toBe('claude --dangerously-skip-permissions')
+    expect(captureCommand?.slice(0, 3)).toEqual(['tmux', '-u', 'capture-pane'])
     expect(response.sessions[0]?.agentType).toBe('claude')
   })
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4168,7 +4168,13 @@ function captureTmuxHistory(target: string): string | null {
   try {
     // Capture only the visible pane so initial attach paints the current view
     // immediately instead of replaying the entire scrollback buffer.
-    const result = Bun.spawnSync(['tmux', 'capture-pane', '-t', target, '-p', '-J'], {
+    const result = Bun.spawnSync(['tmux', ...withTmuxUtf8Flag([
+      'capture-pane',
+      '-t',
+      target,
+      '-p',
+      '-J',
+    ])], {
       stdout: 'pipe',
       stderr: 'pipe',
       timeout: config.tmuxTimeoutMs,

--- a/src/server/logMatcher.ts
+++ b/src/server/logMatcher.ts
@@ -17,6 +17,7 @@ import {
   TMUX_UI_GLYPH_PATTERN,
 } from './terminal/tmuxText'
 import { logger } from './logger'
+import { withTmuxUtf8Flag } from './tmuxFormat'
 
 export type LogTextMode = 'all' | 'assistant' | 'user' | 'assistant-user'
 
@@ -1278,7 +1279,15 @@ export function captureTerminalScrollback(
 ): { ok: boolean; content: string } {
   const safeLines = Math.max(1, lines)
   const result = runCommandSync(
-    ['tmux', 'capture-pane', '-t', tmuxWindow, '-p', '-J', '-S', `-${safeLines}`],
+    ['tmux', ...withTmuxUtf8Flag([
+      'capture-pane',
+      '-t',
+      tmuxWindow,
+      '-p',
+      '-J',
+      '-S',
+      `-${safeLines}`,
+    ])],
     { timeoutMs: TMUX_CAPTURE_TIMEOUT_MS }
   )
   if (result.exitCode !== 0) {
@@ -1301,7 +1310,15 @@ export async function captureTerminalScrollbackAsync(
 ): Promise<{ ok: boolean; content: string }> {
   const safeLines = Math.max(1, lines)
   const result = await runCommandAsync(
-    ['tmux', 'capture-pane', '-t', tmuxWindow, '-p', '-J', '-S', `-${safeLines}`],
+    ['tmux', ...withTmuxUtf8Flag([
+      'capture-pane',
+      '-t',
+      tmuxWindow,
+      '-p',
+      '-J',
+      '-S',
+      `-${safeLines}`,
+    ])],
     { timeoutMs: TMUX_CAPTURE_TIMEOUT_MS }
   )
   if (result.exitCode !== 0) {
@@ -1320,7 +1337,16 @@ export function getTerminalScrollbackWithAnsi(
 ): string {
   const safeLines = Math.max(1, lines)
   const result = runCommandSync(
-    ['tmux', 'capture-pane', '-t', tmuxWindow, '-p', '-J', '-e', '-S', `-${safeLines}`],
+    ['tmux', ...withTmuxUtf8Flag([
+      'capture-pane',
+      '-t',
+      tmuxWindow,
+      '-p',
+      '-J',
+      '-e',
+      '-S',
+      `-${safeLines}`,
+    ])],
     { timeoutMs: TMUX_CAPTURE_TIMEOUT_MS }
   )
   if (result.exitCode !== 0) {
@@ -1335,7 +1361,16 @@ export async function getTerminalScrollbackWithAnsiAsync(
 ): Promise<string> {
   const safeLines = Math.max(1, lines)
   const result = await runCommandAsync(
-    ['tmux', 'capture-pane', '-t', tmuxWindow, '-p', '-J', '-e', '-S', `-${safeLines}`],
+    ['tmux', ...withTmuxUtf8Flag([
+      'capture-pane',
+      '-t',
+      tmuxWindow,
+      '-p',
+      '-J',
+      '-e',
+      '-S',
+      `-${safeLines}`,
+    ])],
     { timeoutMs: TMUX_CAPTURE_TIMEOUT_MS }
   )
   if (result.exitCode !== 0) {

--- a/src/server/sessionRefreshWorker.ts
+++ b/src/server/sessionRefreshWorker.ts
@@ -240,7 +240,13 @@ function listAllWindowData(): WindowData[] {
 function capturePane(tmuxWindow: string): string | null {
   try {
     const result = Bun.spawnSync(
-      ['tmux', 'capture-pane', '-t', tmuxWindow, '-p', '-J'],
+      ['tmux', ...withTmuxUtf8Flag([
+        'capture-pane',
+        '-t',
+        tmuxWindow,
+        '-p',
+        '-J',
+      ])],
       {
         stdout: 'pipe',
         stderr: 'pipe',
@@ -267,7 +273,15 @@ function captureScrollback(tmuxWindow: string, lines: number): string {
   const safeLines = Math.max(1, lines)
   try {
     const result = Bun.spawnSync(
-      ['tmux', 'capture-pane', '-t', tmuxWindow, '-p', '-J', '-S', `-${safeLines}`],
+      ['tmux', ...withTmuxUtf8Flag([
+        'capture-pane',
+        '-t',
+        tmuxWindow,
+        '-p',
+        '-J',
+        '-S',
+        `-${safeLines}`,
+      ])],
       {
         stdout: 'pipe',
         stderr: 'pipe',


### PR DESCRIPTION
Follow-up to #191.

## Summary
- force UTF-8 output for every local capture-pane path
- preserve Unicode in initial terminal history, status refresh, and log matching captures
- keep already-safe remote capture behavior unchanged
- bump the patch version to 0.4.14

## Verification
- bun run lint
- bun run typecheck
- bun run test
- CI=1 E2E_PORT=43219 bunx playwright test --reporter=line
- isolated 430x932 browser reload verified áéíñü-你好-🚀 in the restored terminal snapshot

All tmux and Agentboard browser checks used private sockets and throwaway state.