### PR TITLE
fix: preserve multiline manual pastes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/__tests__/terminalControls.test.tsx
+++ b/src/client/__tests__/terminalControls.test.tsx
@@ -222,8 +222,9 @@ describe('TerminalControls', () => {
     expect(sent).toEqual(['pasted text'])
   })
 
-  test('manual paste input sends text on enter', async () => {
+  test('manual paste textarea preserves multiline text', async () => {
     const sent: string[] = []
+    const pasted: string[] = []
 
     globalAny.navigator = {
       vibrate: () => true,
@@ -236,6 +237,7 @@ describe('TerminalControls', () => {
     const renderer = TestRenderer.create(
       <TerminalControls
         onSendKey={(key) => sent.push(key)}
+        onPasteText={(text) => pasted.push(text)}
         sessions={[{ id: 'session-1', name: 'alpha', status: 'working' }]}
         currentSessionId="session-1"
         onSelectSession={() => {}}
@@ -251,20 +253,38 @@ describe('TerminalControls', () => {
       await pasteButton.props.onClick()
     })
 
-    const input = renderer.root.findByType('input')
+    const textarea = renderer.root.findByType('textarea')
 
     act(() => {
-      input.props.onChange({ target: { value: 'manual' } })
+      textarea.props.onChange({ target: { value: 'line 1\nline 2\n' } })
     })
 
+    let prevented = false
     act(() => {
-      input.props.onKeyDown({
+      textarea.props.onKeyDown({
         key: 'Enter',
-        preventDefault: () => {},
+        preventDefault: () => {
+          prevented = true
+        },
       })
     })
 
-    expect(sent).toEqual(['manual'])
+    expect(prevented).toBe(false)
+    expect(pasted).toEqual([])
+
+    const sendButton = renderer.root
+      .findAllByType('button')
+      .find((button) => button.props.children === 'Send')
+    if (!sendButton) {
+      throw new Error('Expected send button')
+    }
+
+    act(() => {
+      sendButton.props.onClick()
+    })
+
+    expect(pasted).toEqual(['line 1\nline 2\n'])
+    expect(sent).toEqual([])
   })
 
   test('paste button uploads clipboard image and sends a bracketed path for Claude', async () => {

--- a/src/client/components/TerminalControls.tsx
+++ b/src/client/components/TerminalControls.tsx
@@ -171,7 +171,7 @@ export default function TerminalControls({
   const [pasteError, setPasteError] = useState<string | null>(null)
   const [isUploading, setIsUploading] = useState(false)
   const [ctrlActive, setCtrlActive] = useState(false)
-  const pasteInputRef = useRef<HTMLInputElement>(null)
+  const pasteInputRef = useRef<HTMLTextAreaElement>(null)
   const pasteZoneRef = useRef<HTMLDivElement>(null)
   const lastTouchTimeRef = useRef(0)
   const controlsRef = useRef<HTMLDivElement>(null)
@@ -638,22 +638,20 @@ export default function TerminalControls({
                 Uploading image...
               </div>
             ) : (
-              <input
+              <textarea
                 ref={pasteInputRef}
-                type="text"
                 value={pasteValue}
                 onChange={(e) => setPasteValue(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault()
-                    handlePasteSubmit()
-                  } else if (e.key === 'Escape') {
+                  if (e.key === 'Escape') {
                     e.preventDefault()
                     handlePasteCancel()
                   }
                 }}
                 placeholder="Paste here..."
-                className="w-full h-11 px-3 text-[16px] bg-surface border border-border rounded-md text-primary placeholder:text-muted outline-none focus:border-accent"
+                aria-label="Paste text"
+                rows={4}
+                className="block w-full min-h-24 resize-y px-3 py-2 text-[16px] bg-surface border border-border rounded-md text-primary placeholder:text-muted outline-none focus:border-accent"
                 style={{ fontSize: '16px' }}
               />
             )}

--- a/tests/e2e/manual-paste.spec.ts
+++ b/tests/e2e/manual-paste.spec.ts
@@ -1,0 +1,116 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { expect, test, type Page } from '@playwright/test'
+
+const REPL_PATH = fileURLToPath(new URL('./fixtures/paste-repl.py', import.meta.url))
+
+function tmux(args: string[]): { status: number | null; stdout: string } {
+  const result = spawnSync('tmux', args, { encoding: 'utf-8' })
+  return { status: result.status, stdout: result.stdout ?? '' }
+}
+
+async function waitForPaneText(
+  target: string,
+  needle: string,
+  timeoutMs = 10000
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs
+  let content = ''
+  while (Date.now() < deadline) {
+    content = tmux(['capture-pane', '-t', target, '-p']).stdout
+    if (content.includes(needle)) return content
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+  throw new Error(
+    `Timed out waiting for ${JSON.stringify(needle)} in pane ${target}. Last content:\n${content}`
+  )
+}
+
+async function exerciseManualPaste(page: Page, windowName: string) {
+  const session = process.env.E2E_TMUX_SESSION
+  test.skip(!session, 'E2E_TMUX_SESSION not set')
+  const target = `${session}:${windowName}`
+
+  const created = tmux([
+    'new-window',
+    '-t',
+    session!,
+    '-n',
+    windowName,
+    `python3 ${REPL_PATH}`,
+  ])
+  expect(created.status).toBe(0)
+
+  try {
+    await waitForPaneText(target, 'PASTE-REPL READY')
+
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: {
+          read: () => Promise.reject(new Error('clipboard permission denied')),
+          readText: () => Promise.reject(new Error('clipboard permission denied')),
+        },
+      })
+    })
+
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Open session menu' }).click()
+    const drawer = page.getByRole('dialog', { name: 'Session list' })
+    const card = drawer.getByTestId('session-card').filter({ hasText: windowName })
+    await expect(card).toBeVisible({ timeout: 20000 })
+    await card.click()
+    await expect(page.locator('.xterm')).toBeVisible()
+
+    const pasteButton = page.locator('button[aria-label="Paste"]')
+    await expect(pasteButton).toBeVisible({ timeout: 20000 })
+    await pasteButton.click()
+    const textarea = page.getByRole('textbox', { name: 'Paste text' })
+    await expect(textarea).toBeVisible()
+
+    const dialogBounds = await textarea.locator('xpath=..').boundingBox()
+    expect(dialogBounds).not.toBeNull()
+    expect(dialogBounds!.x).toBeGreaterThanOrEqual(0)
+    expect(dialogBounds!.y).toBeGreaterThanOrEqual(0)
+    expect(dialogBounds!.x + dialogBounds!.width).toBeLessThanOrEqual(
+      page.viewportSize()!.width
+    )
+    expect(dialogBounds!.y + dialogBounds!.height).toBeLessThanOrEqual(
+      page.viewportSize()!.height
+    )
+
+    await textarea.fill('manual_alpha\nmanual_beta')
+    await textarea.press('Enter')
+    await expect(textarea).toHaveValue('manual_alpha\nmanual_beta\n')
+
+    // Approximate the reduced visual viewport while the iOS keyboard is open.
+    await page.setViewportSize({ width: 430, height: 500 })
+    await page.waitForTimeout(100)
+    const compactBounds = await textarea.locator('xpath=..').boundingBox()
+    expect(compactBounds).not.toBeNull()
+    expect(compactBounds!.y).toBeGreaterThanOrEqual(0)
+    expect(compactBounds!.y + compactBounds!.height).toBeLessThanOrEqual(500)
+
+    const sendButton = page.getByRole('button', { name: 'Send' })
+    await expect(sendButton).toBeVisible()
+    await sendButton.click()
+
+    const pane = await waitForPaneText(target, 'HELD:manual_alpha|manual_beta|')
+    expect(pane).not.toContain('SUBMITTED:')
+  } finally {
+    tmux(['kill-window', '-t', target])
+  }
+}
+
+test.describe('iOS PWA-sized manual paste fallback', () => {
+  test.use({
+    viewport: { width: 430, height: 932 },
+    hasTouch: true,
+    userAgent:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.7 Mobile/15E148 Safari/604.1',
+  })
+
+  test('preserves multiline text and stays within the viewport', async ({ page }) => {
+    await exerciseManualPaste(page, 'manual-paste-mobile')
+  })
+})

--- a/tests/e2e/paste.spec.ts
+++ b/tests/e2e/paste.spec.ts
@@ -7,6 +7,8 @@ import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { test, expect } from '@playwright/test'
 
+test.use({ viewport: { width: 1440, height: 900 } })
+
 const WINDOW_NAME = 'paste-repl'
 const REPL_PATH = fileURLToPath(new URL('./fixtures/paste-repl.py', import.meta.url))
 const UNICODE_INPUT = 'áéíñü-你好-🚀'


### PR DESCRIPTION
## Summary

- replace the iOS/manual paste fallback's single-line input with a multiline textarea
- keep Enter available for newlines and submit through the existing Send button
- preserve the existing server-side bracketed paste transport
- bump the package version to 0.4.15

Closes #196.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test` — 752 tests passed, with real-tmux tests isolated to a private socket during the explicit validation run
- Chromium E2E at 430×932: manual fallback preserved exact multiline text and delivered one held bracketed paste
- Chromium E2E at 1440×900: direct multiline paste remained held and did not auto-submit
- WebKit 26 at 430×932 with an iOS 18.7 Safari user agent: textarea preserved newlines and delivered `HELD:webkit_alpha|webkit_beta|`
- WebKit and Chromium compact-height check at 430×500: dialog and Send button remained within the viewport
- hands-on dev-browser visual inspection at 430×932 and 1440×900

Physical-device iOS long-press/keyboard behavior was not available locally; WebKit, touch, user-agent, viewport, and reduced-height coverage exercise the relevant browser behavior.
