### PR TITLE
fix: restore iOS PWA keyboard after resume

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/__tests__/useTerminal.test.tsx
+++ b/src/client/__tests__/useTerminal.test.tsx
@@ -2269,6 +2269,126 @@ describe('useTerminal', () => {
     })
   })
 
+  test('iOS PWA resume refocuses an interrupted terminal on the next touchstart', async () => {
+    const docListeners = new Map<string, Set<EventListener>>()
+    const winListeners = new Map<string, Set<EventListener>>()
+    let visibilityState: DocumentVisibilityState = 'visible'
+    let documentFocused = true
+    let activeElement: Element | null = null
+
+    globalAny.window = {
+      ...globalAny.window,
+      matchMedia: () => ({
+        matches: true,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+      }),
+      addEventListener(event: string, handler: EventListener) {
+        const set = winListeners.get(event) ?? new Set()
+        set.add(handler)
+        winListeners.set(event, set)
+      },
+      removeEventListener(event: string, handler: EventListener) {
+        winListeners.get(event)?.delete(handler)
+      },
+    } as unknown as Window & typeof globalThis
+    globalAny.document = {
+      fonts: { ready: Promise.resolve() },
+      get visibilityState() { return visibilityState },
+      get activeElement() { return activeElement },
+      hasFocus: () => documentFocused,
+      addEventListener(event: string, handler: EventListener) {
+        const set = docListeners.get(event) ?? new Set()
+        set.add(handler)
+        docListeners.set(event, set)
+      },
+      removeEventListener(event: string, handler: EventListener) {
+        docListeners.get(event)?.delete(handler)
+      },
+    } as unknown as Document
+    globalAny.navigator = {
+      userAgent: 'iPhone',
+      platform: 'iPhone',
+      maxTouchPoints: 5,
+      clipboard: { writeText: () => Promise.resolve(), readText: () => Promise.resolve('') },
+      vibrate: () => true,
+    } as unknown as Navigator
+
+    const { container, dispatchEvent, textarea } = createContainerMock()
+    const dispatchDocument = (event: string, value: Event) => {
+      for (const handler of docListeners.get(event) ?? []) handler(value)
+    }
+    const dispatchWindow = (event: string, value: Event) => {
+      for (const handler of winListeners.get(event) ?? []) handler(value)
+    }
+
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalComponent
+          session={terminalSession}
+          sessions={[terminalSession]}
+          connectionStatus="connected"
+          sendMessage={() => {}}
+          subscribe={() => () => {}}
+          onClose={() => {}}
+          onSelectSession={() => {}}
+          onNewSession={() => {}}
+          onKillSession={() => {}}
+          onRenameSession={() => {}}
+          onResumeSession={() => {}}
+          onOpenSettings={() => {}}
+        />,
+        { createNodeMock: () => container },
+      )
+      await Promise.resolve()
+    })
+
+    const touch = { clientX: 25, clientY: 25 } as Touch
+
+    // A foreground transition must not arm focus when the keyboard was already hidden.
+    act(() => {
+      visibilityState = 'hidden'
+      documentFocused = false
+      dispatchDocument('visibilitychange', new Event('visibilitychange'))
+      visibilityState = 'visible'
+      documentFocused = true
+      dispatchDocument('visibilitychange', new Event('visibilitychange'))
+      dispatchEvent('touchstart', { touches: [touch] })
+    })
+    expect(textarea.focusCalls).toBe(0)
+
+    // Focused terminal is interrupted by app backgrounding. The first trusted
+    // touchstart after resume restores it; a second touchstart does not refocus.
+    act(() => {
+      activeElement = textarea
+      dispatchDocument('focusin', { target: textarea } as unknown as FocusEvent)
+      dispatchWindow('blur', new Event('blur'))
+      visibilityState = 'hidden'
+      documentFocused = false
+      dispatchDocument('visibilitychange', new Event('visibilitychange'))
+      activeElement = null
+      dispatchDocument('focusout', { target: textarea } as unknown as FocusEvent)
+      visibilityState = 'visible'
+      documentFocused = true
+      dispatchDocument('visibilitychange', new Event('visibilitychange'))
+      dispatchWindow('focus', new Event('focus'))
+      dispatchEvent('touchstart', { touches: [touch] })
+    })
+    expect(textarea.focusCalls).toBe(1)
+
+    act(() => {
+      dispatchEvent('touchstart', { touches: [touch] })
+    })
+    expect(textarea.focusCalls).toBe(1)
+
+    act(() => {
+      renderer.unmount()
+    })
+  })
+
   test('falls back to clipboard API when paste event never fires', async () => {
     jest.useFakeTimers()
     const originalFetch = globalThis.fetch

--- a/src/client/components/Terminal.tsx
+++ b/src/client/components/Terminal.tsx
@@ -545,6 +545,90 @@ export default function Terminal({
 
   // Flag to swallow next mouse event (after iOS selection dismissal)
   const swallowNextMouseRef = useRef(false)
+  const terminalInputFocusedRef = useRef(false)
+  const inputWasFocusedBeforeBackgroundRef = useRef(false)
+  const restoreInputOnNextTouchRef = useRef(false)
+
+  // iOS PWA resume can dismiss the software keyboard and then ignore a focus()
+  // delayed until touchend. Remember interrupted terminal focus and perform one
+  // refocus on the next trusted touchstart instead of opening the keyboard on resume.
+  useEffect(() => {
+    if (!isiOS) return
+    const container = containerRef.current
+    if (!container) return
+
+    let focusOutTimer: number | null = null
+    const getTextarea = () =>
+      container.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null
+
+    const handleFocusIn = (event: FocusEvent) => {
+      if (event.target !== getTextarea()) return
+      terminalInputFocusedRef.current = true
+      restoreInputOnNextTouchRef.current = false
+    }
+
+    const handleFocusOut = (event: FocusEvent) => {
+      if (event.target !== getTextarea()) return
+      if (focusOutTimer !== null) window.clearTimeout(focusOutTimer)
+      focusOutTimer = window.setTimeout(() => {
+        focusOutTimer = null
+        const textarea = getTextarea()
+        const documentStillFocused =
+          typeof document.hasFocus !== 'function' || document.hasFocus()
+        if (
+          document.activeElement !== textarea &&
+          document.visibilityState !== 'hidden' &&
+          documentStillFocused
+        ) {
+          terminalInputFocusedRef.current = false
+        }
+      }, 0)
+    }
+
+    const rememberInterruptedFocus = () => {
+      const textarea = getTextarea()
+      if (document.activeElement === textarea || terminalInputFocusedRef.current) {
+        inputWasFocusedBeforeBackgroundRef.current = true
+      }
+    }
+
+    const armResumeRefocus = () => {
+      if (!inputWasFocusedBeforeBackgroundRef.current) return
+      inputWasFocusedBeforeBackgroundRef.current = false
+      restoreInputOnNextTouchRef.current = true
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        rememberInterruptedFocus()
+      } else {
+        armResumeRefocus()
+      }
+    }
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) armResumeRefocus()
+    }
+
+    document.addEventListener('focusin', handleFocusIn)
+    document.addEventListener('focusout', handleFocusOut)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('blur', rememberInterruptedFocus)
+    window.addEventListener('focus', armResumeRefocus)
+    window.addEventListener('pageshow', handlePageShow)
+
+    return () => {
+      document.removeEventListener('focusin', handleFocusIn)
+      document.removeEventListener('focusout', handleFocusOut)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.removeEventListener('blur', rememberInterruptedFocus)
+      window.removeEventListener('focus', armResumeRefocus)
+      window.removeEventListener('pageshow', handlePageShow)
+      if (focusOutTimer !== null) window.clearTimeout(focusOutTimer)
+      terminalInputFocusedRef.current = false
+      inputWasFocusedBeforeBackgroundRef.current = false
+      restoreInputOnNextTouchRef.current = false
+    }
+  }, [containerRef, isiOS, session?.id])
 
   // Touch scroll with native long-press selection
   // Single tap focuses terminal for keyboard input
@@ -791,6 +875,14 @@ export default function Terminal({
       if (isSelectingTextRef.current) {
         resetTouchState()
         return
+      }
+
+      if (
+        restoreInputOnNextTouchRef.current &&
+        !inTmuxCopyModeRef.current
+      ) {
+        restoreInputOnNextTouchRef.current = false
+        focusTerminalInput()
       }
 
       if (e.touches.length === 1) {

--- a/src/client/components/Terminal.tsx
+++ b/src/client/components/Terminal.tsx
@@ -53,6 +53,8 @@ interface TerminalProps {
   error?: string | null
 }
 
+type IOSResumeInputState = 'idle' | 'focused' | 'interrupted' | 'armed'
+
 const statusText: Record<Session['status'], string> = {
   working: 'Working',
   waiting: 'Waiting',
@@ -545,9 +547,7 @@ export default function Terminal({
 
   // Flag to swallow next mouse event (after iOS selection dismissal)
   const swallowNextMouseRef = useRef(false)
-  const terminalInputFocusedRef = useRef(false)
-  const inputWasFocusedBeforeBackgroundRef = useRef(false)
-  const restoreInputOnNextTouchRef = useRef(false)
+  const iosResumeInputStateRef = useRef<IOSResumeInputState>('idle')
 
   // iOS PWA resume can dismiss the software keyboard and then ignore a focus()
   // delayed until touchend. Remember interrupted terminal focus and perform one
@@ -563,8 +563,7 @@ export default function Terminal({
 
     const handleFocusIn = (event: FocusEvent) => {
       if (event.target !== getTextarea()) return
-      terminalInputFocusedRef.current = true
-      restoreInputOnNextTouchRef.current = false
+      iosResumeInputStateRef.current = 'focused'
     }
 
     const handleFocusOut = (event: FocusEvent) => {
@@ -580,22 +579,25 @@ export default function Terminal({
           document.visibilityState !== 'hidden' &&
           documentStillFocused
         ) {
-          terminalInputFocusedRef.current = false
+          iosResumeInputStateRef.current = 'idle'
         }
       }, 0)
     }
 
     const rememberInterruptedFocus = () => {
       const textarea = getTextarea()
-      if (document.activeElement === textarea || terminalInputFocusedRef.current) {
-        inputWasFocusedBeforeBackgroundRef.current = true
+      if (
+        document.activeElement === textarea ||
+        iosResumeInputStateRef.current === 'focused'
+      ) {
+        iosResumeInputStateRef.current = 'interrupted'
       }
     }
 
     const armResumeRefocus = () => {
-      if (!inputWasFocusedBeforeBackgroundRef.current) return
-      inputWasFocusedBeforeBackgroundRef.current = false
-      restoreInputOnNextTouchRef.current = true
+      if (iosResumeInputStateRef.current === 'interrupted') {
+        iosResumeInputStateRef.current = 'armed'
+      }
     }
 
     const handleVisibilityChange = () => {
@@ -624,9 +626,7 @@ export default function Terminal({
       window.removeEventListener('focus', armResumeRefocus)
       window.removeEventListener('pageshow', handlePageShow)
       if (focusOutTimer !== null) window.clearTimeout(focusOutTimer)
-      terminalInputFocusedRef.current = false
-      inputWasFocusedBeforeBackgroundRef.current = false
-      restoreInputOnNextTouchRef.current = false
+      iosResumeInputStateRef.current = 'idle'
     }
   }, [containerRef, isiOS, session?.id])
 
@@ -878,10 +878,10 @@ export default function Terminal({
       }
 
       if (
-        restoreInputOnNextTouchRef.current &&
+        iosResumeInputStateRef.current === 'armed' &&
         !inTmuxCopyModeRef.current
       ) {
-        restoreInputOnNextTouchRef.current = false
+        iosResumeInputStateRef.current = 'idle'
         focusTerminalInput()
       }
 


### PR DESCRIPTION
Closes #195

## Summary
- remember when iOS backgrounding interrupts a focused terminal input
- restore focus on the next trusted terminal touchstart instead of auto-opening the keyboard on resume
- preserve normal touchend focus when the keyboard was already hidden
- bump the patch version to 0.4.17

## Validation
- lint, typecheck, full unit/integration suite, and production PWA build
- isolated Agentboard and tmux preview on port 4178
- WebKit iPhone PWA profile (`navigator.standalone = true`): interrupted focus occurs during touchstart; ordinary hidden-keyboard taps remain touchend-focused
- live Agentboard health verified after isolated preview shutdown