### PR TITLE
fix: surface tmux copy mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/__tests__/terminal.test.tsx
+++ b/src/client/__tests__/terminal.test.tsx
@@ -251,6 +251,63 @@ afterEach(() => {
 })
 
 describe('Terminal', () => {
+  test('shows an explicit exit control for externally entered tmux copy mode', () => {
+    const listeners: Array<(message: ServerMessage) => void> = []
+    const sentMessages: unknown[] = []
+    const { createNodeMock } = createContainerMock()
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    act(() => {
+      renderer = TestRenderer.create(
+        <Terminal
+          session={baseSession}
+          sessions={[baseSession]}
+          connectionStatus="connected"
+          sendMessage={(message) => sentMessages.push(message)}
+          subscribe={(listener) => {
+            listeners.push(listener)
+            return () => {}
+          }}
+          onClose={() => {}}
+          onSelectSession={() => {}}
+          onNewSession={() => {}}
+          onKillSession={() => {}}
+          onRenameSession={() => {}}
+          onResumeSession={() => {}}
+          onOpenSettings={() => {}}
+        />,
+        { createNodeMock },
+      )
+    })
+
+    act(() => {
+      listeners[0]?.({
+        type: 'tmux-copy-mode-status',
+        sessionId: baseSession.id,
+        inCopyMode: true,
+        appMouse: true,
+      })
+    })
+
+    const exitButton = renderer.root.findByProps({ title: 'Exit tmux copy mode and return to live output' })
+    expect(exitButton.props['aria-label']).toBe('Exit copy mode')
+    expect(renderer.root.findAllByProps({ title: 'Scroll to bottom' })).toHaveLength(0)
+
+    act(() => {
+      exitButton.props.onClick()
+    })
+
+    expect(sentMessages[sentMessages.length - 1]).toEqual({
+      type: 'tmux-cancel-copy-mode',
+      sessionId: baseSession.id,
+    })
+    expect(renderer.root.findAllByProps({ title: 'Exit tmux copy mode and return to live output' })).toHaveLength(0)
+
+    act(() => {
+      renderer.unmount()
+    })
+  })
+
   test('shows scroll button and handles more menu actions', () => {
     let openSettingsCalls = 0
 
@@ -292,10 +349,10 @@ describe('Terminal', () => {
     })
 
     const scrollButton = renderer.root.findAllByType('button').find(
-      (button) => button.props.title === 'Scroll to bottom'
+      (button) => button.props.title === 'Exit tmux copy mode and return to live output'
     )
     if (!scrollButton) {
-      throw new Error('Expected scroll button')
+      throw new Error('Expected copy-mode exit button')
     }
 
     const initialMessageCount = sentMessages.length

--- a/src/client/__tests__/useTerminal.test.tsx
+++ b/src/client/__tests__/useTerminal.test.tsx
@@ -336,7 +336,7 @@ function TerminalHarness(props: {
   useWebGL?: boolean
   onScrollChange?: (isAtBottom: boolean) => void
 }) {
-  const { containerRef } = useTerminal({
+  const { containerRef, isTmuxCopyMode } = useTerminal({
     ...props,
     tmuxTarget: props.tmuxTarget ?? null,
     connectionStatus: props.connectionStatus ?? 'connected',
@@ -346,7 +346,7 @@ function TerminalHarness(props: {
     fontFamily: props.fontFamily ?? '"JetBrains Mono Variable", monospace',
     useWebGL: props.useWebGL ?? true,
   })
-  return <div ref={containerRef} />
+  return <div ref={containerRef} data-copy-mode={isTmuxCopyMode ? 'true' : 'false'} />
 }
 
 const terminalSession: Session = {
@@ -1867,6 +1867,68 @@ describe('useTerminal', () => {
       })
     })
     expect(terminal.writes).toContain('\x1b[?1000h\x1b[?1002h\x1b[?1006h')
+
+    act(() => {
+      renderer.unmount()
+    })
+  })
+
+  test('actual copy-mode stays authoritative when the pane also reports app mouse', async () => {
+    globalAny.navigator = {
+      userAgent: 'Chrome',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      clipboard: { writeText: () => Promise.resolve(), readText: () => Promise.resolve('') },
+    } as unknown as Navigator
+
+    const sendCalls: Array<Record<string, unknown>> = []
+    const listeners: Array<(message: ServerMessage) => void> = []
+    const { container } = createContainerMock()
+
+    let renderer!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          sendMessage={(message) => sendCalls.push(message)}
+          subscribe={(listener) => {
+            listeners.push(listener)
+            return () => {}
+          }}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+        { createNodeMock: () => container },
+      )
+      await Promise.resolve()
+    })
+
+    const terminal = TerminalMock.instances[0]
+    if (!terminal) throw new Error('Expected terminal instance')
+
+    act(() => {
+      listeners[0]?.({
+        type: 'tmux-copy-mode-status',
+        sessionId: 'session-1',
+        inCopyMode: true,
+        appMouse: true,
+      })
+    })
+
+    expect(renderer.root.findByType('div').props['data-copy-mode']).toBe('true')
+    expect(terminal.writes).toContain('\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l')
+
+    sendCalls.length = 0
+    act(() => {
+      terminal.emitData('x')
+    })
+
+    expect(sendCalls).toEqual([
+      { type: 'tmux-cancel-copy-mode', sessionId: 'session-1' },
+      { type: 'terminal-input', sessionId: 'session-1', data: 'x' },
+    ])
+    expect(renderer.root.findByType('div').props['data-copy-mode']).toBe('false')
 
     act(() => {
       renderer.unmount()

--- a/src/client/components/Terminal.tsx
+++ b/src/client/components/Terminal.tsx
@@ -164,6 +164,7 @@ export default function Terminal({
     containerRef,
     terminalRef,
     inTmuxCopyModeRef,
+    isTmuxCopyMode,
     appMouseRef,
     setTmuxCopyMode,
     isSwitching,
@@ -1556,9 +1557,25 @@ export default function Terminal({
           </div>
         )}
 
-        {/* Scroll to bottom button */}
-        {showScrollButton && session && !isSelectingText && (
+        {/* Copy-mode indicator / scroll to bottom button */}
+        {isTmuxCopyMode && session && !isSelectingText ? (
           <button
+            type="button"
+            onClick={scrollToBottom}
+            className="absolute bottom-14 left-1/2 z-20 flex h-10 items-center justify-center overflow-hidden rounded-full border border-amber-400/35 bg-amber-500/20 text-amber-100 shadow-lg backdrop-blur-sm transition-all hover:bg-amber-500/30 active:scale-95 md:bottom-8"
+            style={{ transform: 'translateX(-50%)' }}
+            title="Exit tmux copy mode and return to live output"
+            aria-label="Exit copy mode"
+          >
+            <span className="px-3 text-[11px] font-semibold uppercase tracking-wide">
+              Copy mode
+            </span>
+            <span className="self-stretch border-l border-amber-400/25" aria-hidden="true" />
+            <span className="px-3 text-sm font-medium">Exit</span>
+          </button>
+        ) : showScrollButton && session && !isSelectingText ? (
+          <button
+            type="button"
             onClick={scrollToBottom}
             className="absolute bottom-8 left-1/2 z-20 flex h-10 px-4 items-center justify-center gap-1.5 rounded-full bg-blue-600/90 text-white shadow-lg hover:bg-blue-600 active:scale-95 transition-all"
             style={{ transform: 'translateX(-50%)' }}
@@ -1580,7 +1597,7 @@ export default function Terminal({
             </svg>
             <span className="text-sm font-medium">Jump to bottom</span>
           </button>
-        )}
+        ) : null}
 
       </div>
 

--- a/src/client/hooks/useTerminal.ts
+++ b/src/client/hooks/useTerminal.ts
@@ -326,6 +326,7 @@ export function useTerminal({
   // Wheel event handling for tmux scrollback
   const wheelAccumRef = useRef<number>(0)
   const inTmuxCopyModeRef = useRef<boolean>(false)
+  const [isTmuxCopyMode, setIsTmuxCopyMode] = useState(false)
   const appMouseRef = useRef<boolean>(false)
   const altScreenRef = useRef<boolean>(false)
   const copyModeCheckTimer = useRef<number | null>(null)
@@ -472,9 +473,9 @@ export function useTerminal({
   }, [])
 
   const setTmuxCopyMode = useCallback((nextValue: boolean) => {
-    if (nextValue && appMouseRef.current) return
     if (inTmuxCopyModeRef.current === nextValue) return
     inTmuxCopyModeRef.current = nextValue
+    setIsTmuxCopyMode(nextValue)
 
     // Disable mouse tracking when entering copy-mode so xterm.js does local selection
     // instead of generating mouse sequences. When exiting copy-mode, tmux will refresh
@@ -1193,7 +1194,7 @@ export function useTerminal({
         attachedTargetRef.current = null
         attachedConnectionEpochRef.current = -1
         focusAfterAttachSessionRef.current = null
-        inTmuxCopyModeRef.current = false
+        setTmuxCopyMode(false)
       }
       terminal.reset()
       needsResetRef.current = false
@@ -1215,7 +1216,7 @@ export function useTerminal({
         attachedTargetRef.current = null
         attachedConnectionEpochRef.current = -1
         focusAfterAttachSessionRef.current = null
-        inTmuxCopyModeRef.current = false
+        setTmuxCopyMode(false)
       }
       // Server state may have changed — all snapshots are potentially stale
       clearSnapshotCache()
@@ -1247,7 +1248,7 @@ export function useTerminal({
       attachedConnectionEpochRef.current = -1
       focusAfterAttachSessionRef.current = null
       // Reset copy-mode state - each session has its own scroll position
-      inTmuxCopyModeRef.current = false
+      setTmuxCopyMode(false)
     }
 
     // Attach to new session
@@ -1396,7 +1397,7 @@ export function useTerminal({
         attachDebounceRef.current = null
       }
     }
-  }, [sessionId, tmuxTarget, allowAttach, connectionStatus, connectionEpoch, checkScrollPosition])
+  }, [sessionId, tmuxTarget, allowAttach, connectionStatus, connectionEpoch, checkScrollPosition, setTmuxCopyMode])
 
   useEffect(() => {
     if (copyModePollIntervalRef.current !== null) {
@@ -1616,7 +1617,7 @@ export function useTerminal({
         attachedSession &&
         message.sessionId === attachedSession
       ) {
-        const nextAppMouse = message.appMouse === true
+        const nextAppMouse = message.appMouse === true && !message.inCopyMode
         const wasAppMouse = appMouseRef.current
         appMouseRef.current = nextAppMouse
         altScreenRef.current = message.altScreen === true
@@ -1625,7 +1626,7 @@ export function useTerminal({
           terminalRef.current?.write(ENABLE_MOUSE_TRACKING)
         }
 
-        setTmuxCopyMode(nextAppMouse ? false : message.inCopyMode)
+        setTmuxCopyMode(message.inCopyMode)
       }
     })
 
@@ -1778,6 +1779,7 @@ export function useTerminal({
     serializeAddonRef,
     progressAddonRef,
     inTmuxCopyModeRef,
+    isTmuxCopyMode,
     appMouseRef,
     setTmuxCopyMode,
     isSwitching,


### PR DESCRIPTION
Closes #194

## Summary
- make actual tmux copy-mode authoritative when an app also reports mouse tracking
- expose copy-mode as reactive UI state and show an explicit Copy mode / Exit control
- preserve the generic Jump to bottom control for ordinary local scrollback
- bump the patch version to 0.4.18

## Validation
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- Chromium desktop (1440x900) and mobile (390x844)
- WebKit desktop (1440x900)
- WebKit iPhone 15 standalone/PWA profile
- isolated real tmux runtime with pane_in_mode=1 and mouse_any_flag=1; Exit returned pane_in_mode to 0 while preserving mouse_any_flag=1

All tmux/browser validation used a separate socket, session, data directory, and port.