### PR TITLE
fix: preserve PTY newline semantics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/__tests__/useTerminal.test.tsx
+++ b/src/client/__tests__/useTerminal.test.tsx
@@ -34,7 +34,8 @@ class TerminalMock {
   private keyHandler?: (event: KeyboardEvent) => boolean
   private wheelHandler?: (event: WheelEvent) => boolean
 
-  constructor() {
+  constructor(options: Record<string, unknown> = {}) {
+    this.options = { ...options }
     TerminalMock.instances.push(this)
   }
 
@@ -456,6 +457,32 @@ describe('sanitizeLink', () => {
 })
 
 describe('useTerminal', () => {
+  test('leaves PTY line-feed semantics unchanged in xterm', async () => {
+    const { container } = createContainerMock()
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          sendMessage={() => {}}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+        { createNodeMock: () => container },
+      )
+      await Promise.resolve()
+    })
+
+    expect(TerminalMock.instances[0]?.options.convertEol).toBe(false)
+
+    act(() => {
+      renderer.unmount()
+    })
+  })
+
   test('attaches, forwards input/output, and handles key events', () => {
     const clipboardWrites: string[] = []
     globalAny.navigator = {

--- a/src/client/hooks/useTerminal.ts
+++ b/src/client/hooks/useTerminal.ts
@@ -549,7 +549,9 @@ export function useTerminal({
       scrollback: 0, // Disabled - we use tmux scrollback instead
       cursorBlink: false,
       cursorStyle: 'underline',
-      convertEol: true,
+      // PTY/tmux output already carries cursor movement. Rewriting LF as CRLF
+      // corrupts cursor-column state for fullscreen applications.
+      convertEol: false,
       theme,
       screenReaderMode: isiOS,
       // Ensure text is readable even when apps use true color (24-bit RGB) sequences

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -2936,7 +2936,7 @@ describe('server message handlers', () => {
       (message) =>
         message.type === 'terminal-output' &&
         message.sessionId === baseSession.id &&
-        message.data === 'visible pane 你好 🚀\n'
+        message.data === 'visible pane 你好 🚀\r\n'
     )
     expect(historyIndex).toBeGreaterThanOrEqual(0)
     expect(ws.data.currentTmuxTarget).toBe(groupedTarget)

--- a/src/server/__tests__/tmuxText.test.ts
+++ b/src/server/__tests__/tmuxText.test.ts
@@ -3,6 +3,7 @@ import {
   cleanTmuxLine,
   isDecorativeLine,
   isMetadataLine,
+  normalizeCapturedHistory,
   stripAnsi,
   TMUX_METADATA_MATCH_PATTERNS,
   TMUX_METADATA_STATUS_PATTERNS,
@@ -12,6 +13,12 @@ describe('tmuxText helpers', () => {
   test('stripAnsi removes escape codes', () => {
     const input = '\u001b[31mRed\u001b[0m Text'
     expect(stripAnsi(input)).toBe('Red Text')
+  })
+
+  test('normalizeCapturedHistory converts capture-pane line feeds to CRLF', () => {
+    const normalized = normalizeCapturedHistory('line1\nline2\r\nline3\rline4\n')
+    expect(normalized).toBe('line1\r\nline2\r\nline3\rline4\r\n')
+    expect(/(^|[^\r])\n/.test(normalized)).toBe(false)
   })
 
   test('detects decorative lines', () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -67,6 +67,7 @@ import { normalizePaneStartCommand } from './agentDetection'
 import { generateSessionName } from './nameGenerator'
 import { shellQuote } from './shellQuote'
 import { SshTerminalProxy } from './terminal/SshTerminalProxy'
+import { normalizeCapturedHistory } from './terminal/tmuxText'
 import {
   buildTmuxFormat,
   splitTmuxFields,
@@ -4250,7 +4251,7 @@ function captureTmuxHistory(target: string): string | null {
     if (output.trim().length === 0) {
       return null
     }
-    return output
+    return normalizeCapturedHistory(output)
   } catch {
     return null
   }
@@ -4312,7 +4313,7 @@ async function captureTmuxHistoryRemote(target: string, host: string): Promise<s
     if (result.exitCode !== 0) return null
     const output = result.stdout ?? ''
     if (output.trim().length === 0) return null
-    return output
+    return normalizeCapturedHistory(output)
   } catch {
     return null
   }

--- a/src/server/terminal/tmuxText.ts
+++ b/src/server/terminal/tmuxText.ts
@@ -34,6 +34,10 @@ export function stripAnsi(text: string): string {
   return text.replace(ANSI_ESCAPE_PATTERN, '')
 }
 
+export function normalizeCapturedHistory(text: string): string {
+  return text.replace(/\r?\n/g, '\r\n')
+}
+
 export function isDecorativeLine(line: string): boolean {
   return TMUX_DECORATIVE_LINE_PATTERN.test(line)
 }


### PR DESCRIPTION
## Summary
- preserve native PTY cursor semantics in xterm with `convertEol: false`
- normalize tmux `capture-pane` history to CRLF before replay, for local and SSH sessions
- add regression coverage and bump the patch version to 0.4.19

This incorporates the core diagnosis from #182 and adds the server-side history normalization needed to avoid the attach-time staircase regression.

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test:ci`
- isolated server handler suite: 104/104
- browser-tested against a private pipe-pane runtime in desktop Chromium, desktop WebKit, and iPhone WebKit standalone-PWA mode
- verified a raw LF-only pane renders each line at column zero with no later output to mask the history behavior

## Host note
The real-tmux benchmark was attempted, but this host cannot currently allocate another PTY (`fork failed: Device not configured`). Process ownership includes the live Agentboard tmux, so no cleanup was attempted. GitHub CI will run on a clean host.