### PR TITLE
feat: add direct session shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ bun run deps:risk -- --threshold moderate
 |--------|-----|---------------|
 | Previous session | `Ctrl+Option+[` | `Ctrl+Shift+[` |
 | Next session | `Ctrl+Option+]` | `Ctrl+Shift+]` |
+| Jump to session 1-9 | `Ctrl+Option+1..9` | `Ctrl+Shift+1..9` |
 | New session | `Ctrl+Option+N` | `Ctrl+Shift+N` |
 | Kill session | `Ctrl+Option+X` | `Ctrl+Shift+X` |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -812,6 +812,27 @@ export default function App() {
         return
       }
 
+      // Direct navigation: [mod]+1..9 selects the corresponding visible
+      // session. As with bracket navigation, use hibernating sessions only
+      // when there are no visible live sessions. Invalid indices remain
+      // unhandled so the browser/terminal keeps the key event.
+      if (isShortcut && /^Digit[1-9]$/.test(code)) {
+        const index = Number(code.slice('Digit'.length)) - 1
+        if (filteredSortedSessions.length > 0) {
+          const target = filteredSortedSessions[index]
+          if (!target) return
+          event.preventDefault()
+          setSelectedSessionId(target.id)
+          return
+        }
+
+        const target = filteredHibernatingSessions[index]
+        if (!target) return
+        event.preventDefault()
+        setSelectedHibernatingSessionId(target.sessionId)
+        return
+      }
+
       // New session: [mod]+N
       if (isShortcut && code === 'KeyN') {
         event.preventDefault()

--- a/src/client/__tests__/app.test.tsx
+++ b/src/client/__tests__/app.test.tsx
@@ -1088,6 +1088,124 @@ describe('App', () => {
     // but kill-failed test below proves it works)
   })
 
+  test('jumps to a visible session by index with the configured modifier', () => {
+    const sessionB: Session = {
+      ...baseSession,
+      id: 'session-2',
+      name: 'beta',
+      createdAt: '2024-01-02T00:00:00.000Z',
+    }
+    const sessionC: Session = {
+      ...baseSession,
+      id: 'session-3',
+      name: 'gamma',
+      createdAt: '2024-01-03T00:00:00.000Z',
+    }
+
+    useSessionStore.setState({
+      sessions: [baseSession, sessionB, sessionC],
+      selectedSessionId: baseSession.id,
+      hasLoaded: true,
+    })
+
+    let renderer!: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(<App />)
+    })
+    activeRenderer = renderer
+
+    let prevented = 0
+    const digitEvent = (
+      digit: number,
+      modifiers: Partial<Pick<KeyboardEvent, 'ctrlKey' | 'shiftKey' | 'altKey' | 'metaKey'>>
+    ) => ({
+      key: String(digit),
+      code: `Digit${digit}`,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      metaKey: false,
+      defaultPrevented: false,
+      preventDefault: () => { prevented += 1 },
+      ...modifiers,
+    }) as KeyboardEvent
+
+    act(() => {
+      getKeyHandler()(digitEvent(3, { ctrlKey: true, shiftKey: true }))
+    })
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-3')
+    expect(prevented).toBe(1)
+
+    // Plain digits and incomplete modifiers stay available to the terminal.
+    act(() => {
+      getKeyHandler()(digitEvent(1, {}))
+      getKeyHandler()(digitEvent(1, { ctrlKey: true }))
+    })
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-3')
+    expect(prevented).toBe(1)
+
+    // An out-of-range shortcut also remains available to the browser/terminal.
+    act(() => {
+      getKeyHandler()(digitEvent(9, { ctrlKey: true, shiftKey: true }))
+    })
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-3')
+    expect(prevented).toBe(1)
+  })
+
+  test('digit shortcuts fall back to hibernating sessions when no live sessions are visible', () => {
+    const hibernatingA: AgentSession = {
+      ...baseAgentSession,
+      sessionId: 'hibernating-1',
+      displayName: 'sleeping alpha',
+      isActive: false,
+      isPinned: true,
+    }
+    const hibernatingB: AgentSession = {
+      ...hibernatingA,
+      sessionId: 'hibernating-2',
+      displayName: 'sleeping beta',
+      createdAt: '2024-01-02T00:00:00.000Z',
+    }
+
+    useSessionStore.setState({
+      sessions: [],
+      selectedSessionId: null,
+      selectedHibernatingSessionId: hibernatingA.sessionId,
+      agentSessions: {
+        active: [],
+        hibernating: [hibernatingA, hibernatingB],
+        history: [],
+      },
+      agentSessionsEpoch: 0,
+      hasLoaded: true,
+    })
+
+    let renderer!: TestRenderer.ReactTestRenderer
+    act(() => {
+      renderer = TestRenderer.create(<App />)
+    })
+    activeRenderer = renderer
+
+    let prevented = false
+    act(() => {
+      getKeyHandler()({
+        key: '2',
+        code: 'Digit2',
+        ctrlKey: true,
+        shiftKey: true,
+        altKey: false,
+        metaKey: false,
+        defaultPrevented: false,
+        preventDefault: () => { prevented = true },
+      } as KeyboardEvent)
+    })
+
+    const state = useSessionStore.getState()
+    expect(state.selectedSessionId).toBeNull()
+    expect(state.selectedHibernatingSessionId).toBe(hibernatingB.sessionId)
+    expect(prevented).toBe(true)
+  })
+
   test('kill-failed restores optimistically removed session', () => {
     useSessionStore.setState({
       sessions: [baseSession],

--- a/src/client/__tests__/useTerminal.test.tsx
+++ b/src/client/__tests__/useTerminal.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, jest, test, mock } from 'bun:test'
 import TestRenderer, { act } from 'react-test-renderer'
 import type { AgentType, ServerMessage, Session } from '@shared/types'
+import { useSettingsStore } from '../stores/settingsStore'
 import type { ITheme } from '@xterm/xterm'
 import type { ConnectionStatus } from '../stores/sessionStore'
 
@@ -102,7 +103,15 @@ class TerminalMock {
     return this.wheelHandler?.(event)
   }
 
-  emitKey(event: { key: string; type: string; ctrlKey?: boolean; metaKey?: boolean }) {
+  emitKey(event: {
+    key: string
+    code?: string
+    type: string
+    ctrlKey?: boolean
+    shiftKey?: boolean
+    altKey?: boolean
+    metaKey?: boolean
+  }) {
     return this.keyHandler?.(event as KeyboardEvent)
   }
 }
@@ -365,6 +374,7 @@ beforeEach(() => {
   TerminalMock.instances = []
   FitAddonMock.instances = []
   WebglAddonMock.instances = []
+  useSettingsStore.setState({ shortcutModifier: 'auto' })
 
   globalAny.window = {
     setTimeout: ((callback: () => void) => {
@@ -477,6 +487,67 @@ describe('useTerminal', () => {
     })
 
     expect(TerminalMock.instances[0]?.options.convertEol).toBe(false)
+
+    act(() => {
+      renderer.unmount()
+    })
+  })
+
+  test('lets configured modifier digit shortcuts bypass xterm', async () => {
+    globalAny.navigator = {
+      userAgent: 'Chrome',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+    } as unknown as Navigator
+    const { container } = createContainerMock()
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalHarness
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          sendMessage={() => {}}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+        { createNodeMock: () => container },
+      )
+      await Promise.resolve()
+    })
+
+    const terminal = TerminalMock.instances[0]
+    expect(terminal?.emitKey({
+      key: '2',
+      code: 'Digit2',
+      type: 'keydown',
+      ctrlKey: true,
+      altKey: true,
+    })).toBe(false)
+    expect(terminal?.emitKey({ key: '2', code: 'Digit2', type: 'keydown' })).toBe(true)
+    expect(terminal?.emitKey({
+      key: '2',
+      code: 'Digit2',
+      type: 'keydown',
+      ctrlKey: true,
+    })).toBe(true)
+
+    useSettingsStore.setState({ shortcutModifier: 'cmd-shift' })
+    expect(terminal?.emitKey({
+      key: '3',
+      code: 'Digit3',
+      type: 'keydown',
+      metaKey: true,
+      shiftKey: true,
+    })).toBe(false)
+    expect(terminal?.emitKey({
+      key: '3',
+      code: 'Digit3',
+      type: 'keyup',
+      metaKey: true,
+      shiftKey: true,
+    })).toBe(true)
 
     act(() => {
       renderer.unmount()

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -940,8 +940,8 @@ export default function SettingsModal({
             </div>
             <p className="mt-1.5 text-[10px] text-muted">
               {draftShortcutModifier === 'auto'
-                ? `Platform default: ${getModifierDisplay(getEffectiveModifier('auto'))}`
-                : `Shortcuts: ${getModifierDisplay(draftShortcutModifier)}+[N/X/[/]]`}
+                ? `Shortcuts: ${getModifierDisplay(getEffectiveModifier('auto'))}+[1-9/N/X/[/]]`
+                : `Shortcuts: ${getModifierDisplay(draftShortcutModifier)}+[1-9/N/X/[/]]`}
             </p>
           </div>
         </div>

--- a/src/client/hooks/useTerminal.ts
+++ b/src/client/hooks/useTerminal.ts
@@ -10,7 +10,9 @@ import { ProgressAddon } from '@xterm/addon-progress'
 import type { AgentType, ClipboardOfferSource, SendClientMessage, ServerMessageWithDiagnostics, SubscribeServerMessage } from '@shared/types'
 import { clientLog } from '../utils/clientLog'
 import type { ConnectionStatus } from '../stores/sessionStore'
+import { useSettingsStore } from '../stores/settingsStore'
 import { copyText } from '../utils/copyText'
+import { getEffectiveModifier, matchesModifier } from '../utils/device'
 import { bracketedPaste, sanitizeImagePath } from '../utils/paste'
 
 // Module-level snapshot cache: sessionId → serialized terminal content.
@@ -769,6 +771,21 @@ export function useTerminal({
     }
 
     terminal.attachCustomKeyEventHandler((event) => {
+      // Let Agentboard's window-level direct-navigation handler receive the
+      // configured modifier + 1..9 before xterm translates or cancels it.
+      // Read the store synchronously so modifier changes take effect without
+      // recreating the terminal instance.
+      if (
+        event.type === 'keydown' &&
+        /^Digit[1-9]$/.test(event.code) &&
+        matchesModifier(
+          event,
+          getEffectiveModifier(useSettingsStore.getState().shortcutModifier)
+        )
+      ) {
+        return false
+      }
+
       // Cmd/Ctrl+C: copy selection (only non-whitespace to avoid clearing images from clipboard)
       if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'c') {
         if (terminal.hasSelection()) {

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { spawnSync } from 'node:child_process'
 
 test('dashboard loads and terminal attaches', async ({ page }) => {
   await page.goto('/')
@@ -11,4 +12,44 @@ test('dashboard loads and terminal attaches', async ({ page }) => {
 
   await expect(page.getByTestId('terminal-panel')).toBeVisible()
   await expect(page.locator('.xterm')).toBeVisible()
+})
+
+test('digit shortcut switches sessions while the terminal has focus', async ({ page }) => {
+  const session = process.env.E2E_TMUX_SESSION
+  if (!session) throw new Error('E2E_TMUX_SESSION is not set')
+  const targetName = `shortcut-target-${process.pid}-${Date.now()}`
+
+  const created = spawnSync(
+    'tmux',
+    ['new-window', '-t', `=${session}`, '-n', targetName],
+    { encoding: 'utf-8' }
+  )
+  if (created.status !== 0) {
+    throw new Error(`Failed to create shortcut target: ${created.stderr}`)
+  }
+
+  await page.goto('/')
+  const cards = page.getByTestId('session-card')
+  const target = cards.filter({ hasText: targetName })
+  await expect(target).toBeVisible({ timeout: 10000 })
+
+  const cardTexts = await cards.allTextContents()
+  const targetIndex = cardTexts.findIndex((text) => text.includes(targetName))
+  if (targetIndex < 0 || targetIndex >= 9) {
+    throw new Error(`Shortcut target has unsupported visible index ${targetIndex}`)
+  }
+  const initial = cards.nth(targetIndex === 0 ? 1 : 0)
+  await initial.click()
+  await expect(initial).toHaveClass(/selected/)
+
+  const terminalInput = page.locator('.xterm-helper-textarea')
+  await terminalInput.focus()
+  await expect(terminalInput).toBeFocused()
+
+  const isMac = await page.evaluate(() => /Mac|iPhone|iPad|iPod/.test(navigator.platform))
+  const digit = String(targetIndex + 1)
+  await page.keyboard.press(isMac ? `Control+Alt+${digit}` : `Control+Shift+${digit}`)
+
+  await expect(target).toHaveClass(/selected/)
+  await expect(initial).not.toHaveClass(/selected/)
 })


### PR DESCRIPTION
## Summary
- add the existing Agentboard modifier + `1..9` to select the corresponding visible session
- preserve the live-session-first / hibernating-fallback behavior used by bracket navigation
- bypass xterm only for exact configured modifier digit chords, preventing shortcut bytes from reaching the PTY
- update shortcut documentation/settings copy and bump the patch version to 0.4.20

This incorporates the core feature proposed in #179 while intentionally omitting its separate bare Cmd/Ctrl chord setting, which conflicts with browsers, operating systems, and terminal control sequences. Credit to @younesehb for the original contribution.

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test:ci` (762 core tests plus isolated suites)
- `bun run build`
- focused App/useTerminal tests: 79 passing
- frontend-only real-browser fixture with xterm focused:
  - Chromium desktop
  - WebKit desktop
  - WebKit iPhone 15 with `navigator.standalone=true`
- each browser confirmed modifier+2 switches the visible session with no terminal-input bytes, while a plain digit still reaches the selected terminal

## Host note
The private real-tmux e2e suite cannot allocate a PTY on this host (`fork failed: Device not configured`). No live tmux or Agentboard process was touched. The new isolated e2e regression is included for clean-host CI.