### PR TITLE
fix: skip unnecessary startup orphan rematch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/server/__tests__/logPoller.test.ts
+++ b/src/server/__tests__/logPoller.test.ts
@@ -163,6 +163,25 @@ class InlineMatchWorkerClient {
   dispose(): void {}
 }
 
+class RecordingMatchWorkerClient {
+  requests: Array<Omit<MatchWorkerRequest, 'id'>> = []
+
+  async poll(
+    request: Omit<MatchWorkerRequest, 'id'>,
+    _options?: { timeoutMs?: number }
+  ): Promise<MatchWorkerResponse> {
+    this.requests.push(request)
+    return {
+      id: 'test',
+      type: 'result',
+      entries: [],
+      orphanMatches: [],
+    }
+  }
+
+  dispose(): void {}
+}
+
 beforeEach(async () => {
   tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-poller-'))
   process.env.CLAUDE_CONFIG_DIR = path.join(tempRoot, 'claude')
@@ -205,6 +224,137 @@ afterEach(async () => {
 })
 
 describe('LogPoller', () => {
+  test('skips startup orphan rematch when every live window is already claimed', async () => {
+    const db = initDatabase({ path: ':memory:' })
+    const registry = new SessionRegistry()
+    registry.replaceSessions([baseSession])
+    const now = new Date().toISOString()
+
+    db.insertSession({
+      sessionId: 'active-session',
+      logFilePath: path.join(tempRoot, 'active.jsonl'),
+      projectPath: baseSession.projectPath,
+      slug: null,
+      agentType: 'claude',
+      displayName: baseSession.name,
+      createdAt: now,
+      lastActivityAt: now,
+      lastUserMessage: 'ready',
+      currentWindow: baseSession.tmuxWindow,
+      isPinned: false,
+      lastResumeError: null,
+      lastKnownLogSize: 0,
+      isCodexExec: false,
+      launchCommand: null,
+    })
+
+    const oldTimestamp = '2020-01-01T00:00:00.000Z'
+    for (let index = 0; index < 10_000; index += 1) {
+      db.insertSession({
+        sessionId: `history-${index}`,
+        logFilePath: path.join(tempRoot, `history-${index}.jsonl`),
+        projectPath: `/archived/project-${index}`,
+        slug: null,
+        agentType: index % 2 === 0 ? 'claude' : 'codex',
+        displayName: `history-${index}`,
+        createdAt: oldTimestamp,
+        lastActivityAt: oldTimestamp,
+        lastUserMessage: 'archived',
+        currentWindow: null,
+        isPinned: false,
+        lastResumeError: null,
+        lastKnownLogSize: 0,
+        isCodexExec: false,
+        launchCommand: null,
+      })
+    }
+
+    const historyQueries: Array<{ maxAgeHours?: number } | undefined> = []
+    const getHistorySessions = db.getHistorySessions
+    db.getHistorySessions = (options) => {
+      historyQueries.push(options)
+      return getHistorySessions(options)
+    }
+
+    const worker = new RecordingMatchWorkerClient()
+    const poller = new LogPoller(db, registry, {
+      matchWorkerClient: worker,
+    })
+
+    poller.start(5000)
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    await poller.waitForOrphanRematch()
+
+    // One request is the normal startup poll. A second request would be the
+    // expensive orphan rematch that previously loaded all 10,000 rows.
+    expect(worker.requests).toHaveLength(1)
+    expect(historyQueries).toEqual([{ maxAgeHours: 72 }])
+
+    poller.stop()
+    db.close()
+  })
+
+  test('scopes startup orphan candidates to unclaimed window metadata without an age cutoff', async () => {
+    const db = initDatabase({ path: ':memory:' })
+    const registry = new SessionRegistry()
+    registry.replaceSessions([baseSession])
+    const oldTimestamp = '2020-01-01T00:00:00.000Z'
+
+    db.insertSession({
+      sessionId: 'old-compatible-orphan',
+      logFilePath: path.join(tempRoot, 'compatible.jsonl'),
+      projectPath: baseSession.projectPath,
+      slug: null,
+      agentType: 'claude',
+      displayName: 'compatible-orphan',
+      createdAt: oldTimestamp,
+      lastActivityAt: oldTimestamp,
+      lastUserMessage: 'old but live',
+      currentWindow: null,
+      isPinned: false,
+      lastResumeError: null,
+      lastKnownLogSize: 0,
+      isCodexExec: false,
+      launchCommand: null,
+    })
+    db.insertSession({
+      sessionId: 'unrelated-orphan',
+      logFilePath: path.join(tempRoot, 'unrelated.jsonl'),
+      projectPath: '/unrelated/project',
+      slug: null,
+      agentType: 'claude',
+      displayName: 'unrelated-orphan',
+      createdAt: oldTimestamp,
+      lastActivityAt: oldTimestamp,
+      lastUserMessage: 'unrelated',
+      currentWindow: null,
+      isPinned: false,
+      lastResumeError: null,
+      lastKnownLogSize: 0,
+      isCodexExec: false,
+      launchCommand: null,
+    })
+
+    const worker = new RecordingMatchWorkerClient()
+    const poller = new LogPoller(db, registry, {
+      matchWorkerClient: worker,
+    })
+
+    poller.start(5000)
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    await poller.waitForOrphanRematch()
+
+    expect(worker.requests).toHaveLength(2)
+    const orphanRequest = worker.requests[1]
+    expect(orphanRequest?.forceOrphanRematch).toBeTrue()
+    expect(orphanRequest?.orphanCandidates?.map((record) => record.sessionId)).toEqual([
+      'old-compatible-orphan',
+    ])
+
+    poller.stop()
+    db.close()
+  })
+
   test('skips file content reads for already-known sessions', async () => {
     const db = initDatabase({ path: ':memory:' })
     const registry = new SessionRegistry()
@@ -344,7 +494,8 @@ describe('LogPoller', () => {
       onSessionActivated: (sessionId, window) => activated.push({ sessionId, window }),
     })
 
-    await poller.pollOnce()
+    poller.start(5000)
+    await new Promise((resolve) => setTimeout(resolve, 100))
     await poller.waitForOrphanRematch()
 
     const record = db.getSessionById('hibernating-session')
@@ -352,6 +503,7 @@ describe('LogPoller', () => {
     expect(record?.isPinned).toBeTrue()
     expect(activated).toEqual([])
 
+    poller.stop()
     db.close()
   })
 
@@ -391,7 +543,7 @@ describe('LogPoller', () => {
       agentType: 'claude',
       displayName: 'alpha',
       createdAt: stats.birthtime.toISOString(),
-      lastActivityAt: stats.mtime.toISOString(),
+      lastActivityAt: '2020-01-01T00:00:00.000Z',
       lastUserMessage: null,
       currentWindow: null,
       isPinned: true,
@@ -1227,7 +1379,7 @@ describe('LogPoller', () => {
       agentType: 'claude',
       displayName: 'orphan',
       createdAt: stats.birthtime.toISOString(),
-      lastActivityAt: stats.mtime.toISOString(),
+      lastActivityAt: '2020-01-01T00:00:00.000Z',
       lastUserMessage: null,
       currentWindow: null,
       isPinned: false,

--- a/src/server/__tests__/logPoller.test.ts
+++ b/src/server/__tests__/logPoller.test.ts
@@ -294,67 +294,6 @@ describe('LogPoller', () => {
     db.close()
   })
 
-  test('scopes startup orphan candidates to unclaimed window metadata without an age cutoff', async () => {
-    const db = initDatabase({ path: ':memory:' })
-    const registry = new SessionRegistry()
-    registry.replaceSessions([baseSession])
-    const oldTimestamp = '2020-01-01T00:00:00.000Z'
-
-    db.insertSession({
-      sessionId: 'old-compatible-orphan',
-      logFilePath: path.join(tempRoot, 'compatible.jsonl'),
-      projectPath: baseSession.projectPath,
-      slug: null,
-      agentType: 'claude',
-      displayName: 'compatible-orphan',
-      createdAt: oldTimestamp,
-      lastActivityAt: oldTimestamp,
-      lastUserMessage: 'old but live',
-      currentWindow: null,
-      isPinned: false,
-      lastResumeError: null,
-      lastKnownLogSize: 0,
-      isCodexExec: false,
-      launchCommand: null,
-    })
-    db.insertSession({
-      sessionId: 'unrelated-orphan',
-      logFilePath: path.join(tempRoot, 'unrelated.jsonl'),
-      projectPath: '/unrelated/project',
-      slug: null,
-      agentType: 'claude',
-      displayName: 'unrelated-orphan',
-      createdAt: oldTimestamp,
-      lastActivityAt: oldTimestamp,
-      lastUserMessage: 'unrelated',
-      currentWindow: null,
-      isPinned: false,
-      lastResumeError: null,
-      lastKnownLogSize: 0,
-      isCodexExec: false,
-      launchCommand: null,
-    })
-
-    const worker = new RecordingMatchWorkerClient()
-    const poller = new LogPoller(db, registry, {
-      matchWorkerClient: worker,
-    })
-
-    poller.start(5000)
-    await new Promise((resolve) => setTimeout(resolve, 100))
-    await poller.waitForOrphanRematch()
-
-    expect(worker.requests).toHaveLength(2)
-    const orphanRequest = worker.requests[1]
-    expect(orphanRequest?.forceOrphanRematch).toBeTrue()
-    expect(orphanRequest?.orphanCandidates?.map((record) => record.sessionId)).toEqual([
-      'old-compatible-orphan',
-    ])
-
-    poller.stop()
-    db.close()
-  })
-
   test('skips file content reads for already-known sessions', async () => {
     const db = initDatabase({ path: ':memory:' })
     const registry = new SessionRegistry()
@@ -1346,7 +1285,7 @@ describe('LogPoller', () => {
     db.close()
   })
 
-  test('rematches orphaned sessions on startup without new activity', async () => {
+  test('rematches an old orphan with stale project metadata on startup', async () => {
     const db = initDatabase({ path: ':memory:' })
     const registry = new SessionRegistry()
     registry.replaceSessions([baseSession])
@@ -1374,7 +1313,7 @@ describe('LogPoller', () => {
     db.insertSession({
       sessionId: 'claude-session-orphan',
       logFilePath: logPath,
-      projectPath,
+      projectPath: '/stale/moved/project',
       slug: null,
       agentType: 'claude',
       displayName: 'orphan',

--- a/src/server/logPoller.ts
+++ b/src/server/logPoller.ts
@@ -151,6 +151,36 @@ function canAttemptDormantRematch(record: {
   return !record.isPinned || hasRecoverableWakePending(record)
 }
 
+function canMatchDormantRecordToWindow(
+  record: Pick<SessionRecord, 'agentType' | 'displayName' | 'projectPath'>,
+  window: Session
+): boolean {
+  // Preserve the managed-window name fallback even when project metadata is
+  // stale or missing. The claim path still requires the window name to be
+  // unique before it uses this fallback.
+  if (window.source === 'managed' && record.displayName === window.name) {
+    return true
+  }
+
+  if (
+    record.agentType &&
+    window.agentType &&
+    record.agentType !== window.agentType
+  ) {
+    return false
+  }
+
+  const recordProject = normalizeProjectPath(record.projectPath ?? '')
+  const windowProject = normalizeProjectPath(window.projectPath ?? '')
+  if (recordProject && windowProject) {
+    return isSameOrChildPath(recordProject, windowProject)
+  }
+
+  // Missing metadata cannot safely rule a candidate out. Content matching is
+  // still responsible for proving the association.
+  return true
+}
+
 interface PollStats {
   logsScanned: number
   newSessions: number
@@ -306,18 +336,42 @@ export class LogPoller {
 
     try {
       const windows = this.registry.getAll()
-      const logDirs = getLogSearchDirs()
-      const sessionRecords = [
-        ...this.db.getActiveSessions(),
+      const activeSessions = this.db.getActiveSessions()
+      const initiallyClaimedWindows = new Set(
+        activeSessions
+          .map((session) => session.currentWindow)
+          .filter(Boolean) as string[]
+      )
+      const unclaimedWindows = windows.filter(
+        (window) => !initiallyClaimedWindows.has(window.tmuxWindow)
+      )
+
+      // The common restart path already has a persisted owner for every live
+      // window. Avoid loading all history rows or touching any log files when
+      // there is nothing the rematcher can claim.
+      if (unclaimedWindows.length === 0) {
+        logger.info('orphan_rematch_skip', {
+          reason: 'no_unclaimed_windows',
+          windowCount: windows.length,
+        })
+        return
+      }
+
+      const rematchStartedAt = Date.now()
+      const selectionStartedAt = Date.now()
+      const dormantSessions = [
         ...this.db.getHibernatingSessions(),
         ...this.db.getHistorySessions(),
       ]
+      const logDirs = getLogSearchDirs()
       const excludedProjects = config.excludeProjects ?? []
 
-      // Build orphan candidates - sessions without active windows
+      // Build candidates for the actual recovery targets. A candidate with
+      // complete metadata must overlap at least one unclaimed window; missing
+      // metadata remains eligible for content-based proof.
       const orphanCandidates: OrphanCandidate[] = []
-      for (const record of sessionRecords) {
-        if (record.currentWindow) continue
+      const orphanRecords: typeof dormantSessions = []
+      for (const record of dormantSessions) {
         if (!canAttemptDormantRematch(record)) continue
         const logFilePath = record.logFilePath
         if (!logFilePath) continue
@@ -331,6 +385,14 @@ export class LogPoller {
           })
           if (shouldExclude) continue
         }
+        if (
+          !unclaimedWindows.some((window) =>
+            canMatchDormantRecordToWindow(record, window)
+          )
+        ) {
+          continue
+        }
+        orphanRecords.push(record)
         orphanCandidates.push({
           sessionId: record.sessionId,
           logFilePath,
@@ -341,14 +403,26 @@ export class LogPoller {
       }
 
       if (orphanCandidates.length === 0) {
-        logger.info('orphan_rematch_skip', { reason: 'no_orphans' })
+        logger.info('orphan_rematch_skip', {
+          reason: 'no_orphans',
+          unclaimedWindowCount: unclaimedWindows.length,
+          selectionMs: Date.now() - selectionStartedAt,
+        })
         return
       }
 
-      logger.info('orphan_rematch_start', { orphanCount: orphanCandidates.length })
+      const selectionMs = Date.now() - selectionStartedAt
+      logger.info('orphan_rematch_start', {
+        orphanCount: orphanCandidates.length,
+        unclaimedWindowCount: unclaimedWindows.length,
+        selectionMs,
+      })
 
       // Run orphan rematch on dedicated worker - doesn't block regular polling
-      const sessions: SessionSnapshot[] = sessionRecords.map((session) => ({
+      const sessions: SessionSnapshot[] = [
+        ...activeSessions,
+        ...orphanRecords,
+      ].map((session) => ({
         sessionId: session.sessionId,
         logFilePath: session.logFilePath,
         currentWindow: session.currentWindow,
@@ -383,12 +457,7 @@ export class LogPoller {
         windows.map((window) => [window.tmuxWindow, window])
       )
       // Track claimed windows and matched orphan sessionIds for name fallback
-      const claimedWindows = new Set(
-        this.db
-          .getActiveSessions()
-          .map((s) => s.currentWindow)
-          .filter(Boolean) as string[]
-      )
+      const claimedWindows = new Set(initiallyClaimedWindows)
       const matchedOrphanSessionIds = new Set<string>()
       let orphanMatches = 0
 
@@ -487,6 +556,9 @@ export class LogPoller {
       logger.info('orphan_rematch_complete', {
         orphanCount: orphanCandidates.length,
         matches: orphanMatches,
+        unclaimedWindowCount: unclaimedWindows.length,
+        selectionMs,
+        durationMs: Date.now() - rematchStartedAt,
       })
     } catch (error) {
       logger.warn('orphan_rematch_error', {
@@ -945,6 +1017,9 @@ export class LogPoller {
     this.pollInFlight = true
     const start = Date.now()
     let workerErrors = 0
+    let snapshotMs = 0
+    let workerMs = 0
+    let processMs = 0
 
     try {
       const windows = this.registry.getAll()
@@ -997,8 +1072,10 @@ export class LogPoller {
           })
         }
       }
+      snapshotMs = Date.now() - start
 
       let response: MatchWorkerResponse | null = null
+      const workerStartedAt = Date.now()
       if (!this.matchWorker) {
         if (!this.warnedWorkerDisabled) {
           this.warnedWorkerDisabled = true
@@ -1039,6 +1116,7 @@ export class LogPoller {
           })
         }
       }
+      workerMs = Date.now() - workerStartedAt
 
       if (response?.profile) {
         logger.info('log_match_profile', {
@@ -1054,6 +1132,7 @@ export class LogPoller {
         })
       }
 
+      const processStartedAt = Date.now()
       const processed = response
         ? this.processMatchResponse(response, windows, sessionRecords)
         : {
@@ -1064,6 +1143,7 @@ export class LogPoller {
             errors: 0,
             durationMs: 0,
           }
+      processMs = Date.now() - processStartedAt
 
       const durationMs = Date.now() - start
       const stats: PollStats = {
@@ -1075,7 +1155,15 @@ export class LogPoller {
         durationMs,
       }
 
-      logger.info('log_poll', { ...stats })
+      logger.info('log_poll', {
+        ...stats,
+        snapshotMs,
+        workerMs,
+        processMs,
+        workerScanMs: response?.scanMs ?? null,
+        workerSortMs: response?.sortMs ?? null,
+        workerMatchMs: response?.matchMs ?? null,
+      })
       this.notifyOrphanSessionsDiscovered(stats.orphans)
       return stats
     } finally {

--- a/src/server/logPoller.ts
+++ b/src/server/logPoller.ts
@@ -151,36 +151,6 @@ function canAttemptDormantRematch(record: {
   return !record.isPinned || hasRecoverableWakePending(record)
 }
 
-function canMatchDormantRecordToWindow(
-  record: Pick<SessionRecord, 'agentType' | 'displayName' | 'projectPath'>,
-  window: Session
-): boolean {
-  // Preserve the managed-window name fallback even when project metadata is
-  // stale or missing. The claim path still requires the window name to be
-  // unique before it uses this fallback.
-  if (window.source === 'managed' && record.displayName === window.name) {
-    return true
-  }
-
-  if (
-    record.agentType &&
-    window.agentType &&
-    record.agentType !== window.agentType
-  ) {
-    return false
-  }
-
-  const recordProject = normalizeProjectPath(record.projectPath ?? '')
-  const windowProject = normalizeProjectPath(window.projectPath ?? '')
-  if (recordProject && windowProject) {
-    return isSameOrChildPath(recordProject, windowProject)
-  }
-
-  // Missing metadata cannot safely rule a candidate out. Content matching is
-  // still responsible for proving the association.
-  return true
-}
-
 interface PollStats {
   logsScanned: number
   newSessions: number
@@ -366,9 +336,10 @@ export class LogPoller {
       const logDirs = getLogSearchDirs()
       const excludedProjects = config.excludeProjects ?? []
 
-      // Build candidates for the actual recovery targets. A candidate with
-      // complete metadata must overlap at least one unclaimed window; missing
-      // metadata remains eligible for content-based proof.
+      // Build eligible dormant candidates. Project and agent metadata are not
+      // hard filters here: the content matcher treats them as soft preferences,
+      // which preserves recovery after a repo move, symlink change, or relaunch
+      // from a different worktree path.
       const orphanCandidates: OrphanCandidate[] = []
       const orphanRecords: typeof dormantSessions = []
       for (const record of dormantSessions) {
@@ -384,13 +355,6 @@ export class LogPoller {
             return projectPath.startsWith(excluded)
           })
           if (shouldExclude) continue
-        }
-        if (
-          !unclaimedWindows.some((window) =>
-            canMatchDormantRecordToWindow(record, window)
-          )
-        ) {
-          continue
         }
         orphanRecords.push(record)
         orphanCandidates.push({


### PR DESCRIPTION
## Summary

- skip startup orphan rematching before loading history when every live window is already claimed
- preserve exact-content recovery for old sessions even when stored project metadata is stale
- reduce the orphan worker snapshot to active and eligible dormant records
- add phase timings for database snapshots, worker work, response processing, and orphan selection
- preserve pinned-session protection and pending-wake recovery

## Tests

- added a 10,000-history-row regression proving the fully claimed startup path performs no unbounded history query or orphan worker request
- added exact-content recovery coverage for a six-year-old orphan with deliberately stale stored project metadata
- corrected hibernation coverage to exercise the actual startup rematch path
- `bun run lint`
- `bun run typecheck`
- `bun run test:ci`

## Review follow-up

An independent Claude review identified that the original metadata prefilter was stricter than the content matcher and could cause false negatives after repo moves, symlink changes, or worktree changes. That filter was removed; this PR now retains only the safe fully-claimed fast path and observability changes. Genuinely bounded reconciliation with unclaimed windows is deferred to a separate design.

## Safety

All test data used temporary databases and log directories. No production Agentboard or tmux state was targeted.