### PR TITLE
fix: keep log reconciliation off startup path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/server/__tests__/logPoller.test.ts
+++ b/src/server/__tests__/logPoller.test.ts
@@ -182,6 +182,44 @@ class RecordingMatchWorkerClient {
   dispose(): void {}
 }
 
+class BlockingMatchWorkerClient extends RecordingMatchWorkerClient {
+  private releaseFirst: (() => void) | null = null
+
+  override async poll(
+    request: Omit<MatchWorkerRequest, 'id'>,
+    _options?: { timeoutMs?: number }
+  ): Promise<MatchWorkerResponse> {
+    this.requests.push(request)
+    if (this.requests.length === 1) {
+      await new Promise<void>((resolve) => {
+        this.releaseFirst = resolve
+      })
+    }
+    return {
+      id: 'test',
+      type: 'result',
+      entries: [],
+      orphanMatches: [],
+    }
+  }
+
+  release(): void {
+    this.releaseFirst?.()
+    this.releaseFirst = null
+  }
+}
+
+async function waitForRequestCount(
+  worker: RecordingMatchWorkerClient,
+  expected: number
+): Promise<void> {
+  const deadline = Date.now() + 1000
+  while (worker.requests.length < expected && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  expect(worker.requests).toHaveLength(expected)
+}
+
 beforeEach(async () => {
   tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-poller-'))
   process.env.CLAUDE_CONFIG_DIR = path.join(tempRoot, 'claude')
@@ -224,6 +262,98 @@ afterEach(async () => {
 })
 
 describe('LogPoller', () => {
+  test('watch-mode startup refreshes only persisted active log paths', async () => {
+    const db = initDatabase({ path: ':memory:' })
+    const registry = new SessionRegistry()
+    registry.replaceSessions([baseSession])
+
+    const logDir = path.join(
+      process.env.CLAUDE_CONFIG_DIR ?? '',
+      'projects',
+      encodeProjectPath(baseProjectPath)
+    )
+    await fs.mkdir(logDir, { recursive: true })
+    const activeLogPath = path.join(logDir, 'active.jsonl')
+    await fs.writeFile(
+      activeLogPath,
+      `${buildUserLogEntry('active', {
+        sessionId: 'active-session',
+        cwd: baseProjectPath,
+      })}\n`
+    )
+    const now = new Date().toISOString()
+    db.insertSession({
+      sessionId: 'active-session',
+      logFilePath: activeLogPath,
+      projectPath: baseProjectPath,
+      slug: null,
+      agentType: 'claude',
+      displayName: 'active',
+      createdAt: now,
+      lastActivityAt: now,
+      lastUserMessage: 'active',
+      currentWindow: baseSession.tmuxWindow,
+      isPinned: false,
+      lastResumeError: null,
+      lastKnownLogSize: 0,
+      isCodexExec: false,
+      launchCommand: null,
+    })
+
+    // This historical file makes a full-tree scan observable: it must not be
+    // included in the startup request.
+    const historicalLogPath = path.join(logDir, 'historical.jsonl')
+    await fs.writeFile(
+      historicalLogPath,
+      `${buildUserLogEntry('historical', {
+        sessionId: 'historical-session',
+        cwd: baseProjectPath,
+      })}\n`
+    )
+
+    db.getKnownSessionKeys = () => {
+      throw new Error('watch startup must not load the full history key set')
+    }
+
+    const worker = new RecordingMatchWorkerClient()
+    const poller = new LogPoller(db, registry, { matchWorkerClient: worker })
+    poller.start(5000, 'watch')
+
+    await waitForRequestCount(worker, 1)
+    await poller.waitForOrphanRematch()
+
+    expect(worker.requests[0]?.preFilteredPaths).toEqual([activeLogPath])
+    expect(worker.requests[0]?.preFilteredPaths).not.toContain(historicalLogPath)
+
+    poller.stop()
+    db.close()
+  })
+
+  test('coalesces watcher paths received while another poll is in flight', async () => {
+    const db = initDatabase({ path: ':memory:' })
+    const registry = new SessionRegistry()
+    const worker = new BlockingMatchWorkerClient()
+    const poller = new LogPoller(db, registry, { matchWorkerClient: worker })
+
+    const firstPath = path.join(tempRoot, 'first.jsonl')
+    const secondPath = path.join(tempRoot, 'second.jsonl')
+    const firstPoll = poller.pollChanged([firstPath])
+    await waitForRequestCount(worker, 1)
+
+    await poller.pollChanged([secondPath, secondPath])
+    expect(worker.requests).toHaveLength(1)
+
+    worker.release()
+    await firstPoll
+    await waitForRequestCount(worker, 2)
+
+    expect(worker.requests[0]?.preFilteredPaths).toEqual([firstPath])
+    expect(worker.requests[1]?.preFilteredPaths).toEqual([secondPath])
+
+    poller.stop()
+    db.close()
+  })
+
   test('skips startup orphan rematch when every live window is already claimed', async () => {
     const db = initDatabase({ path: ':memory:' })
     const registry = new SessionRegistry()

--- a/src/server/__tests__/logPoller.test.ts
+++ b/src/server/__tests__/logPoller.test.ts
@@ -329,6 +329,82 @@ describe('LogPoller', () => {
     db.close()
   })
 
+  test('runs orphan rematch only after delayed comprehensive reconciliation', async () => {
+    const db = initDatabase({ path: ':memory:' })
+    const registry = new SessionRegistry()
+    registry.replaceSessions([baseSession])
+    const now = new Date().toISOString()
+    db.insertSession({
+      sessionId: 'dormant-session',
+      logFilePath: path.join(tempRoot, 'dormant.jsonl'),
+      projectPath: baseProjectPath,
+      slug: null,
+      agentType: 'claude',
+      displayName: 'dormant',
+      createdAt: now,
+      lastActivityAt: now,
+      lastUserMessage: 'old session',
+      currentWindow: null,
+      isPinned: false,
+      lastResumeError: null,
+      lastKnownLogSize: 0,
+      isCodexExec: false,
+      launchCommand: null,
+    })
+
+    const worker = new RecordingMatchWorkerClient()
+    const poller = new LogPoller(db, registry, {
+      matchWorkerClient: worker,
+      startupReconciliationDelayMs: 5,
+    })
+    poller.start(5000, 'watch')
+
+    await waitForRequestCount(worker, 2)
+
+    expect(worker.requests[0]?.preFilteredPaths).toBeUndefined()
+    expect(worker.requests[0]?.forceOrphanRematch).toBe(false)
+    expect(worker.requests[1]?.forceOrphanRematch).toBe(true)
+
+    poller.stop()
+    db.close()
+  })
+
+  test('delayed reconciliation discovers logs created while offline', async () => {
+    const db = initDatabase({ path: ':memory:' })
+    const registry = new SessionRegistry()
+    const projectPath = path.join(tempRoot, 'offline-project')
+    const logDir = path.join(
+      process.env.CLAUDE_CONFIG_DIR ?? '',
+      'projects',
+      encodeProjectPath(projectPath)
+    )
+    await fs.mkdir(logDir, { recursive: true })
+    const logPath = path.join(logDir, 'offline-session.jsonl')
+    await fs.writeFile(
+      logPath,
+      `${buildUserLogEntry('created before startup', {
+        sessionId: 'offline-session',
+        cwd: projectPath,
+      })}\n`
+    )
+
+    const poller = new LogPoller(db, registry, {
+      matchWorkerClient: new InlineMatchWorkerClient(),
+      startupReconciliationDelayMs: 5,
+    })
+    poller.start(5000, 'watch')
+
+    const deadline = Date.now() + 1000
+    while (!db.getSessionById('offline-session') && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 5))
+    }
+
+    expect(db.getSessionById('offline-session')?.logFilePath).toBe(logPath)
+
+    poller.stop()
+    db.close()
+  })
+
   test('coalesces watcher paths received while another poll is in flight', async () => {
     const db = initDatabase({ path: ':memory:' })
     const registry = new SessionRegistry()
@@ -349,6 +425,30 @@ describe('LogPoller', () => {
 
     expect(worker.requests[0]?.preFilteredPaths).toEqual([firstPath])
     expect(worker.requests[1]?.preFilteredPaths).toEqual([secondPath])
+
+    poller.stop()
+    db.close()
+  })
+
+  test('drains large watcher batches in bounded worker requests', async () => {
+    const db = initDatabase({ path: ':memory:' })
+    const registry = new SessionRegistry()
+    const worker = new RecordingMatchWorkerClient()
+    const poller = new LogPoller(db, registry, {
+      matchWorkerClient: worker,
+      maxLogsPerPoll: 2,
+    })
+    const changedPaths = [
+      path.join(tempRoot, 'one.jsonl'),
+      path.join(tempRoot, 'two.jsonl'),
+      path.join(tempRoot, 'three.jsonl'),
+    ]
+
+    await poller.pollChanged(changedPaths)
+    await waitForRequestCount(worker, 2)
+
+    expect(worker.requests[0]?.preFilteredPaths).toEqual(changedPaths.slice(0, 2))
+    expect(worker.requests[1]?.preFilteredPaths).toEqual(changedPaths.slice(2))
 
     poller.stop()
     db.close()

--- a/src/server/logPoller.ts
+++ b/src/server/logPoller.ts
@@ -35,6 +35,7 @@ const HISTORY_SNAPSHOT_MAX_AGE_HOURS = 72
 // short prefix is enough — full texts made each postMessage clone ~100+ MB.
 const SNAPSHOT_MESSAGE_MAX_LENGTH = 2048
 const STARTUP_LAST_MESSAGE_BACKFILL_MAX = 100
+const STARTUP_RECONCILIATION_DELAY_MS = 5000
 const MIN_LOG_TOKENS_FOR_INSERT = 1
 const REMATCH_COOLDOWN_MS = 60 * 1000 // 1 minute between re-match attempts
 const WAKE_PENDING_REMATCH_TTL_MS = 10 * 60 * 1000
@@ -158,6 +159,7 @@ interface PollStats {
   orphans: number
   errors: number
   durationMs: number
+  completed: boolean
 }
 
 interface MatchWorkerClient {
@@ -170,6 +172,7 @@ interface MatchWorkerClient {
 
 export class LogPoller {
   private interval: ReturnType<typeof setInterval> | null = null
+  private startupReconciliationTimer: ReturnType<typeof setTimeout> | null = null
   private logWatcher: LogWatcher | null = null
   private db: SessionDatabase
   private registry: SessionRegistry
@@ -180,6 +183,7 @@ export class LogPoller {
   private maxLogsPerPoll: number
   private matchProfile: boolean
   private rgThreads?: number
+  private startupReconciliationDelayMs: number
   private matchWorker: MatchWorkerClient | null
   private pollInFlight = false
   private pendingChangedPaths = new Set<string>()
@@ -206,6 +210,7 @@ export class LogPoller {
       rgThreads,
       matchWorker,
       matchWorkerClient,
+      startupReconciliationDelayMs,
     }: {
       onSessionOrphaned?: (sessionId: string, supersededBy?: string) => void
       onSessionActivated?: (sessionId: string, window: string) => void
@@ -216,6 +221,7 @@ export class LogPoller {
       rgThreads?: number
       matchWorker?: boolean
       matchWorkerClient?: MatchWorkerClient
+      startupReconciliationDelayMs?: number
     } = {}
   ) {
     this.db = db
@@ -228,6 +234,10 @@ export class LogPoller {
     this.maxLogsPerPoll = Math.max(1, limit)
     this.matchProfile = matchProfile ?? false
     this.rgThreads = rgThreads
+    this.startupReconciliationDelayMs = Math.max(
+      0,
+      startupReconciliationDelayMs ?? STARTUP_RECONCILIATION_DELAY_MS
+    )
     this.matchWorker =
       matchWorkerClient ??
       (matchWorker ? (new LogMatchWorkerClient() as MatchWorkerClient) : null)
@@ -248,14 +258,10 @@ export class LogPoller {
   private startPollMode(intervalMs: number): void {
     const safeInterval = Math.max(MIN_INTERVAL_MS, intervalMs)
     this.interval = setInterval(() => {
-      void this.pollOnce()
+      void this.runComprehensiveReconciliation()
     }, safeInterval)
-    // Start orphan rematch after first poll completes to avoid worker contention
-    void this.pollOnce().then(() => {
-      if (this.orphanRematchPending && !this.orphanRematchInProgress) {
-        this.orphanRematchPromise = this.runOrphanRematchInBackground()
-      }
-    })
+    // Start orphan rematch after the first successful comprehensive poll.
+    void this.runComprehensiveReconciliation()
   }
 
   private startWatchMode(fallbackIntervalMs: number): void {
@@ -273,12 +279,12 @@ export class LogPoller {
     // fallback interval to avoid regressing from the default 5s poll mode.
     const minFallback = process.platform === 'linux' ? 15_000 : 60_000
     this.interval = setInterval(() => {
-      void this.pollOnce()
+      void this.runComprehensiveReconciliation()
     }, Math.max(fallbackIntervalMs, minFallback))
 
     // Refresh only persisted live-session logs on startup. The watcher handles
-    // new activity from this point forward, while the fallback poll performs
-    // the comprehensive reconciliation for logs created while we were offline.
+    // new activity from this point forward, while a delayed and then periodic
+    // comprehensive reconciliation finds logs created while we were offline.
     // This keeps a large historical log tree off the startup critical path.
     const startupPaths = this.db
       .getActiveSessions()
@@ -290,10 +296,20 @@ export class LogPoller {
       : Promise.resolve()
 
     void startupRefresh.then(() => {
-      if (this.orphanRematchPending && !this.orphanRematchInProgress) {
-        this.orphanRematchPromise = this.runOrphanRematchInBackground()
-      }
+      if (!this.logWatcher) return
+      this.startupReconciliationTimer = setTimeout(() => {
+        this.startupReconciliationTimer = null
+        void this.runComprehensiveReconciliation()
+      }, this.startupReconciliationDelayMs)
     })
+  }
+
+  private async runComprehensiveReconciliation(): Promise<void> {
+    const stats = await this.pollOnce()
+    if (!stats.completed || stats.errors > 0) return
+    if (this.orphanRematchPending && !this.orphanRematchInProgress) {
+      this.orphanRematchPromise = this.runOrphanRematchInBackground()
+    }
   }
 
   /** Wait for the background orphan rematch to complete (for testing) */
@@ -558,6 +574,10 @@ export class LogPoller {
       clearInterval(this.interval)
     }
     this.interval = null
+    if (this.startupReconciliationTimer) {
+      clearTimeout(this.startupReconciliationTimer)
+    }
+    this.startupReconciliationTimer = null
     this.logWatcher?.stop()
     this.logWatcher = null
     this.matchWorker?.dispose()
@@ -581,8 +601,13 @@ export class LogPoller {
     }
     if (this.pollInFlight || this.pendingChangedPaths.size === 0) return
 
-    const pathsToPoll = [...this.pendingChangedPaths]
-    this.pendingChangedPaths.clear()
+    const pathsToPoll = [...this.pendingChangedPaths].slice(
+      0,
+      this.maxLogsPerPoll
+    )
+    for (const pathToPoll of pathsToPoll) {
+      this.pendingChangedPaths.delete(pathToPoll)
+    }
     this.pollInFlight = true
 
     try {
@@ -1003,6 +1028,7 @@ export class LogPoller {
       orphans,
       errors,
       durationMs: 0,
+      completed: true,
     }
   }
 
@@ -1015,6 +1041,7 @@ export class LogPoller {
         orphans: 0,
         errors: 0,
         durationMs: 0,
+        completed: false,
       }
     }
     this.pollInFlight = true
@@ -1145,6 +1172,7 @@ export class LogPoller {
             orphans: 0,
             errors: 0,
             durationMs: 0,
+            completed: false,
           }
       processMs = Date.now() - processStartedAt
 
@@ -1156,6 +1184,7 @@ export class LogPoller {
         orphans: processed.orphans,
         errors: processed.errors + workerErrors,
         durationMs,
+        completed: response !== null,
       }
 
       logger.info('log_poll', {

--- a/src/server/logPoller.ts
+++ b/src/server/logPoller.ts
@@ -182,6 +182,7 @@ export class LogPoller {
   private rgThreads?: number
   private matchWorker: MatchWorkerClient | null
   private pollInFlight = false
+  private pendingChangedPaths = new Set<string>()
   private orphanRematchPending = true
   private orphanRematchInProgress = false
   private orphanRematchPromise: Promise<void> | null = null
@@ -275,7 +276,20 @@ export class LogPoller {
       void this.pollOnce()
     }, Math.max(fallbackIntervalMs, minFallback))
 
-    void this.pollOnce().then(() => {
+    // Refresh only persisted live-session logs on startup. The watcher handles
+    // new activity from this point forward, while the fallback poll performs
+    // the comprehensive reconciliation for logs created while we were offline.
+    // This keeps a large historical log tree off the startup critical path.
+    const startupPaths = this.db
+      .getActiveSessions()
+      .map((session) => session.logFilePath)
+      .filter((logPath): logPath is string => Boolean(logPath))
+
+    const startupRefresh = startupPaths.length > 0
+      ? this.pollChanged(startupPaths)
+      : Promise.resolve()
+
+    void startupRefresh.then(() => {
       if (this.orphanRematchPending && !this.orphanRematchInProgress) {
         this.orphanRematchPromise = this.runOrphanRematchInBackground()
       }
@@ -562,7 +576,13 @@ export class LogPoller {
   }
 
   async pollChanged(changedPaths: string[]): Promise<void> {
-    if (this.pollInFlight) return
+    for (const changedPath of changedPaths) {
+      this.pendingChangedPaths.add(changedPath)
+    }
+    if (this.pollInFlight || this.pendingChangedPaths.size === 0) return
+
+    const pathsToPoll = [...this.pendingChangedPaths]
+    this.pendingChangedPaths.clear()
     this.pollInFlight = true
 
     try {
@@ -585,7 +605,20 @@ export class LogPoller {
         lastUserMessage: toSnapshotMessage(session.lastUserMessage),
         lastKnownLogSize: session.lastKnownLogSize,
       }))
-      const knownSessions: KnownSession[] = this.db.getKnownSessionKeys()
+      // Watch batches are already path-scoped. Resolve metadata only for those
+      // paths instead of loading and cloning every historical session key.
+      const knownSessions: KnownSession[] = pathsToPoll.flatMap((logPath) => {
+        const session = this.db.getSessionByLogPath(logPath)
+        if (!session) return []
+        return [{
+          logFilePath: session.logFilePath,
+          sessionId: session.sessionId,
+          projectPath: session.projectPath,
+          slug: session.slug,
+          agentType: session.agentType,
+          isCodexExec: session.isCodexExec,
+        }]
+      })
 
       const response = await this.matchWorker.poll({
         windows,
@@ -599,7 +632,7 @@ export class LogPoller {
         orphanCandidates: [],
         lastMessageCandidates: [],
         skipMatchingPatterns: config.skipMatchingPatterns,
-        preFilteredPaths: changedPaths,
+        preFilteredPaths: pathsToPoll,
         search: {
           rgThreads: this.rgThreads,
         },
@@ -610,11 +643,17 @@ export class LogPoller {
     } catch (error) {
       logger.warn('log_poll_changed_error', {
         message: error instanceof Error ? error.message : String(error),
-        pathCount: changedPaths.length,
+        pathCount: pathsToPoll.length,
       })
     } finally {
       this.pollInFlight = false
+      this.drainPendingChangedPaths()
     }
+  }
+
+  private drainPendingChangedPaths(): void {
+    if (this.pendingChangedPaths.size === 0) return
+    queueMicrotask(() => void this.pollChanged([]))
   }
 
   private processMatchResponse(
@@ -1132,6 +1171,7 @@ export class LogPoller {
       return stats
     } finally {
       this.pollInFlight = false
+      this.drainPendingChangedPaths()
     }
   }
 }


### PR DESCRIPTION
## Summary
- refresh only persisted active-session log paths when watch mode starts
- run full-tree reconciliation after a short startup delay, before dormant-session rematching
- preserve offline-created log discovery without keeping the scan on the startup critical path
- coalesce filesystem changes and drain large watcher batches in bounded requests
- resolve watcher metadata per changed path instead of loading every historical key
- bump the patch version to 0.4.22

## Why
The initial watch-mode poll recursively scanned and statted the complete Claude, Codex, and Pi log tree. On a large history this could exceed the worker timeout and delay startup. It also dropped watcher batches received while that scan held the shared poll lock.

The delayed comprehensive pass runs before orphan rematching so a log created while Agentboard was offline can claim its live window before any stale dormant-session fallback.

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test:ci`
- `bun run build`
- targeted `logPoller.test.ts`: 29 passed
- read-only Claude critique; ordering and batch-size findings addressed

All validation used temporary log/database fixtures and the safe CI suite; no production Agentboard or tmux instance was touched.