### PR TITLE
fix(matcher): hard agent-type gate + robust empty-log check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/server/__tests__/logMatcher.test.ts
+++ b/src/server/__tests__/logMatcher.test.ts
@@ -678,6 +678,51 @@ describe('logMatcher', () => {
     await fs.rm(tempDir, { recursive: true, force: true })
   })
 
+  test('matchWindowsToLogsByExactRg never swaps a claude and a codex window sharing a prompt', async () => {
+    // Incident replay: same prompt in a claude window (pane shows the collapsed
+    // paste placeholder, which is in no log) and a codex window (pane shows the
+    // raw paste). Phase 1: only the claude log has flushed. Phase 2: both have.
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-logmatch-'))
+    const claudeDir = path.join(tempDir, '.claude', 'projects', 'proj')
+    const codexDir = path.join(tempDir, '.codex', 'sessions')
+    await fs.mkdir(claudeDir, { recursive: true })
+    await fs.mkdir(codexDir, { recursive: true })
+    const claudeLog = path.join(claudeDir, 'claude-session.jsonl')
+    const codexLog = path.join(codexDir, 'rollout-codex.jsonl')
+    const paste = 'Look at this slack convo and tell me what our product should focus on'
+
+    const base = {
+      projectPath: '/tmp/proj',
+      status: 'waiting' as const,
+      lastActivity: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+      source: 'managed' as const,
+    }
+    const windows: Session[] = [
+      { ...base, id: 'w-claude', name: 'claude-win', tmuxWindow: 'agentboard:1', agentType: 'claude' },
+      { ...base, id: 'w-codex', name: 'codex-win', tmuxWindow: 'agentboard:2', agentType: 'codex' },
+    ]
+    setTmuxOutput('agentboard:1', buildPromptScrollback(['[Pasted text #1 +400 lines]']))
+    setTmuxOutput('agentboard:2', buildPromptScrollback([paste]))
+
+    // Phase 1: claude log flushed first
+    await fs.writeFile(claudeLog, buildUserLogEntry(paste))
+    let { matches } = matchWindowsToLogsByExactRg(windows, tempDir)
+    expect(matches.size).toBe(0)
+
+    // Phase 2: codex log catches up
+    await fs.writeFile(codexLog, buildUserLogEntry(paste))
+    ;({ matches } = matchWindowsToLogsByExactRg(windows, tempDir))
+    expect(matches.get(codexLog)?.tmuxWindow).toBe('agentboard:2')
+    expect(matches.has(claudeLog)).toBe(false)
+
+    const asyncResult = await matchWindowsToLogsByExactRgAsync(windows, tempDir)
+    expect(asyncResult.matches.get(codexLog)?.tmuxWindow).toBe('agentboard:2')
+    expect(asyncResult.matches.has(claudeLog)).toBe(false)
+
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
   test('matchWindowsToLogsByExactRg returns noMessageWindows for empty terminals', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-nomsg-'))
     const logPath = path.join(tempDir, 'session.jsonl')

--- a/src/server/__tests__/logMatcher.test.ts
+++ b/src/server/__tests__/logMatcher.test.ts
@@ -9,6 +9,7 @@ import {
   matchWindowsToLogsByExactRg,
   matchWindowsToLogsByExactRgAsync,
   tryExactMatchWindowToLog,
+  getLogTokenCount,
   verifyWindowLogAssociation,
   verifyWindowLogAssociationDetailedAsync,
   extractRecentTraceLinesFromTmux,
@@ -520,6 +521,72 @@ describe('logMatcher', () => {
 
     const result = tryExactMatchWindowToLog('agentboard:1', tempDir)
     expect(result?.logPath).toBe(logPath)
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  test('tryExactMatchWindowToLog refuses a log of a different agent type than the window', async () => {
+    // Same prompt pasted into a claude window and a codex window seconds apart:
+    // the claude log flushes first, so for a moment it is the only log containing
+    // the codex pane's text. The codex window must wait, not claim the claude log.
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-logmatch-'))
+    const claudeDir = path.join(tempDir, '.claude', 'projects', 'proj')
+    await fs.mkdir(claudeDir, { recursive: true })
+    const claudeLog = path.join(claudeDir, 'claude-session.jsonl')
+    const message = 'look at this slack convo and tell me what you think'
+    await fs.writeFile(claudeLog, buildUserLogEntry(message))
+    setTmuxOutput('agentboard:1', buildPromptScrollback([message]))
+
+    expect(
+      tryExactMatchWindowToLog('agentboard:1', tempDir, undefined, { agentType: 'codex' })
+    ).toBeNull()
+    // Unknown window type fails open
+    expect(
+      tryExactMatchWindowToLog('agentboard:1', tempDir, undefined, {})?.logPath
+    ).toBe(claudeLog)
+    expect(
+      tryExactMatchWindowToLog('agentboard:1', tempDir, undefined, { agentType: 'claude' })?.logPath
+    ).toBe(claudeLog)
+
+    // Once the codex log catches up, the codex window picks it over the claude log
+    const codexDir = path.join(tempDir, '.codex', 'sessions')
+    await fs.mkdir(codexDir, { recursive: true })
+    const codexLog = path.join(codexDir, 'rollout-codex.jsonl')
+    await fs.writeFile(codexLog, buildUserLogEntry(message))
+    expect(
+      tryExactMatchWindowToLog('agentboard:1', tempDir, undefined, { agentType: 'codex' })?.logPath
+    ).toBe(codexLog)
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  test('getLogTokenCount survives a single message line larger than the tail read window', async () => {
+    // A 150KB+ pasted message followed by its item_completed echo: the 200KB
+    // tail slice starts mid-way through the paste line, so the tail parse sees
+    // only an unparseable fragment plus a non-message event.
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-logmatch-'))
+    const logPath = path.join(tempDir, 'rollout.jsonl')
+    const hugeText = 'pasted transcript line\n'.repeat(8000)
+    const userLine = JSON.stringify({
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: hugeText }],
+      },
+    })
+    const echoLine = JSON.stringify({
+      type: 'event_msg',
+      payload: { type: 'item_completed', item: { type: 'user_message', text: hugeText } },
+    })
+    expect(userLine.length).toBeGreaterThan(150 * 1024)
+    await fs.writeFile(
+      logPath,
+      [JSON.stringify({ type: 'session_meta', payload: { id: 'x' } }), userLine, echoLine].join('\n')
+    )
+    expect(getLogTokenCount(logPath)).toBeGreaterThan(0)
+
+    const emptyPath = path.join(tempDir, 'empty.jsonl')
+    await fs.writeFile(emptyPath, JSON.stringify({ type: 'session_meta', payload: { id: 'y' } }))
+    expect(getLogTokenCount(emptyPath)).toBe(0)
     await fs.rm(tempDir, { recursive: true, force: true })
   })
 

--- a/src/server/agentDetection.ts
+++ b/src/server/agentDetection.ts
@@ -72,6 +72,14 @@ function unwrapBashLoginWrapper(command: string): string | null {
   return unquoteShellString(rest)
 }
 
+export type AgentFamily = 'claude' | 'codex' | 'pi'
+
+/** Collapse agent variants onto the log family they write to (claude-rp -> claude). */
+export function agentFamily(agentType: AgentType | null | undefined): AgentFamily | null {
+  if (!agentType) return null
+  return agentType === 'claude-rp' ? 'claude' : agentType
+}
+
 export function normalizePaneStartCommand(command: string): string {
   const trimmed = command.trim()
   if (!trimmed) return ''

--- a/src/server/logMatcher.ts
+++ b/src/server/logMatcher.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import { performance } from 'node:perf_hooks'
 import { normalizeAgentLogEntry } from '../shared/eventTaxonomy'
 import type { AgentType, Session } from '../shared/types'
+import { agentFamily } from './agentDetection'
 import {
   extractProjectPath,
   inferAgentTypeFromPath,
@@ -1385,20 +1386,7 @@ export function readLogContent(
 ): string {
   try {
     const buffer = fs.readFileSync(logPath)
-    let content = buffer.toString('utf8')
-
-    if (byteLimit > 0 && content.length > byteLimit) {
-      content = content.slice(-byteLimit)
-    }
-
-    if (lineLimit > 0) {
-      const lines = content.split('\n')
-      if (lines.length > lineLimit) {
-        content = lines.slice(-lineLimit).join('\n')
-      }
-    }
-
-    return content
+    return applyReadLimits(buffer.toString('utf8'), { lineLimit, byteLimit })
   } catch {
     return ''
   }
@@ -1410,6 +1398,10 @@ export function extractLogText(
 ): string {
   const resolvedRead = resolveLogReadOptions(logRead)
   const raw = readLogContent(logPath, resolvedRead)
+  return extractTextFromRaw(raw, mode)
+}
+
+function extractTextFromRaw(raw: string, mode: LogTextMode): string {
   if (!raw || mode === 'all') {
     return raw
   }
@@ -1435,22 +1427,61 @@ export function extractLogText(
   return chunks.join('\n')
 }
 
+// Logs that yielded zero tokens, keyed by path -> byte length at that time.
+// Enrichment recounts every unknown log each poll, so without this a
+// message-free log would be fully re-parsed on every cycle.
+const zeroTokenLogCache = new Map<string, number>()
+
 export function getLogTokenCount(
   logPath: string,
   { mode = DEFAULT_LOG_TEXT_MODE, logRead }: LogTextOptionsInput = {}
 ): number {
-  const content = extractLogText(logPath, { mode, logRead })
-  const count = countTokens(content)
+  const resolvedRead = resolveLogReadOptions(logRead)
+  let fileSize: number | null = null
+  try {
+    fileSize = fs.statSync(logPath).size
+  } catch {
+    return 0
+  }
+  if (zeroTokenLogCache.get(logPath) === fileSize) {
+    return 0
+  }
+
+  // readLogContent reads the whole file regardless of limits, so read once
+  // and apply the tail limits to the in-memory copy.
+  const raw = readLogContent(logPath, { lineLimit: 0, byteLimit: 0 })
+  const tail = applyReadLimits(raw, resolvedRead)
+  const count = countTokens(extractTextFromRaw(tail, mode))
   if (count > 0 || mode === 'all') return count
-  // The byte-limited tail read can start mid-way through a single huge line
+  // The byte-limited tail can start mid-way through a single huge line
   // (e.g. a 150KB pasted message), leaving only unparseable fragments and
   // tool/echo events in the window. Callers only gate on "any message text
   // at all", so confirm with a head-first scan before reporting empty.
-  return findFirstMessageTokenCount(logPath, mode)
+  const fromHead = findFirstMessageTokenCount(raw, mode)
+  if (fromHead === 0) {
+    zeroTokenLogCache.set(logPath, fileSize)
+  }
+  return fromHead
 }
 
-function findFirstMessageTokenCount(logPath: string, mode: LogTextMode): number {
-  const raw = readLogContent(logPath, { lineLimit: 0, byteLimit: 0 })
+function applyReadLimits(
+  content: string,
+  { lineLimit, byteLimit }: LogReadOptions
+): string {
+  let result = content
+  if (byteLimit > 0 && result.length > byteLimit) {
+    result = result.slice(-byteLimit)
+  }
+  if (lineLimit > 0) {
+    const lines = result.split('\n')
+    if (lines.length > lineLimit) {
+      result = lines.slice(-lineLimit).join('\n')
+    }
+  }
+  return result
+}
+
+function findFirstMessageTokenCount(raw: string, mode: LogTextMode): number {
   if (!raw) return 0
   let start = 0
   while (start < raw.length) {
@@ -1663,9 +1694,8 @@ export function filterCandidatesByAgentType(
   candidates: string[],
   agentType: AgentType | undefined
 ): string[] {
-  if (!agentType) return candidates
-  // claude-rp logs live under the same root as claude logs
-  const windowFamily = agentType === 'claude-rp' ? 'claude' : agentType
+  const windowFamily = agentFamily(agentType)
+  if (!windowFamily) return candidates
   return candidates.filter((candidate) => {
     const logType = inferAgentTypeFromPath(candidate)
     return logType === null || logType === windowFamily

--- a/src/server/logMatcher.ts
+++ b/src/server/logMatcher.ts
@@ -1440,7 +1440,34 @@ export function getLogTokenCount(
   { mode = DEFAULT_LOG_TEXT_MODE, logRead }: LogTextOptionsInput = {}
 ): number {
   const content = extractLogText(logPath, { mode, logRead })
-  return countTokens(content)
+  const count = countTokens(content)
+  if (count > 0 || mode === 'all') return count
+  // The byte-limited tail read can start mid-way through a single huge line
+  // (e.g. a 150KB pasted message), leaving only unparseable fragments and
+  // tool/echo events in the window. Callers only gate on "any message text
+  // at all", so confirm with a head-first scan before reporting empty.
+  return findFirstMessageTokenCount(logPath, mode)
+}
+
+function findFirstMessageTokenCount(logPath: string, mode: LogTextMode): number {
+  const raw = readLogContent(logPath, { lineLimit: 0, byteLimit: 0 })
+  if (!raw) return 0
+  let start = 0
+  while (start < raw.length) {
+    const end = raw.indexOf('\n', start)
+    const line = (end === -1 ? raw.slice(start) : raw.slice(start, end)).trim()
+    start = end === -1 ? raw.length : end + 1
+    if (!line) continue
+    let entry: unknown
+    try {
+      entry = JSON.parse(line)
+    } catch {
+      continue
+    }
+    const tokens = countTokens(extractTextFromEntry(entry, mode).join('\n'))
+    if (tokens > 0) return tokens
+  }
+  return 0
 }
 function countTokens(text: string): number {
   const normalized = normalizeText(text)
@@ -1624,6 +1651,27 @@ export interface ExactMatchContext {
   projectPath?: string
 }
 
+/**
+ * Hard agent-type gate. When the window's agent type is known, a log of a
+ * different type can never be the right match — even if it is the only log
+ * containing the pane's text (e.g. the same prompt pasted into a claude and a
+ * codex window seconds apart, where one log flushes first). Returning an empty
+ * list defers the match until the right-typed log appears. Fails open when the
+ * window type or a log's type is unknown.
+ */
+export function filterCandidatesByAgentType(
+  candidates: string[],
+  agentType: AgentType | undefined
+): string[] {
+  if (!agentType) return candidates
+  // claude-rp logs live under the same root as claude logs
+  const windowFamily = agentType === 'claude-rp' ? 'claude' : agentType
+  return candidates.filter((candidate) => {
+    const logType = inferAgentTypeFromPath(candidate)
+    return logType === null || logType === windowFamily
+  })
+}
+
 export interface ExactMatchResult {
   logPath: string
   userMessage: string
@@ -1727,13 +1775,9 @@ export function tryExactMatchWindowToLog(
     candidates = filtered
   }
 
-  if (context.agentType) {
-    const filtered = candidates.filter(
-      (candidate) => inferAgentTypeFromPath(candidate) === context.agentType
-    )
-    if (filtered.length > 0) {
-      candidates = filtered
-    }
+  candidates = filterCandidatesByAgentType(candidates, context.agentType)
+  if (candidates.length === 0) {
+    return null
   }
 
   if (context.projectPath) {
@@ -1932,13 +1976,9 @@ export async function tryExactMatchWindowToLogAsync(
     candidates = filtered
   }
 
-  if (context.agentType) {
-    const filtered = candidates.filter(
-      (candidate) => inferAgentTypeFromPath(candidate) === context.agentType
-    )
-    if (filtered.length > 0) {
-      candidates = filtered
-    }
+  candidates = filterCandidatesByAgentType(candidates, context.agentType)
+  if (candidates.length === 0) {
+    return null
   }
 
   if (context.projectPath) {

--- a/src/server/logPoller.ts
+++ b/src/server/logPoller.ts
@@ -2,13 +2,14 @@ import { logger } from './logger'
 import { config } from './config'
 import type { SessionDatabase } from './db'
 import { getLogSearchDirs, normalizeProjectPath } from './logDiscovery'
+import { agentFamily } from './agentDetection'
 import { DEFAULT_SCROLLBACK_LINES, extractLastEntryTimestamp, isSameOrChildPath, isToolNotificationText } from './logMatcher'
 import { deriveDisplayName } from './agentSessions'
 import { generateUniqueSessionName } from './nameGenerator'
 import type { SessionRegistry } from './SessionRegistry'
 import { LogMatchWorkerClient } from './logMatchWorkerClient'
 import { LogWatcher } from './logWatcher'
-import type { Session } from '../shared/types'
+import type { AgentType, Session } from '../shared/types'
 import type { KnownSession, LogEntrySnapshot } from './logPollData'
 import {
   getEntriesNeedingMatch,
@@ -721,7 +722,7 @@ export class LogPoller {
     // Only unclaimed managed windows can trigger deferral — external windows and
     // windows already matched to a session are excluded to prevent unrelated blank
     // windows from suppressing legitimate session insertions.
-    const deferralCandidates: Array<{ projectPath: string; agentType: string | null }> = []
+    const deferralCandidates: Array<{ projectPath: string; agentType: AgentType | null }> = []
     for (const nmw of response.noMessageWindows ?? []) {
       if (!nmw.projectPath) continue
       if (nmw.source !== 'managed') continue
@@ -962,7 +963,7 @@ export class LogPoller {
             const hasBoot = deferralCandidates.some(
               (c) =>
                 isSameOrChildPath(normalizedProject, c.projectPath) &&
-                (!c.agentType || !agentType || c.agentType === agentType)
+                (!c.agentType || !agentType || agentFamily(c.agentType) === agentFamily(agentType))
             )
             if (hasBoot) {
               logger.info('log_match_deferred', {


### PR DESCRIPTION
## Summary

Fixes a window↔log mis-attribution where the same prompt pasted into a claude window and a codex window seconds apart caused the two sessions' DB window claims to swap permanently (blue-flood showed the claude conversation; the claude window got the codex session).

**Mechanism** (reconstructed from `agentboard.log` + byte-accurate log replays):
1. Claude's TUI collapses large pastes to `[Pasted text #1 +N lines]`, so the claude pane's text exists in *no* log file, while codex renders the paste raw. The codex pane rg-matched the claude log — the only one flushed yet — and the agent-type filter in `tryExactMatchWindowToLog` was a soft preference, so a known-codex window was allowed to claim a claude log.
2. `getLogTokenCount` reads a 200 KB tail. A 158 KB pasted message line got sliced mid-JSON, parsing to 0 tokens for ~2 minutes and keeping the codex log out of the candidate set; by the time it qualified, its true window was already claimed and it matched the *other* unclaimed window.
3. Rematch only runs for orphaned sessions, so the wrong claims never healed.

## Changes

- **`filterCandidatesByAgentType`** (both sync and async matchers): when the window's agent type is known, candidate logs of a different type are refused and the match defers until the right-typed log appears. Fails open when the window type or log root is unknown; `claude-rp` is treated as the claude family.
- **`getLogTokenCount`**: keep the fast tail path, but if it yields 0 confirm with a head-first early-exit scan before reporting the log as empty. All callers gate on `>= 1`, so this only changes the decapitated-jumbo-line case.
- Tests for the mixed-type paste race (refuse / fail-open / pick codex once available) and the >150 KB single-line case.

A "re-verify claimed windows" fix was considered and rejected: redundant once the gate exists, and without the gate it flaps (unclaim → same wrong re-claim every `REMATCH_COOLDOWN_MS`).

## Test plan

- [x] `bun run lint && bun run typecheck && bun run test`
- [x] Replayed the incident's rollout file truncated to its state at the two `too_few_tokens` skips: 0 tokens before, 18,055 after
- [x] Gate verified against the incident's real log paths (codex window + claude-only candidates → refused)