### PR TITLE
fix: allow unicode characters in session names

### DIFF
--- a/src/server/SessionManager.ts
+++ b/src/server/SessionManager.ts
@@ -659,8 +659,9 @@ export class SessionManager {
       throw new Error('Name cannot be empty')
     }
 
-    // Validate: alphanumeric, hyphens, underscores only
-    if (!/^[\w-]+$/.test(trimmed)) {
+    // Validate: word characters, hyphens, and non-ASCII unicode (U+00A0+).
+    // ASCII special characters and C0/C1 control characters are rejected.
+    if (!/^[\w\u{00A0}-\u{10FFFF}-]+$/u.test(trimmed)) {
       throw new Error(
         'Name can only contain letters, numbers, hyphens, and underscores'
       )

--- a/src/server/__tests__/sessionManager.test.ts
+++ b/src/server/__tests__/sessionManager.test.ts
@@ -1080,6 +1080,46 @@ describe('SessionManager', () => {
     expect(renameCalls).toHaveLength(0)
   })
 
+  test('renameWindow accepts unicode characters', () => {
+    const sessionName = 'agentboard-unicode-name'
+    const runner = createTmuxRunner(
+      [
+        {
+          name: sessionName,
+          windows: [
+            {
+              id: '1',
+              index: 1,
+              name: 'alpha',
+              path: '/tmp/alpha',
+              activity: 0,
+              command: '',
+            },
+          ],
+        },
+      ],
+      1
+    )
+
+    const manager = new SessionManager(sessionName, {
+      runTmux: runner.runTmux,
+      capturePaneContent: () => makePaneCapture(''),
+      now: () => 1700000000000,
+    })
+
+    const validNames = [
+      '测试会话',
+      'my-测试_01',
+      '🚀deploy',
+    ]
+    for (const name of validNames) {
+      runner.calls.length = 0
+      manager.renameWindow(`${sessionName}:1`, name)
+      const renameCall = runner.calls.find((call) => call[0] === 'rename-window')
+      expect(renameCall?.[3]).toBe(name)
+    }
+  })
+
   test('renameWindow rejects the reserved bootstrap window name', () => {
     const sessionName = 'agentboard-reserved-rename'
     const runner = createTmuxRunner(

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2530,7 +2530,7 @@ async function handleRemoteCreate(
 
   // Validate name format if provided (same rules as rename)
   const windowName = name?.trim() || generateSessionName()
-  if (name?.trim() && !/^[\w-]+$/.test(windowName)) {
+  if (name?.trim() && !/^[\w\u{00A0}-\u{10FFFF}-]+$/u.test(windowName)) {
     send(ws, { type: 'error', message: 'Name can only contain letters, numbers, hyphens, and underscores' })
     return
   }
@@ -2961,7 +2961,7 @@ async function handleRename(
           send(ws, { type: 'error', message: 'Name cannot be empty' })
           return
         }
-        if (!/^[\w-]+$/.test(trimmed)) {
+        if (!/^[\w\u{00A0}-\u{10FFFF}-]+$/u.test(trimmed)) {
           send(ws, {
             type: 'error',
             message: 'Name can only contain letters, numbers, hyphens, and underscores',
@@ -2998,7 +2998,7 @@ async function handleRename(
       send(ws, { type: 'error', message: 'Name cannot be empty' })
       return
     }
-    if (!/^[\w-]+$/.test(trimmed)) {
+    if (!/^[\w\u{00A0}-\u{10FFFF}-]+$/u.test(trimmed)) {
       send(ws, { type: 'error', message: 'Name can only contain letters, numbers, hyphens, and underscores' })
       return
     }


### PR DESCRIPTION
## What

The name validation regex `[\w-]` was introduced when session names were exclusively auto-generated slugs (`calm-hollow`, `sure-root` via `nameGenerator.ts`). After `prefer-window-name` landed (#133, #167), users interact with tmux window names directly — but the validation still rejects anything outside ASCII `[a-zA-Z0-9_-]`, including CJK characters, emoji, and accented letters.

This extends the regex to `/^[\w\u{00A0}-\u{10FFFF}-]+$/u`, accepting all printable unicode while preserving the original ASCII restriction. `createWindow` already converts spaces to hyphens (`replace(/\s+/g, '-')`), and the slug convention stays consistent — users can now type CJK names directly via `Ctrl+B ,`.

### Scope

- **Changed:** regex in `SessionManager.renameWindow` + 3 validation sites in `index.ts`
- **Preserved:** ASCII restriction (`[\w-]`), error message, `createWindow` space-to-hyphen behavior
- **Blocked automatically:** C0 controls (U+0000–U+001F), DEL (U+007F), C1 controls (U+0080–U+009F) — the C1 range includes U+009B (CSI, equivalent to `ESC[`) which can inject terminal escape sequences via xterm.js. The whitelist starting at U+00A0 excludes all of these without needing an explicit blocklist.

### Not included (open for discussion)

ASCII spaces — tmux `rename-window` handles them fine and the slug restriction predates `prefer-window-name`, but `createWindow` actively converts them to hyphens and all generated names use the slug convention. Happy to relax if you'd prefer.

## Verification

Container tests (Debian trixie, non-root, `bun run test`) — full suite 0 fail. Additionally verified `tmux rename-window` with CJK, emoji, mixed, and special characters across tmux versions:

| tmux | test suite | rename-window unicode |
|---|---|---|
| 2.6 (Ubuntu 18.04) | 1010 pass, 0 fail | 6/6 |
| 3.1c (Debian Bullseye) | 1010 pass, 0 fail | 6/6 |
| 3.2a (Ubuntu 22.04) | 1010 pass, 0 fail | 6/6 |
| 3.4 (Ubuntu 24.04) | 1010 pass, 0 fail | 6/6 |
| 3.5a (Debian Trixie) | all pass, 0 fail | 6/6 |
| 3.7c (Arch Linux) | 1010 pass, 0 fail | 6/6 |

C1 control characters (U+0080–U+009F) were fuzz-tested against tmux 3.2a — tmux accepts and stores them verbatim without escaping, confirming they must be blocked at the application layer.