### PR TITLE
fix(systemd): stop service restart from killing the tmux server

### DIFF
--- a/systemd/install.sh
+++ b/systemd/install.sh
@@ -24,6 +24,7 @@ After=network.target
 
 [Service]
 Type=simple
+KillMode=process
 WorkingDirectory=$REPO_DIR
 ExecStart=$BUN_PATH run start
 Restart=on-failure


### PR DESCRIPTION
## What

When agentboard starts and no tmux server is running, `tmux new-session` forks a new server inside the service's cgroup. On `systemctl restart`, the default `KillMode=control-group` sends SIGKILL to every process in the cgroup — including the tmux server — destroying all user sessions.

Adding `KillMode=process` limits the kill to the main bun process, leaving the tmux server (and user sessions) intact across restarts.

### Evidence

Journal logs from a production deployment show repeated `agentboard.service: Killing process (tmux: server) with signal SIGKILL` entries on every service restart, each time destroying all active tmux sessions.

## Verification

Single-line change to the generated service template in `systemd/install.sh`. No code or test changes.