### PR TITLE
fix: parse jumbo last-message lines (backward reader, last-prompt fallback, lossy-capture lock release)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/server/__tests__/logMatcher.test.ts
+++ b/src/server/__tests__/logMatcher.test.ts
@@ -1928,6 +1928,27 @@ describe('iterateLogLinesBackward', () => {
     expect(seen).toEqual(['tail'])
   })
 
+  test('enforces maxLineBytes on a line contained entirely within one chunk', async () => {
+    const logPath = path.join(tmpDir, 'in-chunk-oversized.jsonl')
+    await fs.writeFile(logPath, ['early', 'h'.repeat(4 * 1024), 'tail'].join('\n'))
+
+    const seen = [
+      ...iterateLogLinesBackward(logPath, { chunkBytes: 16 * 1024, maxLineBytes: 1024 }),
+    ]
+    expect(seen).toEqual(['tail'])
+  })
+
+  test('handles CRLF line endings', async () => {
+    const logPath = path.join(tmpDir, 'crlf.jsonl')
+    await fs.writeFile(logPath, 'first\r\nsecond\r\nthird\r\n')
+
+    expect([...iterateLogLinesBackward(logPath, { chunkBytes: 4 })]).toEqual([
+      'third',
+      'second',
+      'first',
+    ])
+  })
+
   test('handles a file with no trailing newline and a single line', async () => {
     const logPath = path.join(tmpDir, 'single.jsonl')
     await fs.writeFile(logPath, 'only-line')
@@ -2068,5 +2089,16 @@ describe('stripPastePlaceholders', () => {
   test('leaves unrelated bracketed text alone', () => {
     const input = 'see [Image #1] and [link](https://example.com)'
     expect(stripPastePlaceholders(input)).toBe(input)
+  })
+
+  test('leaves bracketed prose starting with "pasted" alone when no counter token follows', () => {
+    const inputs = [
+      'Compare [pasted from docs] with the generated output.',
+      'The UI displays [pasted content unavailable] here.',
+      'Preserve the literal token [PastedExample].',
+    ]
+    for (const input of inputs) {
+      expect(stripPastePlaceholders(input)).toBe(input)
+    }
   })
 })

--- a/src/server/__tests__/logMatcher.test.ts
+++ b/src/server/__tests__/logMatcher.test.ts
@@ -22,6 +22,8 @@ import {
   isToolNotificationText,
   extractLastEntryTimestamp,
   captureTerminalScrollback,
+  iterateLogLinesBackward,
+  stripPastePlaceholders,
 } from '../logMatcher'
 
 const bunAny = Bun as typeof Bun & {
@@ -1867,5 +1869,204 @@ describe('extractLastEntryTimestamp', () => {
       JSON.stringify({ timestamp: '2025-01-01T00:00:00Z', type: 'message' }) + '\n'
     )
     expect(extractLastEntryTimestamp(logPath)).toBe('2025-01-01T00:00:00Z')
+  })
+})
+
+describe('iterateLogLinesBackward', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-backward-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('yields complete lines newest-first across chunk boundaries', async () => {
+    const logPath = path.join(tmpDir, 'lines.jsonl')
+    const lines = ['first', 'second 你好🚀 multibyte', 'x'.repeat(300), 'last']
+    await fs.writeFile(logPath, lines.join('\n') + '\n')
+
+    const seen = [...iterateLogLinesBackward(logPath, { chunkBytes: 7 })]
+    expect(seen).toEqual([...lines].reverse())
+  })
+
+  test('completes a jumbo line that straddles the scan budget', async () => {
+    const logPath = path.join(tmpDir, 'jumbo.jsonl')
+    const jumbo = 'j'.repeat(50 * 1024)
+    await fs.writeFile(logPath, ['early', jumbo, 'tail'].join('\n'))
+
+    const seen = [
+      ...iterateLogLinesBackward(logPath, { chunkBytes: 1024, maxScanBytes: 4 * 1024 }),
+    ]
+    // 'tail' fits the budget; the jumbo line straddles it and is still
+    // completed; 'early' lies past the budget and is not scanned.
+    expect(seen).toEqual(['tail', jumbo])
+  })
+
+  test('stops at a clean line boundary once the budget is spent', async () => {
+    const logPath = path.join(tmpDir, 'budget.jsonl')
+    const lines = Array.from({ length: 64 }, (_, i) => `line-${i}-${'p'.repeat(100)}`)
+    await fs.writeFile(logPath, lines.join('\n') + '\n')
+
+    const seen = [
+      ...iterateLogLinesBackward(logPath, { chunkBytes: 512, maxScanBytes: 1024 }),
+    ]
+    expect(seen.length).toBeGreaterThan(0)
+    expect(seen.length).toBeLessThan(lines.length)
+    expect(seen[0]).toBe(lines[lines.length - 1] ?? '')
+  })
+
+  test('aborts on a line larger than maxLineBytes', async () => {
+    const logPath = path.join(tmpDir, 'oversized.jsonl')
+    await fs.writeFile(logPath, ['early', 'g'.repeat(8 * 1024), 'tail'].join('\n'))
+
+    const seen = [
+      ...iterateLogLinesBackward(logPath, { chunkBytes: 1024, maxLineBytes: 2 * 1024 }),
+    ]
+    expect(seen).toEqual(['tail'])
+  })
+
+  test('handles a file with no trailing newline and a single line', async () => {
+    const logPath = path.join(tmpDir, 'single.jsonl')
+    await fs.writeFile(logPath, 'only-line')
+    expect([...iterateLogLinesBackward(logPath)]).toEqual(['only-line'])
+  })
+})
+
+describe('jumbo last-message extraction', () => {
+  let tmpDir: string
+  const workerReadOptions = {
+    lineLimit: 0,
+    byteLimit: 32 * 1024,
+    maxByteLimit: 2 * 1024 * 1024,
+  }
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-jumbo-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  test('recovers a Claude user message far larger than the initial tail read', async () => {
+    // Shape of the fresh-silo incident: meta lines, one 121KB+ user line,
+    // then attachments and a last-prompt entry.
+    const logPath = path.join(tmpDir, 'claude.jsonl')
+    const jumboText = 'grill me on this concept: ' + 'detail '.repeat(20_000)
+    await fs.writeFile(
+      logPath,
+      [
+        JSON.stringify({ type: 'mode', mode: 'default' }),
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: jumboText },
+        }),
+        JSON.stringify({ type: 'attachment', attachment: { pad: 'a'.repeat(30_000) } }),
+        JSON.stringify({
+          type: 'last-prompt',
+          lastPrompt: jumboText.slice(0, 200) + '…',
+        }),
+      ].join('\n') + '\n'
+    )
+
+    // Full untruncated text wins over the last-prompt mirror.
+    expect(extractLastUserMessageFromLog(logPath, workerReadOptions)).toBe(
+      jumboText.trim()
+    )
+  })
+
+  test('recovers a jumbo Codex response_item user message', async () => {
+    const logPath = path.join(tmpDir, 'codex.jsonl')
+    const jumboText = 'review this dump: ' + 'lorem '.repeat(60_000)
+    await fs.writeFile(
+      logPath,
+      [
+        JSON.stringify({ type: 'session_meta', payload: { id: 'x' } }),
+        JSON.stringify({
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: jumboText }],
+          },
+        }),
+        JSON.stringify({ type: 'event_msg', payload: { type: 'task_started' } }),
+      ].join('\n') + '\n'
+    )
+
+    expect(extractLastUserMessageFromLog(logPath, workerReadOptions)).toBe(
+      jumboText.trim()
+    )
+  })
+
+  test('falls back to the last-prompt mirror when the user entry is past the scan budget', async () => {
+    const logPath = path.join(tmpDir, 'fallback.jsonl')
+    const truncated = 'huge prompt preview…'
+    await fs.writeFile(
+      logPath,
+      [
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: 'huge prompt ' + 'x'.repeat(1000) },
+        }),
+        // Enough post-user filler to exhaust a small scan budget at a line boundary.
+        ...Array.from({ length: 40 }, (_, i) =>
+          JSON.stringify({ type: 'attachment', attachment: { i, pad: 'f'.repeat(400) } })
+        ),
+        JSON.stringify({ type: 'last-prompt', lastPrompt: truncated }),
+      ].join('\n') + '\n'
+    )
+
+    expect(
+      extractLastUserMessageFromLog(logPath, {
+        lineLimit: 0,
+        byteLimit: 1024,
+        maxByteLimit: 8 * 1024,
+      })
+    ).toBe(truncated)
+  })
+
+  test('prefers the real user entry over a last-prompt mirror', async () => {
+    const logPath = path.join(tmpDir, 'prefer-real.jsonl')
+    await fs.writeFile(
+      logPath,
+      [
+        JSON.stringify({ type: 'last-prompt', lastPrompt: 'older mirror' }),
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: 'the real latest message' },
+        }),
+      ].join('\n') + '\n'
+    )
+
+    expect(extractLastUserMessageFromLog(logPath, workerReadOptions)).toBe(
+      'the real latest message'
+    )
+  })
+})
+
+describe('stripPastePlaceholders', () => {
+  test('returns the same string when no placeholder is present', () => {
+    const input = 'fix the login bug'
+    expect(stripPastePlaceholders(input)).toBe(input)
+  })
+
+  test('strips a Claude paste placeholder and collapses whitespace', () => {
+    expect(
+      stripPastePlaceholders('check this out [Pasted text #1 +263 lines] please')
+    ).toBe('check this out please')
+  })
+
+  test('strips bracketed pasted variants case-insensitively', () => {
+    expect(stripPastePlaceholders('[ pasted 4123 characters ]')).toBe('')
+    expect(stripPastePlaceholders('[Pasted text #2 +9 lines]')).toBe('')
+  })
+
+  test('leaves unrelated bracketed text alone', () => {
+    const input = 'see [Image #1] and [link](https://example.com)'
+    expect(stripPastePlaceholders(input)).toBe(input)
   })
 })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -21,6 +21,7 @@ import { getLogSearchDirs } from './logDiscovery'
 import {
   DEFAULT_SCROLLBACK_LINES,
   matchWindowsToLogsByExactRg,
+  stripPastePlaceholders,
   verifyWindowLogAssociationDetailed,
   verifyWindowLogAssociationDetailedAsync,
   type WindowLogVerificationResult,
@@ -1276,8 +1277,16 @@ function scheduleLastUserMessageCapture(sessionId: string) {
 
 async function captureLastUserMessage(tmuxWindow: string) {
   try {
-    const message = await lastUserMessageWorker.getLastUserMessage(tmuxWindow)
-    if (!message || !message.trim()) return
+    const captured = await lastUserMessageWorker.getLastUserMessage(tmuxWindow)
+    const message = captured?.trim() ? stripPastePlaceholders(captured) : ''
+    if (!message || message !== captured) {
+      // Empty capture, or a paste the TUI collapsed to a "[Pasted text …]"
+      // placeholder: the JSONL log has the real prompt, so release the
+      // Enter-key lock and let the log poller supply/upgrade the summary
+      // instead of blocking it for the full lock window.
+      lastUserMessageLocks.delete(tmuxWindow)
+    }
+    if (!message) return
     const record = db.getSessionByWindow(tmuxWindow)
     if (!record) return
     if (record.lastUserMessage === message) return
@@ -1286,6 +1295,7 @@ async function captureLastUserMessage(tmuxWindow: string) {
     registry.updateSession(tmuxWindow, { lastUserMessage: message })
     updateActiveAgentSessions()
   } catch (error) {
+    lastUserMessageLocks.delete(tmuxWindow)
     logger.warn('last_user_message_capture_error', {
       tmuxWindow,
       message: error instanceof Error ? error.message : String(error),

--- a/src/server/logMatchWorker.ts
+++ b/src/server/logMatchWorker.ts
@@ -31,8 +31,11 @@ import type {
   OrphanCandidate,
 } from './logMatchWorkerTypes'
 
+// lineLimit 0: the backward scan is bounded by maxByteLimit alone — a long
+// autonomous run can put thousands of tool-result lines after the last user
+// message, and a line cap would stop the scan before reaching it.
 const LAST_USER_MESSAGE_READ_OPTIONS = {
-  lineLimit: 200,
+  lineLimit: 0,
   byteLimit: 32 * 1024,
   maxByteLimit: 2 * 1024 * 1024,
 }

--- a/src/server/logMatcher.ts
+++ b/src/server/logMatcher.ts
@@ -371,6 +371,20 @@ export function isToolNotificationText(text: string): boolean {
 }
 
 /**
+ * Agent TUIs collapse a large paste into a bracketed placeholder — Claude
+ * Code renders "[Pasted text #1 +263 lines]" — so a terminal capture of such
+ * a prompt is lossy: only the JSONL log has the real content. Strips every
+ * placeholder and collapses the surrounding whitespace. Returns the input
+ * string unchanged (same reference) when no placeholder is present, so
+ * callers can detect placeholders via `stripPastePlaceholders(t) !== t`.
+ */
+export function stripPastePlaceholders(text: string): string {
+  const stripped = text.replace(/\[\s*pasted[^\]]*\]/gi, ' ')
+  if (stripped === text) return text
+  return stripped.replace(/\s+/g, ' ').trim()
+}
+
+/**
  * Extract the action name from a <user_action> XML block.
  * Returns the action (e.g., "review") or null if not a user_action block.
  */
@@ -436,6 +450,103 @@ function readLogTail(logPath: string, byteLimit = DEFAULT_LOG_TAIL_BYTES): strin
 }
 
 const MAX_PROGRESSIVE_TAIL_BYTES = 2 * 1024 * 1024
+
+const BACKWARD_READ_CHUNK_BYTES = 64 * 1024
+// Safety valve for pathological files (e.g. a multi-GB line with no newlines).
+// A single log entry larger than this aborts the backward scan.
+const MAX_BACKWARD_LINE_BYTES = 16 * 1024 * 1024
+
+/**
+ * Iterate the complete lines of a file from the end toward the start (newest
+ * first). Reads fixed-size chunks backward from EOF and only assembles whole
+ * lines, so a jumbo line (a user message with a large paste can exceed 1MB as
+ * a single JSONL line) costs one pass over that line instead of repeated
+ * expanding tail reads that keep decapitating it at the tail boundary.
+ *
+ * `maxScanBytes` bounds how far back the scan goes, checked at line
+ * boundaries: a line that straddles the budget is still completed and
+ * yielded, so the budget caps scan depth without capping line size.
+ * Splitting on \n is UTF-8 safe (0x0A never appears inside a multi-byte
+ * sequence), so buffers are only decoded once a line is complete.
+ */
+export function* iterateLogLinesBackward(
+  logPath: string,
+  {
+    maxScanBytes = Number.POSITIVE_INFINITY,
+    chunkBytes = BACKWARD_READ_CHUNK_BYTES,
+    maxLineBytes = MAX_BACKWARD_LINE_BYTES,
+  }: { maxScanBytes?: number; chunkBytes?: number; maxLineBytes?: number } = {}
+): Generator<string> {
+  if (maxScanBytes <= 0) return
+  let fd: number
+  let size: number
+  try {
+    fd = fs.openSync(logPath, 'r')
+  } catch {
+    return
+  }
+  try {
+    try {
+      size = fs.fstatSync(fd).size
+    } catch {
+      return
+    }
+    if (size <= 0) return
+
+    let position = size
+    // Partial line at the front of the region read so far; its earlier bytes
+    // live in chunks we have not read yet.
+    let carry = Buffer.alloc(0)
+    let scanned = 0
+    let budgetExhausted = false
+
+    while (position > 0) {
+      // While budget remains, never read past it in one chunk — lines inside
+      // a chunk are emitted unconditionally, so an oversized read would leak
+      // lines from beyond the budget. Once exhausted (mid-line), full chunks
+      // are fine: emission stops at the first completed line.
+      const remaining = budgetExhausted
+        ? chunkBytes
+        : Math.max(1, Math.min(chunkBytes, maxScanBytes - scanned))
+      const readLength = Math.min(remaining, position)
+      const start = position - readLength
+      const chunk = Buffer.alloc(readLength)
+      fs.readSync(fd, chunk, 0, readLength, start)
+      position = start
+      scanned += readLength
+      const combined = carry.length > 0 ? Buffer.concat([chunk, carry]) : chunk
+
+      // Walk newlines from the end; each segment after a newline is complete.
+      let end = combined.length
+      for (let i = combined.length - 1; i >= 0; i--) {
+        if (combined[i] !== 0x0a) continue
+        const line = combined.toString('utf8', i + 1, end).trim()
+        end = i
+        if (line) {
+          yield line
+          // Once past the budget we only finish the straddling line.
+          if (budgetExhausted) return
+        }
+      }
+      carry = combined.subarray(0, end)
+
+      if (carry.length > maxLineBytes) return
+      if (scanned >= maxScanBytes) {
+        // At a line boundary the budget is a clean stop; mid-line, keep
+        // reading just far enough to complete the line in progress.
+        if (carry.length === 0) return
+        budgetExhausted = true
+      }
+    }
+
+    if (carry.length > 0) {
+      const line = carry.toString('utf8').trim()
+      if (line) yield line
+    }
+  } finally {
+    fs.closeSync(fd)
+  }
+}
 
 /**
  * Check if a log file contains a message in a valid user context, using progressive
@@ -1571,15 +1682,50 @@ function extractRoleTextFromEntry(
   return chunks
 }
 
-function extractLastConversationFromLines(lines: string[]): ConversationPair {
+/**
+ * Claude Code mirrors each submitted prompt into a tiny `last-prompt` entry
+ * (~200 chars, pre-truncated) written right after the full user entry. It is
+ * the cheap fallback when the real user entry cannot be recovered — larger
+ * than the line-size cap, or beyond the scan budget. Codex has no equivalent.
+ */
+function extractLastPromptText(entry: unknown): string | null {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null
+  const record = entry as Record<string, unknown>
+  if (record.type !== 'last-prompt') return null
+  if (typeof record.lastPrompt !== 'string') return null
+  return processUserMessageText(record.lastPrompt)
+}
+
+function extractLastConversationFromLog(
+  logPath: string,
+  logRead: Partial<LogReadOptions> = {}
+): ConversationPair {
+  const resolvedRead = resolveLogReadOptions(logRead)
+  const initialByteLimit = Math.max(0, resolvedRead.byteLimit)
+  if (initialByteLimit <= 0) {
+    return { user: '', assistant: '' }
+  }
+  const maxScanBytes = Math.max(
+    initialByteLimit,
+    typeof logRead.maxByteLimit === 'number' ? logRead.maxByteLimit : initialByteLimit
+  )
+  const lineLimit = resolvedRead.lineLimit
+
   let lastUser = ''
   let lastAssistant = ''
-  for (let i = lines.length - 1; i >= 0; i -= 1) {
+  let lastPromptFallback = ''
+  let linesScanned = 0
+
+  for (const line of iterateLogLinesBackward(logPath, { maxScanBytes })) {
+    if (lineLimit > 0 && ++linesScanned > lineLimit) break
     let entry: unknown
     try {
-      entry = JSON.parse(lines[i])
+      entry = JSON.parse(line)
     } catch {
       continue
+    }
+    if (!lastPromptFallback) {
+      lastPromptFallback = extractLastPromptText(entry) ?? ''
     }
     const roleText = extractRoleTextFromEntry(entry)
     for (const { role, text } of roleText) {
@@ -1590,54 +1736,13 @@ function extractLastConversationFromLines(lines: string[]): ConversationPair {
         lastUser = text.trim()
       }
     }
-    if (lastUser && lastAssistant) {
-      break
-    }
+    if (lastUser && lastAssistant) break
+  }
+
+  if (!lastUser && lastPromptFallback) {
+    lastUser = lastPromptFallback
   }
   return { user: lastUser, assistant: lastAssistant }
-}
-
-function extractLastConversationFromLog(
-  logPath: string,
-  logRead: Partial<LogReadOptions> = {}
-): ConversationPair {
-  const resolvedRead = resolveLogReadOptions(logRead)
-  const initialByteLimit = Math.max(0, resolvedRead.byteLimit)
-  const maxByteLimit = Math.max(
-    initialByteLimit,
-    typeof logRead.maxByteLimit === 'number' ? logRead.maxByteLimit : initialByteLimit
-  )
-  const useProgressive = maxByteLimit > initialByteLimit
-  const lineLimit = useProgressive ? 0 : resolvedRead.lineLimit
-
-  if (initialByteLimit <= 0) {
-    return { user: '', assistant: '' }
-  }
-
-  let byteLimit = initialByteLimit
-  let lastPair: ConversationPair = { user: '', assistant: '' }
-
-  while (byteLimit <= maxByteLimit) {
-    const raw = readLogTail(logPath, byteLimit)
-    if (!raw) {
-      return { user: '', assistant: '' }
-    }
-    let lines = raw.split('\n').map((line) => line.trim()).filter(Boolean)
-    if (lineLimit > 0 && lines.length > lineLimit) {
-      lines = lines.slice(-lineLimit)
-    }
-    const pair = extractLastConversationFromLines(lines)
-    lastPair = pair
-    if (pair.user) {
-      return pair
-    }
-    if (byteLimit >= maxByteLimit) {
-      break
-    }
-    byteLimit = Math.min(byteLimit * 4, maxByteLimit)
-  }
-
-  return lastPair
 }
 
 export function extractLastUserMessageFromLog(

--- a/src/server/logMatcher.ts
+++ b/src/server/logMatcher.ts
@@ -374,12 +374,17 @@ export function isToolNotificationText(text: string): boolean {
  * Agent TUIs collapse a large paste into a bracketed placeholder — Claude
  * Code renders "[Pasted text #1 +263 lines]" — so a terminal capture of such
  * a prompt is lossy: only the JSONL log has the real content. Strips every
- * placeholder and collapses the surrounding whitespace. Returns the input
- * string unchanged (same reference) when no placeholder is present, so
- * callers can detect placeholders via `stripPastePlaceholders(t) !== t`.
+ * placeholder and collapses the surrounding whitespace. The pattern demands
+ * a counter token (#N, +N lines, or N chars/lines) so legitimate bracketed
+ * prose like "[pasted from docs]" is left alone. Returns the input string
+ * unchanged (same reference) when no placeholder is present, so callers can
+ * detect placeholders via `stripPastePlaceholders(t) !== t`.
  */
+const PASTE_PLACEHOLDER_PATTERN =
+  /\[\s*pasted(?:\s+text)?[^\]]*?(?:#\d+|\+\d+\s*lines?|\d+\s*(?:characters|chars?|lines?))[^\]]*\]/gi
+
 export function stripPastePlaceholders(text: string): string {
-  const stripped = text.replace(/\[\s*pasted[^\]]*\]/gi, ' ')
+  const stripped = text.replace(PASTE_PLACEHOLDER_PATTERN, ' ')
   if (stripped === text) return text
   return stripped.replace(/\s+/g, ' ').trim()
 }
@@ -465,9 +470,13 @@ const MAX_BACKWARD_LINE_BYTES = 16 * 1024 * 1024
  *
  * `maxScanBytes` bounds how far back the scan goes, checked at line
  * boundaries: a line that straddles the budget is still completed and
- * yielded, so the budget caps scan depth without capping line size.
- * Splitting on \n is UTF-8 safe (0x0A never appears inside a multi-byte
- * sequence), so buffers are only decoded once a line is complete.
+ * yielded, so the budget caps scan depth without capping line size — the
+ * true worst-case read is maxScanBytes + maxLineBytes. Splitting on \n is
+ * UTF-8 safe (0x0A never appears inside a multi-byte sequence), so buffers
+ * are only decoded once a line is complete. An in-progress line is kept as
+ * a list of chunk slices and concatenated once at its newline, so assembling
+ * a jumbo line is linear, not quadratic. The scan aborts (stops yielding) on
+ * any line over maxLineBytes and on a short read (file changed underneath).
  */
 export function* iterateLogLinesBackward(
   logPath: string,
@@ -494,11 +503,20 @@ export function* iterateLogLinesBackward(
     if (size <= 0) return
 
     let position = size
-    // Partial line at the front of the region read so far; its earlier bytes
-    // live in chunks we have not read yet.
-    let carry = Buffer.alloc(0)
+    // Pieces of the in-progress line (file order); its earlier bytes live in
+    // chunks not yet read. Concatenated only once, at the line's newline.
+    let carry: Buffer[] = []
+    let carrySize = 0
     let scanned = 0
     let budgetExhausted = false
+
+    const finishLine = (piece: Buffer): string | null => {
+      const buf = carry.length > 0 ? Buffer.concat([piece, ...carry]) : piece
+      carry = []
+      carrySize = 0
+      if (buf.length > maxLineBytes) return null
+      return buf.toString('utf8').trim()
+    }
 
     while (position > 0) {
       // While budget remains, never read past it in one chunk — lines inside
@@ -511,36 +529,50 @@ export function* iterateLogLinesBackward(
       const readLength = Math.min(remaining, position)
       const start = position - readLength
       const chunk = Buffer.alloc(readLength)
-      fs.readSync(fd, chunk, 0, readLength, start)
+      const bytesRead = fs.readSync(fd, chunk, 0, readLength, start)
+      if (bytesRead !== readLength) return
       position = start
       scanned += readLength
-      const combined = carry.length > 0 ? Buffer.concat([chunk, carry]) : chunk
 
-      // Walk newlines from the end; each segment after a newline is complete.
-      let end = combined.length
-      for (let i = combined.length - 1; i >= 0; i--) {
-        if (combined[i] !== 0x0a) continue
-        const line = combined.toString('utf8', i + 1, end).trim()
+      // Walk newlines from the end of the chunk; the segment after each
+      // newline is a complete line. The first (newest) one also absorbs the
+      // carry accumulated from later chunks.
+      let end = chunk.length
+      let carryConsumed = false
+      for (let i = chunk.length - 1; i >= 0; i--) {
+        if (chunk[i] !== 0x0a) continue
+        const piece = chunk.subarray(i + 1, end)
         end = i
+        let line: string | null
+        if (carryConsumed) {
+          line = piece.length > maxLineBytes ? null : piece.toString('utf8').trim()
+        } else {
+          line = finishLine(piece)
+          carryConsumed = true
+        }
+        if (line === null) return
         if (line) {
           yield line
           // Once past the budget we only finish the straddling line.
           if (budgetExhausted) return
         }
       }
-      carry = combined.subarray(0, end)
+      if (end > 0) {
+        carry.unshift(chunk.subarray(0, end))
+        carrySize += end
+      }
 
-      if (carry.length > maxLineBytes) return
+      if (carrySize > maxLineBytes) return
       if (scanned >= maxScanBytes) {
         // At a line boundary the budget is a clean stop; mid-line, keep
         // reading just far enough to complete the line in progress.
-        if (carry.length === 0) return
+        if (carrySize === 0) return
         budgetExhausted = true
       }
     }
 
-    if (carry.length > 0) {
-      const line = carry.toString('utf8').trim()
+    if (carrySize > 0) {
+      const line = finishLine(Buffer.alloc(0))
       if (line) yield line
     }
   } finally {


### PR DESCRIPTION
## Problem

A user message pasted as one huge JSONL line breaks the last-message summary. Incident: session `d1c4c361…bfb` (fresh-silo) had a 121KB single-line user entry; the summary stayed missing/stale and only appeared much later.

Two mechanisms:

1. **Tail decapitation** — `extractLastConversationFromLog` read fixed-size tails (32KB → 4× up to 2MB). Every tail cut the jumbo line at the read boundary, `JSON.parse` failed silently, and re-extraction was gated on file growth — so the correct summary only landed when an unrelated entry (e.g. `ai-title`) happened to be appended. Codex logs in the wild have single user lines up to **2MB**, right at the old hard cap, and anything larger could never parse.
2. **Enter-key lock held by a junk capture** — on Enter, the tmux-scrollback capture locks the window's summary for 60s. A large paste is collapsed by the TUI to `[Pasted text #N +M lines]`, so the capture is junk, yet it still blocked the log poller (which has the real prompt) for the full lock window.

## Changes

- **`iterateLogLinesBackward`**: reads chunks backward from EOF and decodes only complete lines (newline splitting is UTF-8-safe). The scan budget is enforced at line boundaries — a line straddling the budget is still completed — so the 2MB cap now bounds scan depth, not line size. The old expanding-tail loop and its per-call re-reads are gone; the incident file now extracts in ~3.5ms.
- **`last-prompt` fallback (Claude)**: Claude Code mirrors each prompt into a tiny pre-truncated `last-prompt` entry near the tail. Used as the user-message source when the real entry is beyond the scan budget or line cap (the UI clamps summaries to 250 chars anyway). Codex has no equivalent; it relies on the backward reader.
- **`stripPastePlaceholders` + lock release**: placeholders are stripped from the Enter-key capture; when the capture was empty, lossy, or errored, the 60s lock is released so the next poll upgrades the summary from the log.
- Worker read options: `lineLimit: 0` (scan bounded by bytes alone — a long autonomous run can put thousands of tool-result lines after the last user message).

## Verification

- New unit tests: backward iteration across chunk boundaries (incl. multi-byte UTF-8), budget straddling, `maxLineBytes` abort, jumbo Claude + Codex extraction, `last-prompt` fallback/preference, placeholder stripping.
- Ran against a snapshot of the real incident file: 118KB message extracted in 3.5ms (previously required a lucky re-poll after log growth).
- `bun run lint && bun run typecheck && bun run test` green.

## Notes / trade-offs

- Releasing the lock on a lossy capture reopens a small window where the poller could write the *previous* prompt if the agent hasn't flushed the new user entry yet; in practice both Claude and Codex write the user entry on submit, before the debounced capture fires.
- A last user message located *beyond* the 2MB scan budget (not merely straddling it) is still unreachable for Codex; for Claude the `last-prompt` fallback covers it.

https://claude.ai/code/session_01Js2qHUfHpdRStVPCqAfwS2