### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,10 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
-          node-version: '20'
+          # npm >= 11.5.1 (bundled with node 24) is required for OIDC trusted
+          # publishing; publishes authenticate via the job's id-token, no
+          # NPM_TOKEN secret involved.
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download all artifacts
@@ -80,8 +83,6 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Publish platform packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -e
           VERSION=${{ steps.version.outputs.version }}
@@ -102,9 +103,7 @@ jobs:
         run: node scripts/update-optional-deps.js ${{ steps.version.outputs.version }}
 
       - name: Publish main package
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
 
       - name: Collect binaries and tarballs for GitHub Release
         run: |


### PR DESCRIPTION
npm stopped honoring token-based publishes without an OTP on this account — three freshly-minted granular tokens (including one with 2FA bypass) all failed with EOTP on the v0.4.24 release. This is consistent with npm's phase-out of 2FA-bypass tokens in favor of trusted publishing.

Changes to the release job:
- node 20 → 24 (OIDC publish needs npm ≥ 11.5.1)
- drop both `NODE_AUTH_TOKEN` envs so npm authenticates via the job's `id-token: write` permission (already present)
- `--provenance` on the main-package publish, matching the platform packages

**Before this can work**: each of the 5 packages (`@gbasin/agentboard` + `-darwin-arm64`, `-darwin-x64`, `-linux-x64`, `-linux-arm64`) needs a Trusted Publisher entry on npmjs.com: package → Settings → Trusted Publisher → GitHub Actions → org `gbasin`, repo `agentboard`, workflow `release.yml`, environment blank.

After merging, re-point the `v0.4.24` tag at master to re-trigger the release with the fixed workflow (a plain failed-job rerun would use the old workflow from the tag's commit).

https://claude.ai/code/session_01Js2qHUfHpdRStVPCqAfwS2