### PR TITLE
feat(mobile): add Shift+Tab quick key to terminal controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/__tests__/terminalControls.test.tsx
+++ b/src/client/__tests__/terminalControls.test.tsx
@@ -66,7 +66,7 @@ describe('TerminalControls', () => {
     const keyButtons = renderer.root.findAllByType('button').filter((button) =>
       String(button.props.className ?? '').includes('terminal-key')
     )
-    expect(keyButtons).toHaveLength(9)
+    expect(keyButtons).toHaveLength(10)
     expect(keyButtons.every((button) =>
       String(button.props.className).includes('size-[44px]')
     )).toBe(true)
@@ -110,6 +110,51 @@ describe('TerminalControls', () => {
     })
 
     expect(sent[1]).toBe('a')
+  })
+
+  test('shift+tab quick key sends CSI Z and leaves ctrl armed', () => {
+    globalAny.navigator = { vibrate: () => true } as unknown as Navigator
+
+    const sent: string[] = []
+
+    const renderer = TestRenderer.create(
+      <TerminalControls
+        onSendKey={(key) => sent.push(key)}
+        sessions={[{ id: 'session-1', name: 'alpha', status: 'working' }]}
+        currentSessionId="session-1"
+        onSelectSession={() => {}}
+      />
+    )
+
+    const buttons = renderer.root.findAllByType('button')
+    const shiftTab = buttons.find((button) => button.props['aria-label'] === 'Shift+Tab')
+    const ctrlButton = buttons.find((button) => button.props.children === 'ctrl')
+    if (!shiftTab || !ctrlButton) {
+      throw new Error('Expected shift+tab and ctrl buttons')
+    }
+
+    // Plain press sends the reverse-tab escape sequence.
+    act(() => {
+      shiftTab.props.onClick()
+    })
+    expect(sent).toEqual(['\x1b[Z'])
+
+    // With ctrl armed the multi-byte sequence passes through unchanged and,
+    // like the arrow keys, does not consume the modifier: the next single
+    // character still gets ctrl applied.
+    act(() => {
+      ctrlButton.props.onClick()
+    })
+    act(() => {
+      shiftTab.props.onClick()
+    })
+    expect(sent[1]).toBe('\x1b[Z')
+
+    const numpad = renderer.root.findByType(NumPad)
+    act(() => {
+      numpad.props.onSendKey('a')
+    })
+    expect(sent[2]).toBe(String.fromCharCode(1))
   })
 
   test('session switcher selects sessions when multiple are present', () => {

--- a/src/client/components/TerminalControls.tsx
+++ b/src/client/components/TerminalControls.tsx
@@ -82,6 +82,8 @@ const KeyboardIcon = (
 const CONTROL_KEYS_LEFT: ControlKey[] = [
   { label: 'esc', key: '\x1b' },
   { label: 'tab', key: '\t' },
+  // Shift+Tab (CSI Z): toggles Claude Code's plan / auto-accept mode
+  { label: '⇧tab', key: '\x1b[Z', ariaLabel: 'Shift+Tab' },
 ]
 
 // Keys after the d-pad
@@ -511,6 +513,7 @@ export default function TerminalControls({
           <button
             key={`left-${i}`}
             type="button"
+            aria-label={control.ariaLabel}
             className={`
               terminal-key
               flex items-center justify-center

--- a/tests/e2e/mobile-controls.spec.ts
+++ b/tests/e2e/mobile-controls.spec.ts
@@ -1,0 +1,81 @@
+// E2E: the mobile key deck's ⇧tab key must deliver CSI Z (ESC [ Z) to the
+// attached tmux pane. Claude Code reads that sequence as Shift+Tab to cycle
+// plan / auto-accept mode, and a phone keyboard has no way to type it.
+//
+// Runs in a touch-enabled iPhone viewport so the key deck (hidden on desktop
+// unless the UA is iOS) is rendered and driven through real tap events. The
+// pane runs the paste-repl fixture, which echoes submitted input as hex.
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { test, expect } from '@playwright/test'
+
+test.use({
+  userAgent:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+  viewport: { width: 390, height: 844 },
+  deviceScaleFactor: 3,
+  isMobile: true,
+  hasTouch: true,
+})
+
+const WINDOW_NAME = 'shift-tab-repl'
+const REPL_PATH = fileURLToPath(new URL('./fixtures/paste-repl.py', import.meta.url))
+
+function tmux(args: string[]): { status: number | null; stdout: string } {
+  const result = spawnSync('tmux', args, { encoding: 'utf-8' })
+  return { status: result.status, stdout: result.stdout ?? '' }
+}
+
+async function waitForPaneText(target: string, needle: string, timeoutMs = 10000) {
+  const deadline = Date.now() + timeoutMs
+  let content = ''
+  while (Date.now() < deadline) {
+    content = tmux(['capture-pane', '-t', target, '-p']).stdout
+    if (content.includes(needle)) return content
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+  throw new Error(
+    `Timed out waiting for ${JSON.stringify(needle)} in pane ${target}. Last content:\n${content}`
+  )
+}
+
+test('⇧tab key sends CSI Z to the pane from a touch device', async ({ page }, testInfo) => {
+  const session = process.env.E2E_TMUX_SESSION
+  test.skip(!session, 'E2E_TMUX_SESSION not set')
+  const target = `${session}:${WINDOW_NAME}`
+
+  const created = tmux(['new-window', '-t', session!, '-n', WINDOW_NAME, `python3 ${REPL_PATH}`])
+  expect(created.status).toBe(0)
+
+  try {
+    await waitForPaneText(target, 'PASTE-REPL READY')
+
+    await page.goto('/')
+    // On mobile the session list lives in a drawer: the card is in the DOM
+    // but not visible, so select it with a DOM click.
+    const card = page.getByTestId('session-card').filter({ hasText: WINDOW_NAME }).first()
+    await card.waitFor({ state: 'attached', timeout: 20000 })
+    await card.evaluate((el) => (el as HTMLElement).click())
+    await expect(page.locator('.xterm')).toBeVisible()
+    await page.waitForTimeout(2000) // let the terminal attach settle
+
+    const shiftTab = page.getByRole('button', { name: 'Shift+Tab' })
+    await expect(shiftTab).toBeVisible()
+    const box = await shiftTab.boundingBox()
+    expect(box?.width).toBeGreaterThanOrEqual(44)
+    expect(box?.height).toBeGreaterThanOrEqual(44)
+    // Label must not overflow its 44px cell.
+    const overflows = await shiftTab.evaluate((el) => el.scrollWidth > el.clientWidth)
+    expect(overflows).toBe(false)
+
+    await page.screenshot({ path: testInfo.outputPath('mobile-key-deck.png') })
+
+    await shiftTab.tap()
+    await page.getByRole('button', { name: 'Enter' }).tap()
+
+    // ESC [ Z, and nothing else, was submitted.
+    await waitForPaneText(target, 'INPUT_HEX:1b5b5a')
+  } finally {
+    tmux(['kill-window', '-t', target])
+  }
+})


### PR DESCRIPTION
## Summary

- Add a `⇧tab` key next to `tab` in the mobile key deck. It sends CSI Z (`\x1b[Z`), which Claude Code uses to cycle plan / auto-accept mode. That key is unreachable from a phone keyboard today.
- Pass `ariaLabel` through for the left key group. The render loop for those keys dropped it, so the new key had no accessible name.
- Add a test covering the plain press and the interaction with the ctrl modifier. Like the arrow keys, the multi-byte sequence passes through ctrl unchanged and leaves it armed for the next single character.

Salvages the one still-useful idea from #95 without removing NumPad or changing tmux mouse scoping. The mouse fix there was superseded by #96, and touch scrolling already goes to tmux from `Terminal.tsx`.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test` (full suite, 0 failures)

https://claude.ai/code/session_019eUen9JxwPsC1uiEQbU6oN
