### PR TITLE
fix: resolve clipboard file paths reliably (v0.4.28)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/__tests__/useTerminal.test.tsx
+++ b/src/client/__tests__/useTerminal.test.tsx
@@ -2761,6 +2761,87 @@ describe('useTerminal', () => {
     globalThis.fetch = originalFetch
   })
 
+  test.each((['claude', 'codex'] as const).flatMap((agentType) =>
+    ['report.docx', 'report.pdf', 'sheet.xlsx', 'slides.pptx', 'archive.zip', 'data.csv', 'script.py', 'custom.unknown', 'LICENSE']
+      .map((filename) => ({ agentType, filename }))
+  ))('Cmd+V resolves copied file $filename for $agentType', async ({ agentType, filename }) => {
+    jest.useFakeTimers()
+    globalAny.navigator = {
+      userAgent: 'Chrome',
+      platform: 'MacIntel',
+      maxTouchPoints: 0,
+      clipboard: {
+        writeText: () => Promise.resolve(),
+        readText: () => Promise.resolve(''),
+      },
+    } as unknown as Navigator
+
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      if (String(input) === '/api/clipboard-file-path') {
+        return { ok: true, json: async () => ({ path: `/Users/test/${filename}`, isImage: false }) } as Response
+      }
+      return originalFetch(input)
+    }) as typeof fetch
+
+    const sendCalls: Array<Record<string, unknown>> = []
+    const { container, dispatchEvent } = createContainerMock()
+
+    let renderer!: TestRenderer.ReactTestRenderer
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        <TerminalHarness
+          agentType={agentType}
+          sessionId="session-1"
+          tmuxTarget="agentboard:@1"
+          sendMessage={(message) => sendCalls.push(message)}
+          subscribe={() => () => {}}
+          theme={{ background: '#000' }}
+          fontSize={12}
+        />,
+        { createNodeMock: () => container },
+      )
+      await Promise.resolve()
+    })
+
+    const terminal = TerminalMock.instances[0]
+    if (!terminal) throw new Error('Expected terminal instance')
+
+    terminal.emitKey({ key: 'v', type: 'keydown', metaKey: true, ctrlKey: false })
+
+    dispatchEvent('paste', {
+      type: 'paste',
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      clipboardData: {
+        files: [{ type: '' }],
+        items: [{ kind: 'file', type: '' }],
+        getData: () => filename,
+      },
+    })
+
+    await act(async () => {
+      jest.advanceTimersByTime(100)
+    })
+
+    expect(sendCalls).toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-1',
+      data: `/Users/test/${filename}`,
+    })
+    expect(sendCalls).not.toContainEqual({
+      type: 'terminal-input',
+      sessionId: 'session-1',
+      data: '\x1b[200~\x1b[201~',
+    })
+    expect(sendCalls.filter((message) => message.type === 'terminal-paste')).toEqual([])
+    expect(terminal.pasteCalls).toEqual([])
+
+    act(() => { renderer.unmount() })
+    globalThis.fetch = originalFetch
+  })
+
   test('Cmd+V with macOS clipboard image path sends a bracketed image path', async () => {
     jest.useFakeTimers()
     globalAny.navigator = {

--- a/src/client/__tests__/useTerminal.test.tsx
+++ b/src/client/__tests__/useTerminal.test.tsx
@@ -1322,9 +1322,11 @@ describe('useTerminal', () => {
   test('Cmd+V triggers paste via capture-phase listener', async () => {
     jest.useFakeTimers()
     const originalFetch = globalThis.fetch
+    const clipboardLookup = mock(() => {})
     // Mock fetch so /api/clipboard-file-path returns no file path (normal paste flow)
     globalThis.fetch = (async (input: RequestInfo | URL) => {
       if (String(input) === '/api/clipboard-file-path') {
+        clipboardLookup()
         return { ok: true, json: async () => ({ path: null }) } as Response
       }
       return originalFetch(input)
@@ -1399,6 +1401,7 @@ describe('useTerminal', () => {
       data: 'pasted-text',
     })
     expect(terminal.pasteCalls).toEqual([])
+    expect(clipboardLookup).not.toHaveBeenCalled()
     // The capture-phase listener should have prevented the default to block ClipboardAddon
     expect(pasteEvent.preventDefault).toHaveBeenCalled()
     expect(pasteEvent.stopPropagation).toHaveBeenCalled()
@@ -2761,10 +2764,18 @@ describe('useTerminal', () => {
     globalThis.fetch = originalFetch
   })
 
-  test.each((['claude', 'codex'] as const).flatMap((agentType) =>
+  test.each([ ...(['claude', 'codex'] as const).flatMap((agentType) =>
     ['report.docx', 'report.pdf', 'sheet.xlsx', 'slides.pptx', 'archive.zip', 'data.csv', 'script.py', 'custom.unknown', 'LICENSE']
-      .map((filename) => ({ agentType, filename }))
-  ))('Cmd+V resolves copied file $filename for $agentType', async ({ agentType, filename }) => {
+      .map((filename) => ({
+        agentType, filename, path: `/Users/test/${filename}`, expectedPath: `/Users/test/${filename}`,
+        metadata: { files: [{ type: '' }] }, copyMode: false,
+      }))
+  ),
+    { agentType: 'codex' as const, filename: 'types-only.docx', path: '/tmp/types-only.docx', expectedPath: '/tmp/types-only.docx', metadata: { types: ['Files'] }, copyMode: false },
+    { agentType: 'claude' as const, filename: 'items-only.docx', path: '/tmp/items-only.docx', expectedPath: '/tmp/items-only.docx', metadata: { items: [{ kind: 'file', type: '' }] }, copyMode: false },
+    { agentType: 'codex' as const, filename: 'unresolved.docx', path: null, expectedPath: null, metadata: { types: ['Files'] }, copyMode: false },
+    { agentType: 'claude' as const, filename: 'control-characters.docx', path: '/tmp/report\n\r\x1b\x7f.docx', expectedPath: '/tmp/report.docx', metadata: { types: ['Files'] }, copyMode: true },
+  ])('Cmd+V handles copied file $filename for $agentType', async ({ agentType, filename, path, expectedPath, metadata, copyMode }) => {
     jest.useFakeTimers()
     globalAny.navigator = {
       userAgent: 'Chrome',
@@ -2779,12 +2790,13 @@ describe('useTerminal', () => {
     const originalFetch = globalThis.fetch
     globalThis.fetch = (async (input: RequestInfo | URL) => {
       if (String(input) === '/api/clipboard-file-path') {
-        return { ok: true, json: async () => ({ path: `/Users/test/${filename}`, isImage: false }) } as Response
+        return { ok: true, json: async () => ({ path, isImage: false }) } as Response
       }
       return originalFetch(input)
     }) as typeof fetch
 
     const sendCalls: Array<Record<string, unknown>> = []
+    const listeners: Array<(message: ServerMessage) => void> = []
     const { container, dispatchEvent } = createContainerMock()
 
     let renderer!: TestRenderer.ReactTestRenderer
@@ -2796,7 +2808,7 @@ describe('useTerminal', () => {
           sessionId="session-1"
           tmuxTarget="agentboard:@1"
           sendMessage={(message) => sendCalls.push(message)}
-          subscribe={() => () => {}}
+          subscribe={(listener) => { listeners.push(listener); return () => {} }}
           theme={{ background: '#000' }}
           fontSize={12}
         />,
@@ -2808,6 +2820,10 @@ describe('useTerminal', () => {
     const terminal = TerminalMock.instances[0]
     if (!terminal) throw new Error('Expected terminal instance')
 
+    if (copyMode) {
+      act(() => { listeners[0]?.({ type: 'tmux-copy-mode-status', sessionId: 'session-1', inCopyMode: true }) })
+    }
+
     terminal.emitKey({ key: 'v', type: 'keydown', metaKey: true, ctrlKey: false })
 
     dispatchEvent('paste', {
@@ -2815,8 +2831,7 @@ describe('useTerminal', () => {
       preventDefault: () => {},
       stopPropagation: () => {},
       clipboardData: {
-        files: [{ type: '' }],
-        items: [{ kind: 'file', type: '' }],
+        ...metadata,
         getData: () => filename,
       },
     })
@@ -2826,16 +2841,21 @@ describe('useTerminal', () => {
     })
 
     expect(sendCalls).toContainEqual({
-      type: 'terminal-input',
+      type: expectedPath === null ? 'terminal-paste' : 'terminal-input',
       sessionId: 'session-1',
-      data: `/Users/test/${filename}`,
+      data: expectedPath ?? filename,
     })
     expect(sendCalls).not.toContainEqual({
       type: 'terminal-input',
       sessionId: 'session-1',
       data: '\x1b[200~\x1b[201~',
     })
-    expect(sendCalls.filter((message) => message.type === 'terminal-paste')).toEqual([])
+    expect(sendCalls.filter((message) => ['terminal-paste', 'terminal-input'].includes(String(message.type)))).toHaveLength(1)
+    if (copyMode) {
+      const cancelIndex = sendCalls.findIndex((message) => message.type === 'tmux-cancel-copy-mode')
+      expect(cancelIndex).toBeGreaterThanOrEqual(0)
+      expect(sendCalls.findIndex((message) => message.type === 'terminal-input')).toBeGreaterThan(cancelIndex)
+    }
     expect(terminal.pasteCalls).toEqual([])
 
     act(() => { renderer.unmount() })

--- a/src/client/hooks/useTerminal.ts
+++ b/src/client/hooks/useTerminal.ts
@@ -767,6 +767,10 @@ export function useTerminal({
         attachedSessionRef.current === expected &&
         readySessionRef.current === expected
       ) {
+        if (inTmuxCopyModeRef.current) {
+          sendMessageRef.current({ type: 'tmux-cancel-copy-mode', sessionId: expected })
+          setTmuxCopyMode(false)
+        }
         sendMessageRef.current({ type: 'terminal-input', sessionId: expected, data })
       }
     }
@@ -886,7 +890,7 @@ export function useTerminal({
                     }
                     // Send as raw input (no bracket paste) so Claude Code
                     // doesn't detect a paste and read the system clipboard
-                    sendInputIfStillAttached(attached, path)
+                    sendInputIfStillAttached(attached, sanitizeImagePath(path))
                     return
                   }
                 }

--- a/src/client/hooks/useTerminal.ts
+++ b/src/client/hooks/useTerminal.ts
@@ -149,6 +149,7 @@ function isMacSharedPasteboardPathText(text: string): boolean {
 interface PastePayload {
   text: string
   hasImage: boolean
+  hasFiles: boolean
   imageBlob: Blob | null
 }
 
@@ -869,9 +870,9 @@ export function useTerminal({
               return
             }
 
-            // If paste text is empty and on macOS desktop, check for Finder file copy.
-            // Only hits the server when needed (no latency cost for normal text pastes).
-            if (!text && getIsMac() && !isiOS) {
+            // Finder copies may expose the filename as text alongside file metadata.
+            // Resolve the full path before treating that filename as ordinary text.
+            if ((!text || payload?.hasFiles) && getIsMac() && !isiOS) {
               try {
                 const res = await fetch('/api/clipboard-file-path')
                 if (res.ok) {
@@ -957,7 +958,10 @@ export function useTerminal({
       const hasImage = imageBlob !== null || clipboardHasImage(e.clipboardData)
       const resolver = pasteResolver
       pasteResolver = null
-      resolver({ text, hasImage, imageBlob })
+      const hasFiles = (e.clipboardData?.files?.length ?? 0) > 0
+        || Array.from(e.clipboardData?.items ?? []).some((item) => item.kind === 'file')
+        || Array.from(e.clipboardData?.types ?? []).includes('Files')
+      resolver({ text, hasImage, hasFiles, imageBlob })
     }
     container.addEventListener('paste', handlePaste, { capture: true })
 

--- a/src/server/__tests__/isolated/indexHandlers.test.ts
+++ b/src/server/__tests__/isolated/indexHandlers.test.ts
@@ -5052,14 +5052,14 @@ describe('server fetch handlers', () => {
     expect(await response.json()).toEqual({ path: null, isImage: false })
   })
 
-  test('falls back to osascript when AppKit pasteboard reader fails', async () => {
+  test.each(['report.docx', 'report.pdf', 'custom.unknown', 'LICENSE'])('resolves Finder file %s without starting the Swift interpreter', async (filename) => {
     if (process.platform !== 'darwin') {
       return
     }
 
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentboard-clipboard-'))
     try {
-      const filePath = path.join(tempDir, 'report.pdf')
+      const filePath = path.join(tempDir, filename)
       await fs.writeFile(filePath, new Uint8Array([1, 2, 3]))
 
       const commands: string[][] = []
@@ -5103,7 +5103,7 @@ describe('server fetch handlers', () => {
         throw new Error('Expected response for clipboard file path')
       }
 
-      expect(commands).toContainEqual(['swift', '-e'])
+      expect(commands).not.toContainEqual(['swift', '-e'])
       expect(commands).toContainEqual(['osascript', '-e'])
       expect(await response.json()).toEqual({ path: filePath, isImage: false })
     } finally {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1908,6 +1908,23 @@ app.get('/api/clipboard-file-path', async (c) => {
     return c.json({ path: null, isImage: false })
   }
   try {
+    // Finder file URLs do not need the Swift interpreter. Resolve them first
+    // so cold Swift startup cannot delay ordinary document pastes.
+    const fileProc = Bun.spawn(
+      ['osascript', '-e', 'POSIX path of (the clipboard as «class furl»)'],
+      { stdout: 'pipe', stderr: 'pipe', timeout: MAC_PASTEBOARD_TIMEOUT_MS }
+    )
+    const fileText = await new Response(fileProc.stdout).text()
+    const fileExitCode = await fileProc.exited
+    const filePath = fileText.trim()
+    if (fileExitCode === 0 && filePath.startsWith('/')) {
+      const file = Bun.file(filePath)
+      if (await file.exists()) {
+        c.header('Cache-Control', 'no-store')
+        return c.json({ path: filePath, isImage: isImageFilePath(filePath) })
+      }
+    }
+
     const proc = Bun.spawn(
       ['swift', '-e', macPasteboardSwiftScript],
       {
@@ -1932,21 +1949,6 @@ app.get('/api/clipboard-file-path', async (c) => {
           c.header('Cache-Control', 'no-store')
           return c.json({ path: filePath, isImage: payload.isImage === true })
         }
-      }
-    }
-
-    const fallbackProc = Bun.spawn(
-      ['osascript', '-e', 'POSIX path of (the clipboard as «class furl»)'],
-      { stdout: 'pipe', stderr: 'pipe', timeout: MAC_PASTEBOARD_TIMEOUT_MS }
-    )
-    const fallbackText = await new Response(fallbackProc.stdout).text()
-    const fallbackExitCode = await fallbackProc.exited
-    const fallbackPath = fallbackText.trim()
-    if (fallbackExitCode === 0 && fallbackPath.startsWith('/')) {
-      const file = Bun.file(fallbackPath)
-      if (await file.exists()) {
-        c.header('Cache-Control', 'no-store')
-        return c.json({ path: fallbackPath, isImage: isImageFilePath(fallbackPath) })
       }
     }
 


### PR DESCRIPTION
Copied files can expose a filename alongside file metadata, causing Agentboard to paste only the filename instead of resolving the full path. Resolve file metadata before ordinary text, without restricting document extensions. Prefer the existing Finder file-URL reader before Swift so document pastes do not wait for Swift startup. Sanitize non-image paths and leave copy-mode before delivering paste input.

Bumps the patch version from 0.4.27 to 0.4.28.

Validation:
- Claude consultation found no new functional bug in the initial fix; addressed its path-sanitization, copy-mode, and regression-test findings.
- Tests cover both agent modes, common/unknown/absent extensions, files/items/types metadata, unresolved-file text fallback, and plain text avoiding a clipboard lookup.
- Computer Use: copied real fixture files in Finder and pressed Cmd+V in Chrome. DOCX passed in both agent modes; unknown extensions, extensionless files, and filenames with spaces also delivered one full-path input. Used the actual terminal hook and clipboard route in an isolated harness with recorded transport, not a live agent/tmux session.
- The native test exposed a Swift timeout. The harness's shorter HTTP timeout amplified it; production uses 40 seconds. Finder-first lookup passed subsequent real-clipboard checks.
- Local lint, typecheck, tests with real-tmux integration excluded, and production build.

Production Agentboard and tmux were not operated or restarted. This passes file paths; file-content support depends on the agent's tools.
