### PR TITLE
ci: run E2E in the prebuilt Playwright container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Install dependencies
         # node-pty compiles on Linux; the standard runner supplied node-gyp.
         run: |
+          # Bun lifecycle scripts can use a different HOME from checkout.
+          # Trust only this mounted checkout in the disposable container.
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
           npm install --global node-gyp@11.5.0
           bun install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,14 +62,17 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install Bun setup and terminal test dependencies
-        run: apt-get update && apt-get install -y --no-install-recommends unzip tmux python3
+        run: apt-get update && apt-get install -y --no-install-recommends unzip tmux python3 build-essential
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
         with:
           bun-version-file: .bun-version
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        # node-pty compiles on Linux; the standard runner supplied node-gyp.
+        run: |
+          npm install --global node-gyp@11.5.0
+          bun install --frozen-lockfile
 
       - name: Build
         run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     # Bun spawns under `bun test --coverage`: the server boot via Bun.spawn in
     # integration tests never becomes healthy regardless of timeout (verified
     # at 60s+ wrappers). Investigating root cause separately; the e2e job
-    # below stays on ubuntu-latest because Playwright's own webServer launch
+    # below uses the Playwright container because its webServer launch
     # is unaffected.
     runs-on: ubuntu-22.04
     steps:
@@ -52,6 +52,12 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      # Keep this version aligned with playwright in bun.lock. The image
+      # includes browsers and OS dependencies, avoiding per-run font downloads.
+      image: mcr.microsoft.com/playwright:v1.57.0-noble
+      options: --init --ipc=host
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
@@ -62,11 +68,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
-
-      - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+      - name: Install terminal test dependencies
+        run: apt-get update && apt-get install -y --no-install-recommends tmux python3
 
       - name: Build
         run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,15 +61,15 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
+      - name: Install Bun setup and terminal test dependencies
+        run: apt-get update && apt-get install -y --no-install-recommends unzip tmux python3
+
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
         with:
           bun-version-file: .bun-version
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
-
-      - name: Install terminal test dependencies
-        run: apt-get update && apt-get install -y --no-install-recommends tmux python3
 
       - name: Build
         run: bun run build


### PR DESCRIPTION
The E2E job downloads Chromium and Ubuntu browser dependencies on every run. After v0.5.0 merged, slow font-package downloads delayed setup for more than seven minutes.

Run E2E inside the official Playwright 1.57.0 Noble image, matching bun.lock. It includes browser binaries and their OS dependencies. Install unzip for Bun setup, tmux/Python for terminal fixtures, and native build tools plus node-gyp for node-pty. Trust the exact mounted checkout at the container system level so Bun lifecycle scripts can configure Git regardless of HOME. Bound the job to 15 minutes.

Validation:
- actionlint, lint, typecheck, and isolated unit suite passed locally.
- All GitHub checks passed at 37992c5, including the full E2E suite.
- Container E2E run: 91 seconds total, including 25 seconds initializing the container, 13 seconds installing additional OS tools, and 20 seconds running tests.
- Previous successful host-based E2E run: 64 seconds total, including 17 seconds installing Playwright, 6 seconds installing tmux, and 21 seconds running tests.

This is a compatibility experiment, not a demonstrated speed improvement. It removes browser/font installation from each job, but still pulls a large image and uses apt for Agentboard-specific tools. A derived image could preinstall those tools at the cost of maintaining and publishing another image. One successful run does not establish improved reliability. No application, release, or local-service changes.
