### PR TITLE
fix: restore iOS freeform submission and quick-key scrolling (v0.5.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gbasin/agentboard",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "description": "Web GUI for tmux optimized for AI agent TUIs",
   "author": "gbasin",

--- a/src/client/__tests__/terminalControls.test.tsx
+++ b/src/client/__tests__/terminalControls.test.tsx
@@ -192,7 +192,7 @@ describe('TerminalControls', () => {
     expect(selections).toEqual(['session-2'])
   })
 
-  test('Paste opens a dialog even with clipboard access, then native paste inserts and refocuses', async () => {
+  test('Paste opens a dialog even with clipboard access, then submitted text inserts and refocuses', async () => {
     let refocused = false
     const sent: string[] = []
     const pasted: string[] = []
@@ -229,7 +229,11 @@ describe('TerminalControls', () => {
     })
     expect(renderer.root.findByType('dialog')).toBeDefined()
     await act(async () => {
-      renderer.root.findByType('textarea').props.onPaste({ preventDefault() {}, clipboardData: { getData: () => 'pasted text', files: [] } })
+      renderer.root.findByType('textarea').props.onChange({ target: { value: 'pasted text' } })
+    })
+    expect(renderer.root.findByType('dialog')).toBeDefined()
+    await act(async () => {
+      renderer.root.findByType('form').props.onSubmit({ preventDefault() {} })
     })
 
     // Pasted text goes through the explicit paste path (bracketed server-side),
@@ -269,7 +273,11 @@ describe('TerminalControls', () => {
     })
     expect(renderer.root.findByType('dialog')).toBeDefined()
     await act(async () => {
-      renderer.root.findByType('textarea').props.onPaste({ preventDefault() {}, clipboardData: { getData: () => 'pasted text', files: [] } })
+      renderer.root.findByType('textarea').props.onChange({ target: { value: 'pasted text' } })
+    })
+    expect(renderer.root.findByType('dialog')).toBeDefined()
+    await act(async () => {
+      renderer.root.findByType('form').props.onSubmit({ preventDefault() {} })
     })
 
     expect(sent).toEqual(['pasted text'])
@@ -309,7 +317,11 @@ describe('TerminalControls', () => {
     const textarea = renderer.root.findByType('textarea')
 
     await act(async () => {
-      textarea.props.onPaste({ preventDefault() {}, clipboardData: { getData: () => 'line 1\nline 2\n', files: [] } })
+      textarea.props.onChange({ target: { value: 'line 1\nline 2\n' } })
+    })
+    expect(renderer.root.findByType('dialog')).toBeDefined()
+    await act(async () => {
+      renderer.root.findByType('form').props.onSubmit({ preventDefault() {} })
     })
 
     expect(pasted).toEqual(['line 1\nline 2\n'])
@@ -355,6 +367,10 @@ describe('TerminalControls', () => {
     await act(async () => {
       renderer.root.findByType('textarea').props.onPaste({ preventDefault() {}, clipboardData: { getData: () => '', files: [new File(['png bytes'], 'image.png', { type: 'image/png' })] } })
     })
+    expect(renderer.root.findByType('dialog')).toBeDefined()
+    await act(async () => {
+      renderer.root.findByType('form').props.onSubmit({ preventDefault() {} })
+    })
 
     expect(requests).toHaveLength(1)
     expect(requests[0]?.url).toBe('/api/paste-image')
@@ -398,6 +414,10 @@ describe('TerminalControls', () => {
     await act(async () => {
       renderer.root.findByType('textarea').props.onPaste({ preventDefault() {}, clipboardData: { getData: () => '', files: [new File(['png bytes'], 'image.png', { type: 'image/png' })] } })
     })
+    expect(renderer.root.findByType('dialog')).toBeDefined()
+    await act(async () => {
+      renderer.root.findByType('form').props.onSubmit({ preventDefault() {} })
+    })
 
     // Codex attaches via its own clipboard path, so the raw path is sent as-is.
     expect(sent).toEqual(['/tmp/paste-test.png '])
@@ -437,6 +457,10 @@ describe('TerminalControls', () => {
     expect(renderer.root.findByType('dialog')).toBeDefined()
     await act(async () => {
       renderer.root.findByType('textarea').props.onPaste({ preventDefault() {}, clipboardData: { getData: () => '', files: [new File(['png bytes'], 'image.png', { type: 'image/png' })] } })
+    })
+    expect(renderer.root.findByType('dialog')).toBeDefined()
+    await act(async () => {
+      renderer.root.findByType('form').props.onSubmit({ preventDefault() {} })
     })
 
     // Nothing was pasted, and the inline status shows the failure
@@ -483,6 +507,10 @@ describe('TerminalControls', () => {
     await act(async () => {
       renderer.root.findByType('textarea').props.onPaste({ preventDefault() {}, clipboardData: { getData: () => '', files: [new File(['png bytes'], 'image.png', { type: 'image/png' })] } })
     })
+    expect(renderer.root.findByType('dialog')).toBeDefined()
+    await act(async () => {
+      renderer.root.findByType('form').props.onSubmit({ preventDefault() {} })
+    })
 
     const cancelButton = renderer.root
       .findAllByType('button')
@@ -499,4 +527,55 @@ describe('TerminalControls', () => {
       renderer.root.findAllByType('span').some((p) => p.props.role === 'alert')
     ).toBe(false)
   })
+})
+
+test('a horizontal swipe does not press a key; a stationary tap presses it once', () => {
+  globalAny.navigator = {} as Navigator
+  const sent: string[] = []
+  const renderer = TestRenderer.create(<TerminalControls onSendKey={(key) => sent.push(key)}
+    sessions={[]} currentSessionId="test" onSelectSession={() => {}} isKeyboardVisible={() => true} />)
+  const row = renderer.root.findAllByType('div').find((div) => div.props.onTouchStartCapture)!
+  const esc = renderer.root.findAllByType('button').find((button) => button.props.children === 'esc')!
+  let prevented = false
+  const event = (x: number) => ({ touches: [{ clientX: x, clientY: 0 }], changedTouches: [{ clientX: x, clientY: 0 }],
+    preventDefault: () => { prevented = true }, stopPropagation() {} })
+  act(() => {
+    row.props.onTouchStartCapture(event(100))
+    row.props.onTouchMoveCapture(event(40))
+    esc.props.onTouchEnd(event(40))
+  })
+  expect(prevented).toBe(false)
+  expect(sent).toEqual([])
+  act(() => {
+    row.props.onTouchStartCapture(event(100))
+    esc.props.onTouchEnd(event(100))
+    esc.props.onClick()
+  })
+  expect(prevented).toBe(true)
+  expect(sent).toEqual(['\x1b'])
+  renderer.unmount()
+})
+
+test('selected files survive resetting the native picker and wait with the draft for Submit', async () => {
+  const sent: string[] = []
+  globalAny.navigator = {} as Navigator
+  globalAny.fetch = (async () => Response.json({ path: '/tmp/notes.txt' })) as unknown as typeof fetch
+  const renderer = TestRenderer.create(<TerminalControls onSendKey={text => sent.push(text)}
+    sessions={[]} currentSessionId="test" onSelectSession={() => {}} />)
+  await act(async () => { findPasteButton(renderer)!.props.onClick() })
+  let selected: File[] = [new File(['notes'], 'notes.txt')]
+  const target = {
+    get files() { return selected },
+    set value(_value: string) { selected = [] },
+  }
+  act(() => {
+    renderer.root.findByType('textarea').props.onChange({ target: { value: 'Read this\nplease' } })
+    renderer.root.findByType('input').props.onChange({ target })
+  })
+  expect(selected).toEqual([])
+  expect(renderer.root.findAllByType('li')).toHaveLength(1)
+  expect(sent).toEqual([])
+  await act(async () => { renderer.root.findByType('form').props.onSubmit({ preventDefault() {} }) })
+  expect(sent).toEqual(["Read this\nplease\n'/tmp/notes.txt' "])
+  renderer.unmount()
 })

--- a/src/client/components/PasteStatus.tsx
+++ b/src/client/components/PasteStatus.tsx
@@ -1,44 +1,69 @@
-/** Progress/errors and a device paste/file dialog; the TUI remains the composer. */
-import { useLayoutEffect, useRef } from 'react'
+/** Progress/errors and a device paste/file dialog; freeform text and attachments wait for Submit. */
+import { useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { clipboardFiles } from '../utils/browserFiles'
 import type { BrowserPaste, PasteState } from '../hooks/useBrowserPaste'
 
-export default function PasteStatus({ state, cancel, retry, paste, chooseFiles }: {
+export default function PasteStatus({ state, cancel, retry, paste, allowFiles }: {
   state: PasteState
   cancel: () => void
   retry: () => void
   paste: (input: BrowserPaste) => void
-  chooseFiles?: () => void
+  allowFiles?: boolean
 }) {
-  const dialog = useRef<HTMLDialogElement>(null)
-  useLayoutEffect(() => { if (state.status === 'awaiting-paste') dialog.current?.showModal() }, [state.status])
   if (state.status === 'idle') return null
-  if (state.status === 'awaiting-paste') {
-    const fallback = <dialog ref={dialog} aria-label="Paste from this device" onCancel={cancel}
-      style={{ top: 'calc(var(--viewport-offset-top, 0px) + 1rem)', bottom: 'auto', maxHeight: 'calc(var(--visual-viewport-height, 100dvh) - 2rem)' }}
-      className="mx-auto my-0 w-[calc(100%_-_2rem)] max-w-sm overflow-y-auto rounded-lg border border-border bg-elevated p-4 text-primary backdrop:bg-black/50">
-      <p className="mb-3 text-sm text-primary">Touch and hold in the field, then choose Paste. It goes straight to your terminal.</p>
-      <textarea autoFocus aria-label="Paste here" placeholder="Touch and hold to paste" rows={2}
-        className="w-full rounded border border-border bg-surface p-3 text-base text-primary"
-        onPaste={(event) => {
-          event.preventDefault()
-          const files = clipboardFiles(event.clipboardData)
-          const text = event.clipboardData.getData('text/plain')
-          cancel()
-          const names = files.map(file => file.name).join('\n')
-          paste({ text: files.length && text.trim() === names ? '' : text, files })
-        }} />
-      <div className="mt-3 flex justify-end gap-2">
-        {chooseFiles && <button type="button" className="min-h-[44px] px-3 text-primary" onClick={() => { cancel(); chooseFiles() }}>Choose files</button>}
-        <button type="button" className="min-h-[44px] px-3 text-secondary" onClick={cancel}>Cancel</button>
-      </div>
-    </dialog>
-    return typeof document === 'undefined' ? fallback : createPortal(fallback, document.body)
-  }
+  if (state.status === 'awaiting-paste') return <PasteComposer cancel={cancel} paste={paste} allowFiles={allowFiles} />
   return <div className="flex items-center gap-3 border-t border-border bg-elevated px-3 py-2 text-sm text-primary">
     <span role={state.status === 'error' ? 'alert' : 'status'}>{state.status === 'error' ? state.message : state.status === 'reading' ? 'Reading clipboard…' : 'Uploading files…'}</span>
     {state.status === 'error' && <button type="button" className="min-h-[44px] px-2" onClick={retry}>Retry</button>}
     <button type="button" className="min-h-[44px] px-2 text-secondary" onClick={cancel}>{state.status === 'error' ? 'Dismiss' : 'Cancel'}</button>
   </div>
+}
+
+function PasteComposer({ cancel, paste, allowFiles }: {
+  cancel: () => void
+  paste: (input: BrowserPaste) => void
+  allowFiles?: boolean
+}) {
+  const dialog = useRef<HTMLDialogElement>(null)
+  const [text, setText] = useState('')
+  const [files, setFiles] = useState<File[]>([])
+  useLayoutEffect(() => { dialog.current?.showModal() }, [])
+  const fallback = <dialog ref={dialog} aria-label="Paste from this device" onCancel={cancel}
+    style={{ top: 'calc(var(--viewport-offset-top, 0px) + 1rem)', bottom: 'auto', maxHeight: 'calc(var(--visual-viewport-height, 100dvh) - 2rem)' }}
+    className="mx-auto my-0 w-[calc(100%_-_2rem)] max-w-sm overflow-y-auto rounded-lg border border-border bg-elevated p-4 text-primary backdrop:bg-black/50">
+    <form onSubmit={(event) => { event.preventDefault(); if (text || files.length) { cancel(); paste({ text, files }) } }}>
+      <p className="mb-3 text-sm text-primary">Type or paste text, then submit it to your terminal.</p>
+      <textarea autoFocus aria-label="Paste here" placeholder="Type or paste here" rows={4}
+        value={text} onChange={(event) => setText(event.target.value)}
+        className="w-full rounded border border-border bg-surface p-3 text-base text-primary"
+        onPaste={(event) => {
+          const attached = clipboardFiles(event.clipboardData)
+          if (!attached.length) return
+          event.preventDefault()
+          setFiles(pending => [...pending, ...attached])
+          const pastedText = event.clipboardData.getData('text/plain')
+          if (pastedText && pastedText.trim() !== attached.map(file => file.name).join('\n')) setText(value => value + pastedText)
+        }} />
+      {allowFiles && <label className="mt-3 block text-sm">Attach files
+        <input type="file" multiple aria-label="Choose files" className="mt-2 block w-full text-sm"
+          onChange={(event) => {
+            const selected = Array.from(event.target.files ?? [])
+            setFiles(pending => [...pending, ...selected])
+            event.target.value = ''
+          }} />
+      </label>}
+      {files.length > 0 && <ul className="mt-2 text-sm">{files.map((file, index) => <li key={index} className="flex items-center gap-2">
+        <span className="min-w-0 flex-1 truncate">{file.name}</span>
+        <button type="button" className="min-h-[44px] px-2" aria-label={`Remove ${file.name}`}
+          onClick={() => setFiles(pending => pending.filter((_, i) => i !== index))}>Remove</button>
+      </li>)}</ul>}
+      <div className="mt-3 flex justify-end gap-2">
+        <button type="button" className="min-h-[44px] px-3 text-secondary" onClick={cancel}>Cancel</button>
+        <button type="submit" disabled={!text && files.length === 0}
+          className="min-h-[44px] rounded bg-accent px-3 text-white disabled:opacity-50">Submit</button>
+      </div>
+    </form>
+  </dialog>
+  return typeof document === 'undefined' ? fallback : createPortal(fallback, document.body)
 }

--- a/src/client/components/TerminalControls.tsx
+++ b/src/client/components/TerminalControls.tsx
@@ -143,38 +143,11 @@ export default function TerminalControls({
   isKeyboardVisible,
   onEnterTextMode,
 }: TerminalControlsProps) {
-  const pickerRef = useRef<HTMLInputElement>(null)
   const browserPaste = useBrowserPaste({ sessionId: currentSessionId, disabled, fileUploadsAllowed, agentType,
     onPasteText: onPasteText ?? onSendKey, onPasteImage: onPasteImage ?? onSendKey, onRefocus })
   const [ctrlActive, setCtrlActive] = useState(false)
   const lastTouchTimeRef = useRef(0)
-  const controlsRef = useRef<HTMLDivElement>(null)
-
-
-  useEffect(() => {
-    const controls = controlsRef.current
-    if (!controls) return
-
-    const handleTouchStartCapture = (event: TouchEvent) => {
-      if (disabled) return
-      if (!controls.contains(event.target as Node)) return
-      if ((event.target as HTMLElement).closest?.('[data-native-gesture]')) return
-      if (isKeyboardVisible?.()) {
-        event.preventDefault()
-      }
-    }
-
-    controls.addEventListener('touchstart', handleTouchStartCapture, {
-      passive: false,
-      capture: true,
-    })
-
-    return () => {
-      controls.removeEventListener('touchstart', handleTouchStartCapture, {
-        capture: true,
-      })
-    }
-  }, [disabled, isKeyboardVisible])
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null)
 
   // Intercept keyboard input when ctrl is active to send control characters
   useEffect(() => {
@@ -261,6 +234,9 @@ export default function TerminalControls({
 
   const handleTouchAction = (handler: () => void) => (e: ReactTouchEvent) => {
     if (disabled) return
+    const start = touchStartRef.current
+    const end = e.changedTouches[0]
+    if (!start || !end || Math.hypot(end.clientX - start.x, end.clientY - start.y) > 10) return
     e.preventDefault()
     e.stopPropagation()
     lastTouchTimeRef.current = Date.now()
@@ -277,7 +253,6 @@ export default function TerminalControls({
 
   return (
     <div
-      ref={controlsRef}
       className={`terminal-controls flex flex-col gap-[6px] border-t border-border bg-elevated p-[6px] ${isIOSDevice() ? '' : 'md:hidden'}`}
     >
       {/* Session switcher row */}
@@ -317,7 +292,18 @@ export default function TerminalControls({
         </div>
       )}
       {/* Key row */}
-      <div className="grid grid-flow-col auto-cols-[44px] items-center gap-[4px] overflow-x-auto scrollbar-none">
+      <div className="grid grid-flow-col auto-cols-[44px] items-center gap-[4px] overflow-x-auto scrollbar-none"
+        onTouchStartCapture={(event) => {
+          const touch = event.touches[0]
+          touchStartRef.current = touch ? { x: touch.clientX, y: touch.clientY } : null
+        }}
+        onTouchMoveCapture={(event) => {
+          const start = touchStartRef.current
+          const touch = event.touches[0]
+          if (start && touch && Math.hypot(touch.clientX - start.x, touch.clientY - start.y) > 10) touchStartRef.current = null
+        }}
+        onTouchCancel={() => { touchStartRef.current = null }}
+      >
         {/* Paste button */}
         <button
           type="button"
@@ -359,7 +345,7 @@ export default function TerminalControls({
             ${disabled ? 'opacity-50' : ''}
           `}
           onMouseDown={(e) => e.preventDefault()}
-          onTouchStart={handleTouchAction(handleCtrlToggle)}
+          onTouchEnd={handleTouchAction(handleCtrlToggle)}
           onClick={handleClickAction(handleCtrlToggle)}
           disabled={disabled}
         >
@@ -385,7 +371,7 @@ export default function TerminalControls({
               ${disabled ? 'opacity-50' : ''}
             `}
             onMouseDown={(e) => e.preventDefault()}
-            onTouchStart={handleTouchAction(() => handlePress(control.key))}
+            onTouchEnd={handleTouchAction(() => handlePress(control.key))}
             onClick={handleClickAction(() => handlePress(control.key))}
             disabled={disabled}
           >
@@ -430,7 +416,7 @@ export default function TerminalControls({
               ${disabled ? 'opacity-50' : ''}
             `}
             onMouseDown={(e) => e.preventDefault()}
-            onTouchStart={handleTouchAction(() => handlePress(control.key))}
+            onTouchEnd={handleTouchAction(() => handlePress(control.key))}
             onClick={handleClickAction(() => handlePress(control.key))}
             disabled={disabled}
           >
@@ -454,7 +440,7 @@ export default function TerminalControls({
             ${disabled ? 'opacity-50' : ''}
           `}
           onMouseDown={(e) => e.preventDefault()}
-          onTouchStart={handleTouchAction(handleKeyboardPress)}
+          onTouchEnd={handleTouchAction(handleKeyboardPress)}
           onClick={handleClickAction(handleKeyboardPress)}
           disabled={disabled}
         >
@@ -462,9 +448,7 @@ export default function TerminalControls({
         </button>
       </div>
 
-      <input ref={pickerRef} type="file" multiple aria-label="Choose files" className="hidden"
-        onChange={(event) => { void browserPaste.paste({ text: '', files: Array.from(event.target.files ?? []) }); event.target.value = '' }} />
-      <PasteStatus {...browserPaste} chooseFiles={fileUploadsAllowed ? () => pickerRef.current?.click() : undefined} />
+      <PasteStatus {...browserPaste} allowFiles={fileUploadsAllowed} />
     </div>
   )
 }

--- a/tests/e2e/browser-files.spec.ts
+++ b/tests/e2e/browser-files.spec.ts
@@ -42,6 +42,7 @@ for (const mode of ['desktop', 'mobile', 'drop', 'context-paste'] as const) {
           { name: 'data with spaces.unknown', mimeType: 'application/octet-stream', buffer: Buffer.from('exact device file bytes') },
           { name: 'LICENSE', mimeType: 'text/plain', buffer: Buffer.from('second device file') },
         ])
+        await page.getByRole('button', { name: 'Submit', exact: true }).click()
       } else {
         await page.evaluate((mode) => {
           const input = document.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement

--- a/tests/e2e/manual-paste.spec.ts
+++ b/tests/e2e/manual-paste.spec.ts
@@ -87,11 +87,9 @@ async function exerciseManualPaste(page: Page, windowName: string, clipboardAvai
     expect(compactBounds!.y).toBeGreaterThanOrEqual(0)
     expect(compactBounds!.y + compactBounds!.height).toBeLessThanOrEqual(500)
 
-    await textarea.evaluate(element => {
-      const data = new DataTransfer()
-      data.setData('text/plain', 'manual_alpha\nmanual_beta\n')
-      element.dispatchEvent(new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true }))
-    })
+    await textarea.fill('manual_alpha\nmanual_beta\n')
+    expect(tmux(['capture-pane', '-t', target, '-p']).stdout).not.toContain('HELD:manual_alpha')
+    await page.getByRole('button', { name: 'Submit', exact: true }).click()
     await expect(textarea).toHaveCount(0)
 
     const pane = await waitForPaneText(target, 'HELD:manual_alpha|manual_beta|')

--- a/tests/e2e/mobile-controls.spec.ts
+++ b/tests/e2e/mobile-controls.spec.ts
@@ -75,6 +75,30 @@ test('⇧tab key sends CSI Z to the pane from a touch device', async ({ page }, 
 
     // ESC [ Z, and nothing else, was submitted.
     await waitForPaneText(target, 'INPUT_HEX:1b5b5a')
+
+    // Exercise an actual browser pan, including intermediate touch moves.
+    await page.getByRole('button', { name: 'Show keyboard' }).tap()
+    const input = page.locator('.xterm-helper-textarea')
+    await expect(input).toBeFocused()
+    const row = page.locator('.terminal-controls > .grid')
+    await row.evaluate(element => { element.scrollLeft = 0 })
+    const tab = page.getByRole('button', { name: 'tab', exact: true })
+    const bounds = (await tab.boundingBox())!
+    const x = bounds.x + bounds.width / 2
+    const y = bounds.y + bounds.height / 2
+    const cdp = await page.context().newCDPSession(page)
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [{ x, y }] })
+    for (let distance = 10; distance <= 120; distance += 10) {
+      await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [{ x: x - distance, y }] })
+    }
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+    await expect.poll(() => row.evaluate(element => element.scrollLeft)).toBeGreaterThan(50)
+    await expect(input).toBeFocused()
+    await page.getByRole('button', { name: 'Enter' }).tap()
+    // A swipe beginning on Tab must not insert a tab into the terminal.
+    expect(tmux(['capture-pane', '-t', target, '-p']).stdout).not.toContain('INPUT_HEX:09')
+    await cdp.detach()
+
   } finally {
     tmux(['kill-window', '-t', target])
   }


### PR DESCRIPTION
Restore freeform multiline entry in the mobile paste dialog, with an explicit Submit button and staged file attachments. Let horizontal swipes scroll the quick-key row while ordinary keys activate only after a stationary tap. Bump the version to 0.5.1.

Validation: lint, typecheck, full unit/integration suite, production build, and seven browser end-to-end tests passed. iPhone 17 Pro simulator (iOS 26.1) verified multiline submission and native image selection/upload; uploaded bytes matched the source. Native iOS swiping remains unverified because the simulator automation produced no touch-move events; a complete browser touch-swipe test passed and preserved terminal focus without inserting a Tab key.
