### PR TITLE
fix(e2e): pin the quick-key deck to scrollLeft 0 in the arrow-keys spec

### DIFF
--- a/tests/e2e/arrow-keys.spec.ts
+++ b/tests/e2e/arrow-keys.spec.ts
@@ -112,9 +112,10 @@ test('arrow cluster: tap sends, hold repeats, deck never reflows', async ({ page
     await expect(page.locator('.xterm')).toBeVisible()
     await sleep(2000) // let the terminal attach settle
 
-    // Paste/file controls lead the scrollable deck. Expose the key controls
-    // before taking coordinates for raw touches (which do not auto-scroll).
-    await page.locator('.grid-flow-col').evaluate(element => { element.scrollLeft = element.scrollWidth })
+    // Enter and the arrow trigger lead the scrollable deck, so they are
+    // on-screen at scrollLeft 0. Pin the deck there before taking coordinates
+    // for raw touches (which do not auto-scroll).
+    await page.locator('.grid-flow-col').evaluate(element => { element.scrollLeft = 0 })
 
     const trigger = await center(page, 'Arrow keys')
     const enter = await center(page, 'Enter')


### PR DESCRIPTION
## Summary
- Master CI is red after #225: `tests/e2e/arrow-keys.spec.ts` scrolled the quick-key deck to its end before taking raw touch coordinates, because Enter and the arrow trigger used to be the last keys. #225 moved them to the front, so on a phone-width viewport Enter ends up off-screen and the CDP tap hits nothing (`Expected "UP", Received "(nothing)"`).
- Pin the deck at `scrollLeft = 0` instead. Test-only change.

## Test plan
- [x] `bunx playwright test tests/e2e/arrow-keys.spec.ts` passes locally on the built bundle

https://claude.ai/code/session_01LjsynnVDDBubY6UsGnAXAq